### PR TITLE
docs: add ownership continuity to delegated work governance

### DIFF
--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -48,8 +48,12 @@ Governed agent execution should use explicit orchestration and bounded work unit
 - `GOV-02-ORCH-004` Hidden nested worker-coordinator chains should be avoided by default because they reduce visibility, weaken accountability, and complicate recovery.
 - `GOV-02-ORCH-005` Prefer sequential bounded stages when they improve observability, recoverability, or handoff clarity.
 - `GOV-02-ORCH-006` Parallel lanes are allowed only when each lane still has explicit ownership, bounded scope, visible checkpoints, and recoverable failure handling.
+- `GOV-02-ORCH-007` Delegation does not end parent orchestration accountability. The parent remains responsible for visible ownership of the delegated unit until completion, blocker, or explicit handoff.
+- `GOV-02-ORCH-008` Long-running delegated work must have visible follow-through checkpoints rather than silent fire-and-forget waiting.
+- `GOV-02-ORCH-009` Governed systems should define an early-follow-up checkpoint window and an ongoing cadence for delegated work supervision.
+- `GOV-02-ORCH-010` Governance should require the existence of follow-through cadence, while runtime, project, or operating docs may define the exact timing thresholds appropriate to the environment.
 
-This section governs work structure, not implementation details. It does not prescribe specific runtimes, queue settings, model choices, shell commands, or machine-local paths.
+This section governs work structure, not implementation details. It does not prescribe specific runtimes, queue settings, model choices, shell commands, or machine-local paths. It defines the accountability shape of delegation, while project/runbook docs may specify concrete supervision timings.
 
 ## Execution Modes
 

--- a/.governance/specs/ownership-continuity-and-follow-through.md
+++ b/.governance/specs/ownership-continuity-and-follow-through.md
@@ -1,0 +1,41 @@
+# Ownership Continuity and Follow-Through
+
+## Intent
+Extend GOV-02 so explicit orchestration covers not only delegation shape, but also visible parent accountability after delegation. The outcome is a governance rule that treats silent fire-and-forget worker handling as a structural weakness rather than a harmless runtime detail.
+
+## Scope
+In scope:
+- `GOV-02-ORCH-007` require parent orchestration accountability to continue after delegation until completion, blocker, or explicit handoff
+- `GOV-02-ORCH-008` require visible follow-through checkpoints for long-running delegated work
+- `GOV-02-ORCH-009` require governed systems to define an early-follow-up checkpoint window and an ongoing supervision cadence
+- `GOV-02-ORCH-010` keep exact cadence timings in runtime/project operating docs rather than hardcoding one universal governance constant
+- add a public-facing blog post translating the ACP/setup lesson into governance language
+
+Out of scope:
+- exact ACP/OpenClaw/acpx commands or machine-local setup steps
+- exact timing values such as 60 seconds or 5 minutes as universal governance law
+- transcript-repair patches, runtime bugfixes, or local recovery procedures
+
+## Acceptance Criteria
+- GOV-02 explicitly states that delegation does not end parent orchestration accountability.
+- GOV-02 explicitly states that long-running delegated work requires visible follow-through checkpoints.
+- GOV-02 explicitly requires governed systems to define follow-up cadence while allowing runtime/project docs to set exact timing thresholds.
+- A new blog post explains why successful worker spawn is not the same as governed supervision.
+
+## Tests and Evidence
+- inspect `.governance/rules/gov-02-workflow.mdc`
+- inspect `docs/published/gov-02-workflow.md`
+- inspect `blog/2026-03-19-acp-setup-needs-parent-supervision.md`
+- run `npm run build`
+
+## Documentation Impact
+- update `.governance/rules/gov-02-workflow.mdc`
+- update `docs/published/gov-02-workflow.md`
+- add `blog/2026-03-19-acp-setup-needs-parent-supervision.md`
+
+## Verification
+Verification is documentation-driven. Success requires the canonical rule, published mirror, and new blog post to align on the same governance lesson, plus a successful Docusaurus build.
+
+## Change Notes
+- Keep the new rule at the governance/accountability level, not as an ACP-only implementation note.
+- Preserve the governance-vs-ops split by requiring cadence without hardcoding one universal timing constant.

--- a/blog/2026-03-19-acp-setup-needs-parent-supervision.md
+++ b/blog/2026-03-19-acp-setup-needs-parent-supervision.md
@@ -1,0 +1,129 @@
+---
+slug: acp-setup-needs-parent-supervision
+title: "ACP Setup Is Not Enough: The Parent Must Keep Supervising"
+authors: [VibeGov_team]
+tags: [governance, acp, multi-agent, supervision, workflow]
+---
+
+A multi-agent system can look healthy for exactly the wrong reason:
+
+- the worker spawned successfully
+- the session exists
+- the runtime says it is still alive
+
+That is not the same thing as governed execution.
+
+Recent project learnings made this painfully clear.
+A parent thread can successfully launch a worker thread and still fail the real governance test by going quiet afterwards.
+
+## The hidden failure mode
+
+People often focus on whether ACP setup works at all:
+
+- can the worker spawn?
+- can the runtime create a session?
+- can you read results back later?
+
+Those are important setup questions.
+But they are not the whole question.
+
+The deeper question is:
+
+> does the parent keep visible ownership of the delegated unit until completion, blocker, or explicit handoff?
+
+If the answer is no, the system has a supervision problem even if the worker runtime is technically healthy.
+
+## Worker health is not governance health
+
+A worker can be:
+- alive
+- executing
+- emitting some output
+
+And the governance can still be weak.
+
+Why?
+Because a silent parent creates ambiguity:
+- who owns the unit right now?
+- how long has it been running?
+- has anyone checked progress recently?
+- is the latest state meaningful progress or a stale transcript?
+- when will the next supervisory action happen?
+
+Without those answers, a parent thread is not orchestrating.
+It is just launching.
+
+## Delegation does not end accountability
+
+This is the key lesson.
+
+**Delegation does not transfer orchestration accountability.**
+
+The parent may delegate execution.
+It does not delegate responsibility for visible supervision.
+
+In governed systems, the parent should still:
+1. announce the delegated unit clearly
+2. report worker identity when available
+3. perform early follow-up checks
+4. continue periodic supervision for long-running work
+5. report completion, blocker, or recovery action explicitly
+
+That is what turns delegation into governed execution instead of fire-and-forget behavior.
+
+## Why cadence matters
+
+A common failure pattern is vague follow-through:
+
+- one start message
+- maybe one worker id
+- then silence
+- then, much later, either a result or nothing
+
+That pattern is operationally weak because it hides whether the parent is still on top of the unit.
+
+Governance should not necessarily hardcode one universal timing rule for every environment.
+But governance should require that a system define:
+
+- an early-follow-up checkpoint window
+- an ongoing supervision cadence for long-running work
+- an escalation expectation when progress is stale or ambiguous
+
+The runtime or project docs can set the exact numbers.
+Governance should enforce the accountability shape.
+
+## What this means for ACP setup docs
+
+ACP setup docs should not stop at:
+- how to spawn sessions
+- how to configure backends
+- how to attach tools
+- how to read transcript output
+
+They should also explain:
+- how the parent tracks ownership after delegation
+- how follow-up checks are scheduled or enforced
+- how elapsed runtime is surfaced
+- how stale or missing readback is escalated
+- how the parent proves it is still supervising the worker thread
+
+That is where setup guidance meets governance.
+
+## The better practical test
+
+Instead of asking only:
+
+> did the worker spawn successfully?
+
+Ask:
+
+> if this worker runs for 20 minutes, can a human still see who owns it, how long it has been running, what its latest known state is, and what the next supervisory step will be?
+
+If not, the setup may be functional but it is not yet governable.
+
+## Related docs
+
+- [GOV 02 Workflow](/docs/published/gov-02-workflow)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Workflow Quality Rubric](/docs/workflow-quality-rubric)
+- [Explicit Orchestration Beats Hidden Agent Pyramids](/blog/explicit-orchestration-bounded-work)

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -73,10 +73,14 @@ Governed agent execution should use explicit orchestration and bounded work unit
 - `GOV-02-ORCH-004` Hidden nested worker-coordinator chains should be avoided by default because they reduce visibility, weaken accountability, and complicate recovery.
 - `GOV-02-ORCH-005` Prefer sequential bounded stages when they improve observability, recoverability, or handoff clarity.
 - `GOV-02-ORCH-006` Parallel lanes are allowed only when each lane still has explicit ownership, bounded scope, visible checkpoints, and recoverable failure handling.
+- `GOV-02-ORCH-007` Delegation does not end parent orchestration accountability. The parent remains responsible for visible ownership of the delegated unit until completion, blocker, or explicit handoff.
+- `GOV-02-ORCH-008` Long-running delegated work must have visible follow-through checkpoints rather than silent fire-and-forget waiting.
+- `GOV-02-ORCH-009` Governed systems should define an early-follow-up checkpoint window and an ongoing cadence for delegated work supervision.
+- `GOV-02-ORCH-010` Governance should require the existence of follow-through cadence, while runtime, project, or operating docs may define the exact timing thresholds appropriate to the environment.
 
-This section governs work structure, not implementation details. It does not prescribe specific runtimes, queue settings, model choices, shell commands, or machine-local paths.
+This section governs work structure, not implementation details. It does not prescribe specific runtimes, queue settings, model choices, shell commands, or machine-local paths. It defines the accountability shape of delegation, while project/runbook docs may specify concrete supervision timings.
 
-> Commentary: Defines the default shape of governed multi-agent execution so coordination stays visible, auditable, and recoverable.
+> Commentary: Defines the default shape of governed multi-agent execution so coordination stays visible, auditable, recoverable, and visibly supervised after delegation.
 
 ## Execution Modes
 


### PR DESCRIPTION
## Summary
- extend GOV-02 so delegation does not end parent accountability
- require visible follow-through checkpoints for long-running delegated work
- clarify that governance requires cadence while runtime/project docs define exact timing
- add ACP-focused blog post translating the lesson into setup guidance

## Evidence
- `npm run build` ✅

## Issue
- Closes #5