### PR TITLE
Make strict branch and PR workflow part of bootstrap

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+## Linked Intent
+- Issue:
+- Spec:
+
+## Workflow Route
+- Branch type: `feature` / `fix` / `docs` / `chore` / `hotfix` / `promotion`
+- Source branch:
+- Target branch:
+- Branch name:
+- [ ] This branch name includes the governing issue ID.
+- [ ] No direct agent commits were made to `main` or `develop`.
+- [ ] Normal work targets `develop`; only explicit promotion or hotfix flow targets `main`.
+
+## Validation
+- Checks run:
+  - [ ] `npm run build`
+  - [ ] Other checks listed below
+- Evidence:
+  - 
+
+## Promotion / Hotfix Notes
+- Promotion scope or hotfix reason:
+- Back-merge into `develop` (required for hotfixes):
+
+## Risks / Follow-up
+- 

--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -38,6 +38,22 @@ Follow this loop for meaningful changes:
 - Keep handoff artifacts understandable by a new contributor.
 - Update traceability so requirement IDs map to evidence and follow-up work.
 
+## Branch and Pull Request Workflow
+
+Governed repositories should install a strict Git workflow during bootstrap so protected branches stay promotion surfaces instead of scratch space.
+
+- `GOV-02-GIT-001` `main` is the promotion/release branch. It accepts only explicit promotions from `develop` and urgent hotfix pull requests that originate from `main`.
+- `GOV-02-GIT-002` `develop` is the integration branch for normal work. Agent-authored feature, fix, docs, and chore changes must land in `develop` through pull request.
+- `GOV-02-GIT-003` Normal work must start from an issue-scoped branch created from `develop` using a typed prefix such as `feature/`, `fix/`, `docs/`, or `chore/`, plus the governing issue ID and short slug.
+- `GOV-02-GIT-004` Agents must not commit or push directly to `main` or `develop`.
+- `GOV-02-GIT-005` Every agent-authored non-hotfix change must use a pull request into `develop` that links the governing issue/spec and records verification evidence.
+- `GOV-02-GIT-006` Promotion from `develop` to `main` must be explicit and reviewable. Release or promotion pull requests should state what is being promoted and what release-readiness evidence supports the move.
+- `GOV-02-GIT-007` Hotfix work must branch from `main`, merge back to `main` through an explicit hotfix pull request, and then be back-merged or otherwise reconciled into `develop` immediately so the branches do not drift.
+- `GOV-02-GIT-008` Repositories adopting VibeGov should document branch protection expectations for `main` and `develop`, including required pull requests, review gates, status checks, and restricted direct pushes.
+- `GOV-02-GIT-009` Bootstrap and adoption guidance should install the branch/pull-request workflow, review template, and protection checklist before product-code implementation begins.
+
+This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.
+
 ## Explicit Orchestration and Bounded Work Units
 
 Governed agent execution should use explicit orchestration and bounded work units.

--- a/.governance/specs/strict-branch-pr-bootstrap.md
+++ b/.governance/specs/strict-branch-pr-bootstrap.md
@@ -1,0 +1,58 @@
+# Strict Branch and PR Bootstrap Workflow
+
+## Intent
+Make strict Git workflow part of VibeGov bootstrap so agents inherit explicit branch roles, pull-request routing, and protection expectations before implementation begins.
+
+## Scope
+In scope:
+- `VG-GITWF-001` update `GOV-02` with strict `main`/`develop` workflow rules for agents
+- `VG-GITWF-002` publish the rule update on the public `gov-02` docs page
+- `VG-GITWF-003` add a GitHub pull-request template aligned with issue/spec/evidence reporting
+- `VG-GITWF-004` add a branch protection checklist doc for `main` and `develop`
+- `VG-GITWF-005` update bootstrap/adoption docs so the workflow is installed during bootstrap
+- `VG-GITWF-006` add a blog post explaining how the workflow works and why it matters
+
+Out of scope:
+- automating GitHub branch protection settings
+- changing CI or release pipelines
+- adding merge queue, CODEOWNERS, or repository ruleset automation beyond documented expectations
+
+## Acceptance Criteria
+- `VG-GITWF-001` The canonical `gov-02` rule explicitly defines `main` and `develop` roles, issue-scoped `feature/`, `fix/`, `docs/`, and `chore/` branches, and the no-direct-agent-commit rule for `main`/`develop`.
+- `VG-GITWF-002` The same rule explicitly requires pull requests into `develop` for normal work, explicit promotion from `develop` to `main`, and a hotfix path from `main` with back-merge expectations into `develop`.
+- `VG-GITWF-003` A public published `gov-02` page mirrors the canonical rule update.
+- `VG-GITWF-004` A GitHub pull-request template exists and prompts authors to record issue/spec links, workflow route, validation, and hotfix back-merge details when relevant.
+- `VG-GITWF-005` A branch protection checklist doc exists and explains the expected protection settings and review gates for `main` and `develop`.
+- `VG-GITWF-006` Bootstrap and quickstart docs instruct adopters to install the strict branch/pull-request workflow as part of bootstrap, not as optional post-setup advice.
+- `VG-GITWF-007` Contribution/adoption docs explain the normal feature/fix/docs/chore PR flow, promotion PR flow, and hotfix back-merge path.
+- `VG-GITWF-008` A new blog post explains the workflow without simply duplicating the docs/checklist text.
+- `VG-GITWF-009` `npm run build` succeeds after the documentation and template changes.
+
+## Tests and Evidence
+- inspect `.governance/rules/gov-02-workflow.mdc`
+- inspect `.governance/specs/strict-branch-pr-bootstrap.md`
+- inspect `.github/pull_request_template.md`
+- inspect `docs/branch-protection-checklist.md`
+- inspect `docs/bootstrap.md`, `docs/quickstart.md`, and `docs/contribute.md`
+- inspect `docs/published/gov-02-workflow.md`
+- inspect `blog/2026-03-26-strict-branch-pr-bootstrap.md`
+- run `npm run build`
+
+## Documentation Impact
+- update `.governance/rules/gov-02-workflow.mdc`
+- add `.governance/specs/strict-branch-pr-bootstrap.md`
+- add `.github/pull_request_template.md`
+- add `docs/branch-protection-checklist.md`
+- update `docs/bootstrap.md`
+- update `docs/quickstart.md`
+- update `docs/contribute.md`
+- update `docs/published/gov-02-workflow.md`
+- add `blog/2026-03-26-strict-branch-pr-bootstrap.md`
+- update `sidebars.js`
+
+## Verification
+Verification is documentation-driven. Success requires the canonical rule, published rule page, bootstrap docs, checklist, PR template, and blog post to all describe the same branch/pull-request model, plus a successful site build.
+
+## Change Notes
+- Keep the canonical governance rule tool-agnostic enough to describe Git workflow shape while using GitHub docs/templates as the concrete adoption example in this repo.
+- Document branch protection expectations explicitly instead of claiming they are implied by the presence of `main` and `develop`.

--- a/blog/2026-03-26-strict-branch-pr-bootstrap.md
+++ b/blog/2026-03-26-strict-branch-pr-bootstrap.md
@@ -1,0 +1,118 @@
+---
+slug: strict-branch-pr-bootstrap
+title: "Bootstrap Is Not Finished Until the Branch Workflow Is Governed"
+authors: [VibeGov_team]
+tags: [workflow, bootstrap, git, pull-requests, governance]
+---
+
+Teams often bootstrap the governance folders and stop there.
+
+That is useful, but it leaves one of the most dangerous gaps open:
+
+- agents still have a path to work directly on protected branches
+- promotion to production can blur into normal integration
+- hotfixes can land fast and still leave `develop` behind
+
+If the repo workflow is loose, the governance is only half-installed.
+
+## The missing bootstrap step
+
+Bootstrap should not only install rules.
+It should install the repository path those rules have to travel through.
+
+For a strict VibeGov setup, that means:
+
+- `main` is the promotion/release branch
+- `develop` is the normal integration branch
+- issue-scoped `feature/`, `fix/`, `docs/`, and `chore/` branches start from `develop`
+- agents do not commit directly to `main` or `develop`
+- normal work reaches `develop` through pull request
+- promotion from `develop` to `main` is a separate, explicit decision
+
+That is the branch contract.
+Without it, the rest of the delivery loop is easier to bypass than teams usually admit.
+
+## Why `develop` matters so much
+
+The point of `develop` is not to create ceremony.
+It is to separate normal integration from release promotion.
+
+When all work aims straight at `main`, teams lose a clean place to ask:
+
+- what is ready to integrate?
+- what is ready to promote?
+- what evidence is attached to each decision?
+
+`develop` gives the system a stable answer.
+Normal work integrates there first.
+Promotion to `main` becomes visible instead of accidental.
+
+## Why issue-scoped branches matter
+
+Agents are fast enough that "small shortcut" branching habits become system-level problems.
+
+Issue-scoped branches force three good behaviors:
+
+1. the work has a tracked reason to exist
+2. the scope stays isolated while the change is in motion
+3. reviewers can map the branch back to issue and spec intent quickly
+
+That is why the branch name itself should carry the issue ID.
+It turns Git history into traceability instead of mere chronology.
+
+## Pull requests are the integration gate
+
+The important rule is not merely "use pull requests sometimes."
+It is "normal work must enter `develop` through pull requests, and agents do not bypass that gate."
+
+That matters because pull requests are where teams can reliably attach:
+
+- issue links
+- spec links
+- validation evidence
+- risk notes
+- release-readiness context
+
+The pull request is where branch workflow meets governed evidence.
+
+## Promotion and hotfixes should be explicit too
+
+Promotion from `develop` to `main` is not just another merge.
+It is a release decision.
+
+That decision should be visible in its own pull request so reviewers can ask whether the integrated work is truly ready to become the production/reference state.
+
+Hotfixes need the same clarity from the other direction:
+
+- branch from `main`
+- merge back to `main` through an explicit hotfix pull request
+- then back-merge or otherwise reconcile into `develop` immediately
+
+Without that last step, the repo begins to lie about its own state.
+`main` contains reality, `develop` contains a stale story, and the next integration cycle inherits the drift.
+
+## Branch protection turns the policy into reality
+
+A written workflow is better than nothing, but protected-branch settings are what stop the shortcuts from becoming normal.
+
+That is why VibeGov bootstrap now needs more than a rule file.
+It also needs:
+
+- a repo pull-request template
+- a branch protection checklist
+- adoption docs that explain the promotion and hotfix path clearly
+
+Those artifacts make the workflow teachable and enforceable instead of tribal.
+
+## Practical takeaway
+
+If you want agents to inherit good delivery behavior, bootstrap the Git path as well as the governance text.
+
+Install the folders, install the rules, and also install the strict branch and pull-request contract before product code begins.
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Quick Start](/docs/quickstart)
+- [Branch Protection Checklist](/docs/branch-protection-checklist)
+- [GOV 02 Workflow](/docs/published/gov-02-workflow)

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -18,8 +18,17 @@ Before writing any product code:
 3. Create project intent from `PROJECT_TEMPLATE.md`.
 4. Create the first feature/change spec from `SPEC_TEMPLATE.md`.
 5. Create or normalize a spec-mapped backlog.
-6. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the target path. If none exists, keep `.governance/` canonical and do not invent a mirror path.
-7. Report the active governance sources you are using.
+6. Install the strict Git workflow for agents:
+   - `main` is promotion/release only
+   - `develop` is the pull-request integration branch
+   - issue-scoped `feature/`, `fix/`, `docs/`, and `chore/` branches start from `develop`
+   - agents never commit directly to `main` or `develop`
+   - normal work enters `develop` through pull request
+   - `develop` promotes to `main` through an explicit pull request
+   - hotfixes branch from `main` and must be reconciled back into `develop`
+   - add a repo-local pull-request template and branch-protection checklist
+7. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the target path. If none exists, keep `.governance/` canonical and do not invent a mirror path.
+8. Report the active governance sources you are using and the Git workflow artifacts you installed.
 
 Then stop before product-code implementation.
 
@@ -30,6 +39,8 @@ Quality expectation:
 ```
 
 Need a repeatable way to prove bootstrap works? See [Bootstrap Validation](/docs/bootstrap-validation) and the [Bootstrap Validator Harness](/docs/bootstrap-validator-harness).
+
+Strict Git workflow reference: [Branch Protection Checklist](/docs/branch-protection-checklist).
 
 ## Governance Rules Navigation
 
@@ -62,7 +73,9 @@ Continue only if all are true:
 - `.governance/project/` exists with project intent created from the template
 - `.governance/specs/` exists with the first feature/change spec created from the template
 - backlog maps to spec scope
-- active governance sources were reported
+- strict `main`/`develop` roles and pull-request flow are documented before implementation begins
+- if the repo uses GitHub, a pull-request template exists and branch protection expectations are documented
+- active governance sources and Git workflow artifacts were reported
 - no product code has been written yet
 
 If any fail, rerun the same prompt.

--- a/docs/branch-protection-checklist.md
+++ b/docs/branch-protection-checklist.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 4
+---
+
+# Branch Protection Checklist
+
+Use this during bootstrap or repo adoption when you want agents to inherit the strict VibeGov Git workflow before implementation starts.
+
+## Branch roles
+
+- `main`: promotion/release branch. It accepts only explicit promotion pull requests from `develop` and urgent hotfix pull requests branched from `main`.
+- `develop`: integration branch for normal work. Feature, fix, docs, and chore changes land here through pull request.
+- issue branches: `feature/<issue>-<slug>`, `fix/<issue>-<slug>`, `docs/<issue>-<slug>`, or `chore/<issue>-<slug>` created from `develop`.
+- hotfix branches: `hotfix/<issue>-<slug>` created from `main`.
+- agents never commit directly to `main` or `develop`.
+
+## GitHub protection checklist for `develop`
+
+- [ ] `develop` exists and is used as the pull-request target for normal work.
+- [ ] Require a pull request before merging.
+- [ ] Require approvals according to team policy.
+- [ ] Require the repo's validation/status checks before merge.
+- [ ] Require conversation resolution before merge.
+- [ ] Restrict direct pushes so agents cannot bypass pull requests.
+- [ ] Disable force pushes and branch deletion unless a documented admin exception exists.
+
+## GitHub protection checklist for `main`
+
+- [ ] `main` exists and is treated as the promotion/release branch.
+- [ ] Require a pull request before merging.
+- [ ] Require approvals and release-readiness/status checks before merge.
+- [ ] Restrict direct pushes so agents cannot bypass pull requests.
+- [ ] Disable force pushes and branch deletion unless a documented admin exception exists.
+- [ ] Treat merges into `main` as either explicit promotions from `develop` or urgent hotfix pull requests from `main`-based branches.
+
+## Promotion checklist
+
+- [ ] The release scope is already integrated and verified on `develop`.
+- [ ] The promotion pull request explicitly moves `develop` into `main`.
+- [ ] The promotion pull request states what is being promoted and what evidence supports the move.
+- [ ] Any unresolved risks or follow-up work are recorded before merge.
+
+## Hotfix checklist
+
+- [ ] Start the hotfix from `main`.
+- [ ] Use a `hotfix/<issue>-<slug>` branch name that includes the governing issue ID.
+- [ ] Merge the hotfix back to `main` through a reviewed pull request.
+- [ ] Back-merge or otherwise reconcile the hotfix into `develop` immediately after the `main` merge.
+- [ ] Record the back-merge pull request or commit in the hotfix notes.
+
+## Bootstrap/adoption outputs
+
+- [ ] A repo-local pull-request template exists (for GitHub repos, `.github/pull_request_template.md`).
+- [ ] Bootstrap instructions tell agents that `main` and `develop` are protected integration/promotion surfaces, not working branches.
+- [ ] Quickstart/adoption docs explain issue-scoped branch naming and mandatory pull requests into `develop`.
+- [ ] Contribution docs explain promotion and hotfix flows.
+
+## Practical note
+
+GitHub branch protection can protect `main` and `develop`, but branch naming conventions for source branches may need rulesets, automation, or review discipline depending on the hosting plan and repository setup.
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Quick Start](/docs/quickstart)
+- [Contribute](/docs/contribute)
+- [GOV 02 Workflow](/docs/published/gov-02-workflow)

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -4,7 +4,7 @@ sidebar_position: 4
 
 # Contribute
 
-Feedback is managed in GitHub Issues so decisions stay public, reviewable, and traceable.
+Feedback is managed in GitHub Issues so decisions stay public, reviewable, and traceable. Code and content changes should move through the strict branch and pull-request workflow.
 
 ## Suggest an improvement
 
@@ -14,12 +14,30 @@ Feedback is managed in GitHub Issues so decisions stay public, reviewable, and t
 4. Describe the current problem, the expected improvement, and why it matters.
 5. If relevant, include a concrete wording proposal.
 
+## Branching and pull requests
+
+1. Start from a GitHub issue or clearly linked governed task.
+2. Create an issue-scoped `feature/`, `fix/`, `docs/`, or `chore/` branch from `develop`.
+3. Do not let agents commit directly to `main` or `develop`.
+4. Open a pull request into `develop` and complete the repo pull-request template with issue/spec/evidence links.
+5. Keep validation evidence in the pull request so promotion reviewers can reuse it.
+
+Use the [Branch Protection Checklist](/docs/branch-protection-checklist) when setting up or reviewing repo protections.
+
+## Promotion and hotfix path
+
+- Promote reviewed work from `develop` to `main` with an explicit pull request.
+- Start urgent fixes from `main` with `hotfix/<issue>-<slug>` branches.
+- After a hotfix lands in `main`, back-merge or otherwise reconcile it into `develop` immediately.
+- Record promotion scope, hotfix reason, and any back-merge reference in the related pull request.
+
 ## Strong contribution targets
 
 Especially useful contributions include:
 - unclear execution-mode boundaries
 - weak completion criteria
 - missing or weak evidence expectations
+- weak branch-protection or pull-request workflow guidance
 - blocker-handling ambiguity
 - exploratory-review loopholes
 - persistence-proof gaps
@@ -38,5 +56,6 @@ Especially useful contributions include:
 - Preserve intent over surface wording.
 - Keep governance reusable across projects and providers.
 - Avoid project-specific tool lock-in in core rules.
+- Use issue-scoped branches and pull requests rather than bypassing protected branches.
 - Prefer guidance that is hard to misread and hard to execute badly.
 - If a rule sounds good but is easy to game, keep improving it.

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -63,6 +63,24 @@ Follow this loop for meaningful changes:
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
+## Branch and Pull Request Workflow
+
+Governed repositories should install a strict Git workflow during bootstrap so protected branches stay promotion surfaces instead of scratch space.
+
+- `GOV-02-GIT-001` `main` is the promotion/release branch. It accepts only explicit promotions from `develop` and urgent hotfix pull requests that originate from `main`.
+- `GOV-02-GIT-002` `develop` is the integration branch for normal work. Agent-authored feature, fix, docs, and chore changes must land in `develop` through pull request.
+- `GOV-02-GIT-003` Normal work must start from an issue-scoped branch created from `develop` using a typed prefix such as `feature/`, `fix/`, `docs/`, or `chore/`, plus the governing issue ID and short slug.
+- `GOV-02-GIT-004` Agents must not commit or push directly to `main` or `develop`.
+- `GOV-02-GIT-005` Every agent-authored non-hotfix change must use a pull request into `develop` that links the governing issue/spec and records verification evidence.
+- `GOV-02-GIT-006` Promotion from `develop` to `main` must be explicit and reviewable. Release or promotion pull requests should state what is being promoted and what release-readiness evidence supports the move.
+- `GOV-02-GIT-007` Hotfix work must branch from `main`, merge back to `main` through an explicit hotfix pull request, and then be back-merged or otherwise reconciled into `develop` immediately so the branches do not drift.
+- `GOV-02-GIT-008` Repositories adopting VibeGov should document branch protection expectations for `main` and `develop`, including required pull requests, review gates, status checks, and restricted direct pushes.
+- `GOV-02-GIT-009` Bootstrap and adoption guidance should install the branch/pull-request workflow, review template, and protection checklist before product-code implementation begins.
+
+This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
 ## Explicit Orchestration and Bounded Work Units
 
 Governed agent execution should use explicit orchestration and bounded work units.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,10 +25,19 @@ Initialization contract:
 4) If no provider-native rules directory exists, do not invent placeholder paths; use `.governance/rules/*.mdc` as canonical.
 5) Do not place governance files outside `.governance/` unless explicitly requested.
 6) Read `gov-01` through `gov-08` and extract the active workflow, communication, quality, testing, issue, task, and exploratory rules.
-7) Confirm governance activation by listing active rule files and active governance sources.
+7) Install a strict Git workflow before implementation:
+   - treat `main` as promotion/release only
+   - treat `develop` as the pull-request integration branch
+   - create issue-scoped `feature/`, `fix/`, `docs/`, and `chore/` branches from `develop`
+   - forbid direct agent commits to `main` or `develop`
+   - require pull requests into `develop` for normal work
+   - require explicit promotion from `develop` to `main`
+   - require hotfix branches from `main` with reconciliation back into `develop`
+   - add a repo-local pull-request template and branch protection checklist
+8) Confirm governance activation by listing active rule files, active governance sources, and the installed Git workflow artifacts.
 
 Execution gate:
-- Do not start product-code implementation until steps 1-7 are completed and reported.
+- Do not start product-code implementation until steps 1-8 are completed and reported.
 - Do not use AI only to accelerate implementation while skipping tests, specs, docs, traceability, validation evidence, or delivery clarity.
 
 During delivery:
@@ -73,12 +82,23 @@ Canonical-source model:
 - Keep `.governance/` as the source of truth.
 - Let each agent/provider link to that source using its own structure.
 
-## 3. Fill project intent before coding
+## 3. Install the strict Git workflow
+
+- Use `main` as the promotion/release branch.
+- Use `develop` as the integration branch for normal work.
+- Create issue-scoped `feature/<issue>-<slug>`, `fix/<issue>-<slug>`, `docs/<issue>-<slug>`, or `chore/<issue>-<slug>` branches from `develop`.
+- Do not let agents commit directly to `main` or `develop`.
+- Require pull requests into `develop` for normal work.
+- Promote `develop` to `main` through an explicit promotion pull request.
+- Run hotfixes from `main`, then back-merge or otherwise reconcile them into `develop`.
+- For GitHub repos, add `.github/pull_request_template.md` and follow the [Branch Protection Checklist](/docs/branch-protection-checklist).
+
+## 4. Fill project intent before coding
 
 - Create/update project intent from `.governance/project/PROJECT_TEMPLATE.md`.
 - Create feature/change specs from `.governance/specs/SPEC_TEMPLATE.md` when needed.
 
-## 4. Start with the governance set
+## 5. Start with the governance set
 
 Read in this order:
 1. `gov-01-instructions.mdc`
@@ -86,7 +106,7 @@ Read in this order:
 3. `gov-03` to `gov-07`
 4. `gov-08-exploratory-review.mdc`
 
-## 5. Understand the execution modes
+## 6. Understand the execution modes
 
 VibeGov works through two operating modes:
 - **Development** — change behavior with proof, release-readiness checks, and shipping discipline
@@ -102,7 +122,7 @@ Useful supporting docs:
 - [Workflow Quality Rubric](/docs/workflow-quality-rubric)
 - [Bootstrap Validation](/docs/bootstrap-validation)
 
-## 6. Quality and completeness expectation
+## 7. Quality and completeness expectation
 
 Bootstrap should not only create governance files. It should also raise the expected standard of done.
 
@@ -113,12 +133,15 @@ That expectation is already reinforced by:
 
 The practical implication is that AI should help teams maintain the quality scaffolding around a change — tests, specs, docs, traceability, and delivery clarity — rather than simply producing code faster.
 
-## 7. Validate installation
+## 8. Validate installation
 
 Confirm the agent can read active rule files and that prompts/outputs reflect:
 - spec-first behavior
 - evidence-driven validation
 - issue/task traceability
+- strict `main`/`develop` roles plus issue-scoped branch naming
+- pull-request-only integration through `develop`, with explicit promotion and hotfix flow
+- pull-request template and branch-protection expectations when using GitHub
 - exploratory artifact creation for non-validated findings
 - blocker visibility instead of silent stalls
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -17,6 +17,7 @@ const sidebars = {
     'intro',
     'bootstrap',
     'quickstart',
+    'branch-protection-checklist',
     'vibegov-sdlc',
     'contribute',
     {


### PR DESCRIPTION
## Summary
- add a strict branch/PR/bootstrap governance spec and supporting rule/docs updates
- add PR template and branch protection checklist artifacts
- publish the explainer post for the strict main/develop/feature/PR workflow

## Closes
- closes #12

## Validation
- npm ci
- npm run build

## Notes
This branch predates the newer bootstrap quality-series updates but validates cleanly and stays focused on the branch/PR workflow contract.