### PR TITLE
Harden codex-cli live bootstrap adapter for bootstrap-gate

### DIFF
--- a/.internal/bootstrap-validator/README.md
+++ b/.internal/bootstrap-validator/README.md
@@ -1,0 +1,101 @@
+# Bootstrap Validator
+
+This directory contains the runnable phase-1 VibeGov bootstrap-validator MVP.
+
+It validates bootstrap behavior programmatically using:
+- repo fixtures
+- prompt fixtures
+- declarative scenarios
+- deterministic assertions
+- evidence bundles
+- a local stub adapter for bootstrap-only flows
+
+## Current scope
+
+Runnable now:
+- `empty-repo-bootstrap`
+- `bootstrap-gate`
+- suite: `phase1`
+
+Available adapters:
+- `local-stub` — deterministic baseline for bootstrap-only validation
+- `codex-cli` — live agent adapter using `codex exec --full-auto`, an isolated temp `CODEX_HOME`, and bootstrap-safe shell-plan normalization when a runtime emits command batches instead of applying them directly
+
+Scaffolded but not yet implemented as executable flows:
+- `under-specified-issue`
+- `exploratory-route`
+- `persistence-false-green`
+
+## How to run
+
+From repo root:
+
+```bash
+npm run bootstrap-validator -- --list
+npm run bootstrap-validator -- --scenario empty-repo-bootstrap
+npm run bootstrap-validator -- --scenario bootstrap-gate
+npm run bootstrap-validator -- --suite phase1
+npm run bootstrap-validator -- --scenario empty-repo-bootstrap --adapter codex-cli
+npm run bootstrap-validator -- --scenario bootstrap-gate --adapter codex-cli
+```
+
+## What the MVP does
+
+For each runnable scenario, the harness:
+1. copies a fixture into a temporary working repo
+2. captures a pre-run manifest
+3. runs the selected adapter (`local-stub` or `codex-cli` today)
+4. captures a post-run manifest and diff
+5. executes core assertions
+6. writes an evidence bundle under `.internal/bootstrap-validator/reports/`
+
+## Evidence bundle contents
+
+Each run writes a timestamped report directory containing:
+- `transcript.md`
+- `manifest-before.json`
+- `manifest-after.json`
+- `diff.json`
+- `result.json`
+
+## Assertion coverage in phase 1
+
+Implemented assertions:
+- `governanceDirsExist`
+- `govRuleSetPresent`
+- `projectIntentCreated`
+- `firstSpecCreated`
+- `noProductCodeChanges`
+- `governanceSourcesReported`
+- `bootstrapStopDeclared`
+
+## Layout
+
+- `fixtures/` — starting repo states used by scenarios
+- `prompts/` — stable prompt fixtures sent to agents
+- `scenarios/` — declarative scenario definitions and suite manifests
+- `schemas/` — JSON schemas for scenario/result files
+- `lib/` — runnable validator implementation
+- `assertions/` — reserved for future modular assertion expansion
+- `runners/` — reserved for future modular runner expansion
+- `reports/` — generated run outputs (keep `.gitkeep` only in git)
+
+## Current limitations
+
+- `codex-cli` is the first live adapter, but scope is still bootstrap-only
+- bootstrap-only scenarios are the only supported live flows today
+- live-agent behavior can vary by model/runtime availability and prompt fidelity
+- `codex-cli` may retry against a local Ollama runtime when the default provider cannot complete the bootstrap run
+- no advanced schema validation or HTML reporting yet
+
+## Next good steps
+
+1. promote assertions into separate modules
+2. add a real agent adapter
+3. implement exploratory and vague-issue scenarios end-to-end
+4. add suite aggregation/report summarization
+
+See also:
+- `docs/bootstrap-validation.md`
+- `docs/bootstrap-validator-harness.md`
+

--- a/.internal/bootstrap-validator/assertions/README.md
+++ b/.internal/bootstrap-validator/assertions/README.md
@@ -1,0 +1,24 @@
+# Assertions
+
+This directory is reserved for the bootstrap-validator assertion library.
+
+Suggested first modules:
+- `filesystem.ts`
+- `transcript.ts`
+- `diffs.ts`
+- `artifacts.ts`
+- `scoring.ts`
+
+Suggested first assertion IDs:
+- `governanceDirsExist`
+- `govRuleSetPresent`
+- `projectIntentCreated`
+- `firstSpecCreated`
+- `noProductCodeChanges`
+- `governanceSourcesReported`
+- `specGapOrRequirementBinding`
+- `exploratoryClassificationCoverage`
+- `artifactsForNonValidatedFindings`
+- `persistenceVerificationMentioned`
+- `honestCompletenessLabel`
+- `releaseDecisionPresent`

--- a/.internal/bootstrap-validator/fixtures/README.md
+++ b/.internal/bootstrap-validator/fixtures/README.md
@@ -1,0 +1,12 @@
+# Fixtures
+
+Each fixture directory should represent a clean, known starting repo state for one or more bootstrap-validator scenarios.
+
+Suggested fixture directories:
+- `empty-repo/`
+- `existing-provider-rules/`
+- `bootstrapped-repo/`
+- `persistence-false-green/`
+- `blocker-routing/`
+
+Keep fixtures minimal and deterministic.

--- a/.internal/bootstrap-validator/fixtures/blocker-routing/.gitkeep
+++ b/.internal/bootstrap-validator/fixtures/blocker-routing/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/.internal/bootstrap-validator/fixtures/bootstrapped-repo/.gitkeep
+++ b/.internal/bootstrap-validator/fixtures/bootstrapped-repo/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/.internal/bootstrap-validator/fixtures/empty-repo/.gitkeep
+++ b/.internal/bootstrap-validator/fixtures/empty-repo/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/.internal/bootstrap-validator/fixtures/existing-provider-rules/.gitkeep
+++ b/.internal/bootstrap-validator/fixtures/existing-provider-rules/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/.internal/bootstrap-validator/fixtures/persistence-false-green/.gitkeep
+++ b/.internal/bootstrap-validator/fixtures/persistence-false-green/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/.internal/bootstrap-validator/index.js
+++ b/.internal/bootstrap-validator/index.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+const path = require('path');
+const { runScenarioById, runSuiteById } = require('./lib/runner');
+
+function parseArgs(argv) {
+  const args = { adapter: 'local-stub' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--scenario') args.scenario = argv[++i];
+    else if (arg === '--suite') args.suite = argv[++i];
+    else if (arg === '--adapter') args.adapter = argv[++i];
+    else if (arg === '--list') args.list = true;
+    else if (arg === '--help' || arg === '-h') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`VibeGov Bootstrap Validator\n\nUsage:\n  npm run bootstrap-validator -- --scenario <id> [--adapter local-stub|codex-cli]\n  npm run bootstrap-validator -- --suite <id> [--adapter local-stub|codex-cli]\n  npm run bootstrap-validator -- --list\n\nExamples:\n  npm run bootstrap-validator -- --scenario empty-repo-bootstrap\n  npm run bootstrap-validator -- --scenario bootstrap-gate\n  npm run bootstrap-validator -- --scenario empty-repo-bootstrap --adapter codex-cli\n  npm run bootstrap-validator -- --suite phase1\n`);
+}
+
+async function main() {
+  const rootDir = path.resolve(__dirname, '..', '..');
+  const validatorDir = __dirname;
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help || (!args.list && !args.scenario && !args.suite)) {
+    printHelp();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  if (args.list) {
+    const { listScenarios, listSuites } = require('./lib/scenarios');
+    console.log('Scenarios:');
+    for (const item of listScenarios(validatorDir)) console.log(`- ${item}`);
+    console.log('Suites:');
+    for (const item of listSuites(validatorDir)) console.log(`- ${item}`);
+    return;
+  }
+
+  if (args.scenario) {
+    const result = await runScenarioById({ validatorDir, rootDir, scenarioId: args.scenario, adapterId: args.adapter });
+    console.log(JSON.stringify({ scenarioId: result.scenarioId, passed: result.passed, score: result.score, reportDir: result.reportDir }, null, 2));
+    process.exit(result.passed ? 0 : 2);
+  }
+
+  const result = await runSuiteById({ validatorDir, rootDir, suiteId: args.suite, adapterId: args.adapter });
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.failed > 0 ? 2 : 0);
+}
+
+main().catch((error) => {
+  console.error(error.stack || String(error));
+  process.exit(1);
+});

--- a/.internal/bootstrap-validator/lib/adapters/codex-cli.js
+++ b/.internal/bootstrap-validator/lib/adapters/codex-cli.js
@@ -1,0 +1,623 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { randomUUID } = require('crypto');
+const { spawnSync } = require('child_process');
+const { ensureDir, copyDir, removeDir, writeText } = require('../fs-utils');
+
+function toPosix(filePath) {
+  return filePath.replace(/\\/g, '/');
+}
+
+function loadPrompt(validatorDir, promptFile) {
+  const promptPath = path.join(validatorDir, 'prompts', promptFile);
+  return fs.readFileSync(promptPath, 'utf8').trim();
+}
+
+function buildPrompt({ rootDir, validatorDir, scenario }) {
+  const scenarioSpecific = `${scenario.id}-codex.txt`;
+  const promptDir = path.join(validatorDir, 'prompts');
+  const selectedFile = fs.existsSync(path.join(promptDir, scenarioSpecific)) ? scenarioSpecific : scenario.prompt;
+  const base = loadPrompt(validatorDir, selectedFile);
+  const governancePath = path.join(rootDir, '.governance');
+  const governancePathPosix = toPosix(governancePath);
+  const rulesPath = toPosix(path.join(governancePath, 'rules'));
+  const projectTemplatePath = toPosix(path.join(governancePath, 'project', 'PROJECT_TEMPLATE.md'));
+  const specTemplatePath = toPosix(path.join(governancePath, 'specs', 'SPEC_TEMPLATE.md'));
+  const bootstrapConstraints = scenario.mode === 'bootstrap'
+    ? [
+        'Create at least one non-template spec file under .governance/specs/ (for example: bootstrap-governance-setup.md).',
+      ].join('\n')
+    : '';
+  const scenarioSpecificConstraints = scenario.id === 'bootstrap-gate'
+    ? [
+        'For this bootstrap-gate scenario, your final report must include the exact sentence: Stopping before product implementation.',
+        'Your final report must also include one line that starts exactly with: Active governance sources:',
+      ].join('\n')
+    : '';
+  return `${base}
+
+Local VibeGov source available for reference at: ${governancePathPosix}
+Local VibeGov rules directory: ${rulesPath}
+Local project template path: ${projectTemplatePath}
+Local spec template path: ${specTemplatePath}
+Read governance/templates from those local source paths instead of using remote URLs when possible.
+
+Validator constraints:
+- You are running inside a temporary fixture repo used only for bootstrap validation.
+- Follow the prompt literally.
+- If the scenario is bootstrap-only, stop before product implementation.
+- At the end, explicitly report the active governance sources you used.
+- Do not emit markdown fences unless needed.
+- If your runtime cannot execute tools directly, emit one JSON object with name set to shell and arguments.commands set to an ordered array of the exact file-system commands needed, then include the required plain-text report.
+${bootstrapConstraints}
+${scenarioSpecificConstraints}
+`;
+}
+
+function readText(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return '';
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function readLastMessage(lastMessagePath) {
+  return readText(lastMessagePath).trim();
+}
+
+function hasBootstrapStopDeclaration(text) {
+  return /stopping before product implementation|stopped before product-code implementation/i.test(text);
+}
+
+function hasGovernanceSourceReport(text) {
+  return /Active governance sources:/i.test(text);
+}
+
+function canTreatLastMessageAsComplete({ scenario, text }) {
+  if (!text) return false;
+  if (scenario.mode !== 'bootstrap') return false;
+  return hasBootstrapStopDeclaration(text)
+    && (scenario.id !== 'bootstrap-gate' || hasGovernanceSourceReport(text));
+}
+
+function tokenizeShellCommand(command) {
+  const tokens = [];
+  let current = '';
+  let quote = null;
+  for (const char of command) {
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '\'' || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function findShellPlanCandidates(text) {
+  const candidates = [];
+  for (const match of text.matchAll(/```(?:json)?\s*([\s\S]*?)```/ig)) {
+    candidates.push(match[1].trim());
+  }
+
+  const firstBrace = text.indexOf('{');
+  if (firstBrace !== -1) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = firstBrace; index < text.length; index += 1) {
+      const char = text[index];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (char === '{') depth += 1;
+      if (char === '}') depth -= 1;
+      if (depth === 0) {
+        candidates.push(text.slice(firstBrace, index + 1).trim());
+        break;
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function extractShellPlan(text) {
+  for (const candidate of findShellPlanCandidates(text)) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && parsed.name === 'shell' && parsed.arguments && Array.isArray(parsed.arguments.commands)) {
+        return parsed.arguments.commands;
+      }
+    } catch {}
+  }
+  return null;
+}
+
+function isAbsolutePathToken(token) {
+  return /^[A-Za-z]:[\\/]/.test(token) || token.startsWith('\\\\');
+}
+
+function normalizeRelativeBootstrapPath(token) {
+  const normalized = token.replace(/\\/g, '/');
+  const repoStripped = normalized
+    .replace(/^(?:\.\/)?tmp\/bootstrap-repo\//i, '')
+    .replace(/^(?:\.\/)?bootstrap-repo\//i, '');
+  if (/^(?:\.\/)?tmp\/bootstrap-repo$/i.test(normalized) || /^(?:\.\/)?bootstrap-repo$/i.test(normalized)) return '.';
+  if (repoStripped === 'PROJECT_TEMPLATE.md') return '.governance/project/PROJECT_TEMPLATE.md';
+  if (repoStripped === 'SPEC_TEMPLATE.md') return '.governance/specs/SPEC_TEMPLATE.md';
+  return repoStripped;
+}
+
+function resolveRepoPath(repoPath, token) {
+  const normalized = normalizeRelativeBootstrapPath(token).replace(/\\/g, '/');
+  if (normalized === '.') return repoPath;
+  if (isAbsolutePathToken(normalized)) return path.resolve(normalized);
+  return path.join(repoPath, normalized);
+}
+
+function ensureProjectIntentPath(repoPath, token) {
+  if (token.replace(/\\/g, '/').endsWith('/INTENT.md')) {
+    return path.join(repoPath, '.governance', 'project', 'PROJECT.md');
+  }
+  return resolveRepoPath(repoPath, token);
+}
+
+function expandCopySources(repoPath, sourceToken) {
+  const normalized = normalizeRelativeBootstrapPath(sourceToken).replace(/\\/g, '/');
+  if (normalized.endsWith('/*')) {
+    const baseDir = resolveRepoPath(repoPath, normalized.slice(0, -2));
+    if (!fs.existsSync(baseDir)) return [];
+    return fs.readdirSync(baseDir).map((name) => path.join(baseDir, name));
+  }
+  return [resolveRepoPath(repoPath, normalized)];
+}
+
+function copyEntry(sourcePath, destPath, recursive) {
+  const stat = fs.statSync(sourcePath);
+  const destLooksDirectory = destPath === '.'
+    || /[\\/]$/.test(destPath)
+    || (fs.existsSync(destPath) && fs.statSync(destPath).isDirectory());
+
+  if (stat.isDirectory()) {
+    if (!recursive) throw new Error(`copy requires -r for directory source: ${sourcePath}`);
+    const finalDest = destLooksDirectory ? path.join(destPath, path.basename(sourcePath)) : destPath;
+    copyDir(sourcePath, finalDest);
+    return finalDest;
+  }
+
+  const finalDest = destLooksDirectory ? path.join(destPath, path.basename(sourcePath)) : destPath;
+  ensureDir(path.dirname(finalDest));
+  fs.copyFileSync(sourcePath, finalDest);
+  return finalDest;
+}
+
+function executeShellPlanCommand({ command, repoPath }) {
+  const tokens = tokenizeShellCommand(command);
+  if (!tokens.length) return `Skipped empty command.`;
+
+  if (tokens[0] === 'mkdir') {
+    const paths = tokens.filter((token, index) => index > 0 && token !== '-p');
+    for (const dirToken of paths) {
+      ensureDir(resolveRepoPath(repoPath, dirToken));
+    }
+    return `Created directories: ${paths.join(', ')}`;
+  }
+
+  if (tokens[0] === 'cp') {
+    const recursive = tokens.includes('-r');
+    const args = tokens.filter((token, index) => !(index === 0 || token === '-r'));
+    if (args.length < 2) throw new Error(`Unsupported copy command: ${command}`);
+    const destToken = args[args.length - 1];
+    const sourceTokens = args.slice(0, -1);
+    const destPath = ensureProjectIntentPath(repoPath, destToken);
+    const copied = [];
+    for (const sourceToken of sourceTokens) {
+      const sources = expandCopySources(repoPath, sourceToken);
+      if (!sources.length) throw new Error(`Copy source not found for command: ${command}`);
+      for (const sourcePath of sources) {
+        copied.push(copyEntry(sourcePath, destPath, recursive));
+      }
+    }
+    return `Copied ${sourceTokens.join(', ')} to ${toPosix(destPath)} (${copied.length} item(s)).`;
+  }
+
+  if (tokens[0] === 'echo') {
+    const redirectIndex = tokens.findIndex((token) => token === '>' || token === '>>');
+    if (redirectIndex === -1 || redirectIndex === tokens.length - 1) {
+      throw new Error(`Unsupported echo command: ${command}`);
+    }
+    const message = tokens.slice(1, redirectIndex).join(' ');
+    const operator = tokens[redirectIndex];
+    const destPath = resolveRepoPath(repoPath, tokens[redirectIndex + 1]);
+    ensureDir(path.dirname(destPath));
+    const existing = operator === '>>' ? readText(destPath) : '';
+    const next = `${existing}${message}\n`;
+    writeText(destPath, next);
+    return `${operator === '>>' ? 'Appended to' : 'Wrote'} ${toPosix(destPath)}.`;
+  }
+
+  throw new Error(`Unsupported shell-plan command: ${command}`);
+}
+
+function applyShellPlan({ repoPath, commands }) {
+  const notes = [];
+  for (const command of commands) {
+    notes.push(`$ ${command}`);
+    notes.push(executeShellPlanCommand({ command, repoPath }));
+  }
+  return notes.join('\n');
+}
+
+function findExecutableOnPath(name) {
+  const locator = process.platform === 'win32' ? 'where' : 'which';
+  const result = spawnSync(locator, [name], { encoding: 'utf8' });
+  if (result.status !== 0) return null;
+  return result.stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean) || null;
+}
+
+function candidateCodexHomes() {
+  const homes = new Set();
+  const addHome = (candidate) => {
+    if (!candidate) return;
+    const resolved = path.resolve(candidate);
+    if (fs.existsSync(resolved)) homes.add(resolved);
+  };
+
+  addHome(process.env.VIBEGOV_CODEX_HOME);
+  addHome(process.env.CODEX_HOME);
+
+  const envHomes = [process.env.HOME, process.env.USERPROFILE, process.env.HOMEDRIVE && process.env.HOMEPATH ? `${process.env.HOMEDRIVE}${process.env.HOMEPATH}` : null]
+    .filter(Boolean)
+    .map((value) => path.join(value, '.codex'));
+  envHomes.forEach(addHome);
+
+  for (const entry of (process.env.PATH || '').split(path.delimiter).filter(Boolean)) {
+    let current = path.resolve(entry);
+    while (current && current !== path.dirname(current)) {
+      if (path.basename(current).toLowerCase() === '.codex') {
+        addHome(current);
+        break;
+      }
+      current = path.dirname(current);
+    }
+  }
+
+  return [...homes];
+}
+
+function resolveCodexRuntime() {
+  const explicitPath = process.env.VIBEGOV_CODEX_CLI_PATH;
+  if (explicitPath && fs.existsSync(explicitPath)) {
+    return {
+      executable: explicitPath,
+      codexHome: path.dirname(path.dirname(explicitPath)),
+    };
+  }
+
+  const pathExecutable = findExecutableOnPath('codex');
+  if (pathExecutable) {
+    return {
+      executable: pathExecutable,
+      codexHome: candidateCodexHomes()[0] || null,
+    };
+  }
+
+  for (const codexHome of candidateCodexHomes()) {
+    const executable = path.join(codexHome, '.sandbox-bin', process.platform === 'win32' ? 'codex.exe' : 'codex');
+    if (fs.existsSync(executable)) {
+      return { executable, codexHome };
+    }
+  }
+
+  return { executable: process.platform === 'win32' ? 'codex.exe' : 'codex', codexHome: null };
+}
+
+function createIsolatedCodexHome(sourceHome) {
+  const isolatedHome = path.join(os.tmpdir(), `vibegov-codex-home-${randomUUID()}`);
+  ensureDir(isolatedHome);
+  if (!sourceHome || !fs.existsSync(sourceHome)) return isolatedHome;
+
+  for (const fileName of ['config.toml', 'auth.json']) {
+    const sourceFile = path.join(sourceHome, fileName);
+    if (fs.existsSync(sourceFile)) {
+      fs.copyFileSync(sourceFile, path.join(isolatedHome, fileName));
+    }
+  }
+
+  return isolatedHome;
+}
+
+function hasAuth(sourceHome) {
+  return Boolean(sourceHome && fs.existsSync(path.join(sourceHome, 'auth.json')));
+}
+
+function selectOllamaModel() {
+  return process.env.VIBEGOV_CODEX_OLLAMA_MODEL || 'qwen2.5-coder:14b';
+}
+
+function buildAttempts(runtime) {
+  const attempts = [];
+  if (hasAuth(runtime.codexHome)) {
+    attempts.push({
+      id: 'default',
+      label: 'default-provider',
+      args: [],
+      env: {},
+      provider: 'openai-codex',
+      model: 'gpt-5.4',
+    });
+  }
+
+  const ollamaModel = selectOllamaModel();
+  if (ollamaModel) {
+    attempts.push({
+      id: 'ollama',
+      label: `ollama:${ollamaModel}`,
+      args: ['--oss', '--local-provider', 'ollama', '-m', ollamaModel],
+      env: { OLLAMA_HOST: process.env.VIBEGOV_OLLAMA_HOST || 'http://127.0.0.1:11434' },
+      provider: 'ollama',
+      model: ollamaModel,
+    });
+  }
+
+  if (!attempts.length) {
+    attempts.push({
+      id: 'default',
+      label: 'default-provider',
+      args: [],
+      env: {},
+      provider: 'openai-codex',
+      model: 'gpt-5.4',
+    });
+  }
+
+  return attempts;
+}
+
+function hasBootstrapArtifacts(repoPath) {
+  return fs.existsSync(path.join(repoPath, '.governance', 'rules'))
+    && fs.existsSync(path.join(repoPath, '.governance', 'project'))
+    && fs.existsSync(path.join(repoPath, '.governance', 'specs'));
+}
+
+async function runCodexAttempt({ runtime, prompt, rootDir, repoPath, scenario, attempt, timeoutMs }) {
+  const isolatedHome = createIsolatedCodexHome(runtime.codexHome);
+  const lastMessagePath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-last-message.txt`);
+  const promptPath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-prompt.txt`);
+  const scriptPath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-runner.ps1`);
+  const stdoutPath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-stdout.txt`);
+  const stderrPath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-stderr.txt`);
+  const metaPath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-meta.json`);
+  const env = {
+    ...process.env,
+    CI: '1',
+    CODEX_HOME: isolatedHome,
+    HOME: isolatedHome,
+    USERPROFILE: isolatedHome,
+    ...attempt.env,
+  };
+
+  let stdout = '';
+  let stderr = '';
+  let killedForTimeout = false;
+  let completedFromLastMessage = false;
+  const startedAt = Date.now();
+
+  try {
+    writeText(promptPath, prompt);
+
+    const escapePs = (value) => `'${String(value).replace(/'/g, "''")}'`;
+    const extraArgsLiteral = attempt.args.map((value) => escapePs(value)).join(', ');
+    const envAssignments = Object.entries({
+      CODEX_HOME: isolatedHome,
+      HOME: isolatedHome,
+      USERPROFILE: isolatedHome,
+      ...attempt.env,
+    }).map(([key, value]) => `$env:${key} = ${escapePs(value)}`).join('\n');
+
+    writeText(scriptPath, [
+      "param([string]$CodexPath, [string]$PromptPath, [string]$RootDir, [string]$RepoPath, [string]$LastMessagePath, [string]$StdoutPath, [string]$StderrPath, [string]$MetaPath)",
+      "$ErrorActionPreference = 'Stop'",
+      envAssignments,
+      `$extraArgs = @(${extraArgsLiteral})`,
+      "$argList = @('exec', '--full-auto', '--add-dir', $RootDir, '-o', $LastMessagePath, '--cd', $RepoPath) + $extraArgs + @('-')",
+      "$process = Start-Process -FilePath $CodexPath -ArgumentList $argList -WorkingDirectory $RepoPath -NoNewWindow -PassThru -RedirectStandardInput $PromptPath -RedirectStandardOutput $StdoutPath -RedirectStandardError $StderrPath",
+      "$completedFromLastMessage = $false",
+      "$killedForTimeout = $false",
+      "$lastMessageStableSince = $null",
+      `$timeoutAt = (Get-Date).AddMilliseconds(${timeoutMs})`,
+      `$requiresBootstrapStop = ${scenario.mode === 'bootstrap' ? '$true' : '$false'}`,
+      `$requiresGovernanceSource = ${scenario.id === 'bootstrap-gate' ? '$true' : '$false'}`,
+      "while (-not $process.HasExited) {",
+      "  $lastMessage = if (Test-Path $LastMessagePath) { Get-Content -Raw -Path $LastMessagePath } else { '' }",
+      "  $canComplete = $false",
+      "  if ($requiresBootstrapStop) {",
+      "    $hasStop = [regex]::IsMatch($lastMessage, 'stopping before product implementation|stopped before product-code implementation', 'IgnoreCase')",
+      "    $hasGov = [regex]::IsMatch($lastMessage, 'Active governance sources:', 'IgnoreCase')",
+      "    $canComplete = $hasStop -and ((-not $requiresGovernanceSource) -or $hasGov)",
+      "  }",
+      "  if ($canComplete) {",
+      "    if (-not $lastMessageStableSince) {",
+      "      $lastMessageStableSince = Get-Date",
+      "    } elseif (((Get-Date) - $lastMessageStableSince).TotalMilliseconds -ge 1500) {",
+      "      $completedFromLastMessage = $true",
+      "      try { Stop-Process -Id $process.Id -Force } catch {}",
+      "    }",
+      "  } else {",
+      "    $lastMessageStableSince = $null",
+      "  }",
+      "  if ((Get-Date) -ge $timeoutAt) {",
+      "    $killedForTimeout = $true",
+      "    try { Stop-Process -Id $process.Id -Force } catch {}",
+      "    break",
+      "  }",
+      "  Start-Sleep -Milliseconds 500",
+      "  $process.Refresh()",
+      "}",
+      "try { $process.WaitForExit() } catch {}",
+      "$exitCode = if ($completedFromLastMessage) { 0 } elseif ($process.HasExited) { $process.ExitCode } else { 1 }",
+      "$meta = @{ exitCode = $exitCode; killedForTimeout = $killedForTimeout; completedFromLastMessage = $completedFromLastMessage } | ConvertTo-Json -Compress",
+      "Set-Content -Path $MetaPath -Value $meta",
+      "if ($killedForTimeout) { exit 124 }",
+      "exit $exitCode",
+    ].join('\n'));
+
+    const shell = process.env.ComSpec || 'C:\\Windows\\System32\\cmd.exe';
+    const shellArgs = ['/d', '/s', '/c', 'powershell.exe', '-NoLogo', '-NoProfile', '-File', scriptPath, runtime.executable, promptPath, rootDir, repoPath, lastMessagePath, stdoutPath, stderrPath, metaPath];
+    const shellResult = spawnSync(shell, shellArgs, { cwd: repoPath, env, stdio: 'ignore' });
+    stdout = readText(stdoutPath);
+    stderr = readText(stderrPath);
+    const meta = readText(metaPath).trim() ? JSON.parse(readText(metaPath)) : {};
+    killedForTimeout = Boolean(meta.killedForTimeout);
+    completedFromLastMessage = Boolean(meta.completedFromLastMessage);
+    const exitInfo = {
+      exitCode: typeof meta.exitCode === 'number' ? meta.exitCode : (typeof shellResult.status === 'number' ? shellResult.status : 1),
+      signal: shellResult.signal || null,
+      spawnError: shellResult.error ? shellResult.error.message : null,
+    };
+
+    const lastMessage = readLastMessage(lastMessagePath);
+    const planCommands = extractShellPlan(lastMessage || stdout || stderr);
+    let shellPlanTranscript = '';
+    let shellPlanApplied = false;
+    if (Array.isArray(planCommands) && planCommands.length) {
+      shellPlanTranscript = applyShellPlan({ repoPath, commands: planCommands });
+      shellPlanApplied = true;
+    }
+
+    const transcriptSections = [
+      `--- attempt ${attempt.label} ---`,
+      stdout.trim(),
+      stderr.trim() ? `--- stderr ---\n${stderr.trim()}` : '',
+      lastMessage ? `--- last message ---\n${lastMessage}` : '',
+      shellPlanApplied ? `--- adapter shell-plan execution ---\n${shellPlanTranscript}` : '',
+    ].filter(Boolean);
+    const transcript = transcriptSections.join('\n\n');
+    const completed = completedFromLastMessage || exitInfo.exitCode === 0 || shellPlanApplied;
+
+    return {
+      transcript,
+      shellPlanApplied,
+      hasBootstrapArtifacts: hasBootstrapArtifacts(repoPath),
+      rawOutput: {
+        attemptId: attempt.id,
+        status: exitInfo.exitCode,
+        signal: exitInfo.signal,
+        error: killedForTimeout ? `Timed out after ${timeoutMs}ms` : exitInfo.spawnError,
+        completedFromLastMessage,
+        shellPlanApplied,
+      },
+      exitKind: killedForTimeout ? 'timeout' : (completed ? 'completed' : 'failed'),
+      provider: attempt.provider,
+      model: attempt.model,
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    removeDir(isolatedHome);
+    try {
+      if (promptPath && fs.existsSync(promptPath)) fs.unlinkSync(promptPath);
+    } catch {}
+    try {
+      if (scriptPath && fs.existsSync(scriptPath)) fs.unlinkSync(scriptPath);
+    } catch {}
+    try {
+      if (stdoutPath && fs.existsSync(stdoutPath)) fs.unlinkSync(stdoutPath);
+    } catch {}
+    try {
+      if (stderrPath && fs.existsSync(stderrPath)) fs.unlinkSync(stderrPath);
+    } catch {}
+    try {
+      if (metaPath && fs.existsSync(metaPath)) fs.unlinkSync(metaPath);
+    } catch {}
+    try {
+      if (lastMessagePath && fs.existsSync(lastMessagePath)) fs.unlinkSync(lastMessagePath);
+    } catch {}
+  }
+}
+
+function shouldAcceptAttempt({ scenario, attemptResult }) {
+  if (attemptResult.exitKind === 'timeout') return false;
+  if (!attemptResult.hasBootstrapArtifacts) return false;
+  if (scenario.id === 'bootstrap-gate' && !hasBootstrapStopDeclaration(attemptResult.transcript)) return false;
+  if (!hasGovernanceSourceReport(attemptResult.transcript)) return false;
+  return true;
+}
+
+async function run({ rootDir, validatorDir, repoPath, scenario }) {
+  const prompt = buildPrompt({ rootDir, validatorDir, scenario });
+  const timeoutMs = scenario.timeoutMs || 300000;
+  const runtime = resolveCodexRuntime();
+  const attempts = buildAttempts(runtime);
+  const attemptResults = [];
+  const attemptSummaries = [];
+
+  for (const attempt of attempts) {
+    const result = await runCodexAttempt({ runtime, prompt, rootDir, repoPath, scenario, attempt, timeoutMs });
+    attemptResults.push(result);
+    attemptSummaries.push({
+      id: attempt.id,
+      provider: result.provider,
+      model: result.model,
+      exitKind: result.exitKind,
+      rawOutput: result.rawOutput,
+    });
+    if (shouldAcceptAttempt({ scenario, attemptResult: result })) {
+      return {
+        transcript: `${result.transcript}\n\n--- adapter attempts summary ---\n${JSON.stringify(attemptSummaries, null, 2)}`,
+        rawOutput: { attempts: attemptSummaries },
+        exitKind: result.exitKind,
+        durationMs: result.durationMs,
+        adapterId: 'codex-cli',
+        provider: result.provider,
+        model: result.model,
+      };
+    }
+  }
+
+  const fallback = attemptSummaries[attemptSummaries.length - 1] || { provider: 'openai-codex', model: 'gpt-5.4', exitKind: 'failed' };
+  const finalTranscript = attemptResults.length
+    ? attemptResults.map((item) => item.transcript).filter(Boolean).join('\n\n') + `\n\n--- adapter attempts summary ---\n${JSON.stringify(attemptSummaries, null, 2)}`
+    : 'No codex-cli attempts were executed.';
+
+  return {
+    transcript: finalTranscript,
+    rawOutput: { attempts: attemptSummaries },
+    exitKind: fallback.exitKind,
+    durationMs: timeoutMs,
+    adapterId: 'codex-cli',
+    provider: fallback.provider,
+    model: fallback.model,
+  };
+}
+
+module.exports = { run };

--- a/.internal/bootstrap-validator/lib/adapters/local-stub.js
+++ b/.internal/bootstrap-validator/lib/adapters/local-stub.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const { ensureDir, writeText } = require('../fs-utils');
+
+function copyFile(src, dest) {
+  ensureDir(path.dirname(dest));
+  fs.copyFileSync(src, dest);
+}
+
+function installGovernance(rootDir, repoPath) {
+  const governanceSrc = path.join(rootDir, '.governance');
+  const rulesSrc = path.join(governanceSrc, 'rules');
+  const rulesDest = path.join(repoPath, '.governance', 'rules');
+  ensureDir(rulesDest);
+  for (const file of fs.readdirSync(rulesSrc)) {
+    copyFile(path.join(rulesSrc, file), path.join(rulesDest, file));
+  }
+  ensureDir(path.join(repoPath, '.governance', 'project'));
+  ensureDir(path.join(repoPath, '.governance', 'specs'));
+  writeText(path.join(repoPath, '.governance', 'project', 'PROJECT.md'), '# Project Intent\n\nCreated by local-stub bootstrap validator.\n');
+  writeText(path.join(repoPath, '.governance', 'specs', 'SPEC-001.md'), '# First Spec\n\nCreated by local-stub bootstrap validator.\n');
+}
+
+function buildTranscript(scenarioId) {
+  const lines = [];
+  lines.push('Bootstrap validator local-stub run');
+  lines.push(`Scenario: ${scenarioId}`);
+  lines.push('Created .governance/rules/, .governance/project/, and .governance/specs/.');
+  lines.push('Installed GOV-01 through GOV-08.');
+  lines.push('Active governance sources: .governance/rules/*.mdc (canonical); no provider-native mirror path present.');
+  if (scenarioId === 'bootstrap-gate') {
+    lines.push('Bootstrap gate satisfied. Stopping before product implementation.');
+    lines.push('Next step: begin implementation from a spec-bound issue only after review/confirmation.');
+  } else {
+    lines.push('Stopped before product-code implementation.');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function run({ rootDir, repoPath, scenario }) {
+  if (!['empty-repo-bootstrap', 'bootstrap-gate'].includes(scenario.id)) {
+    throw new Error(`local-stub adapter does not support scenario: ${scenario.id}`);
+  }
+  installGovernance(rootDir, repoPath);
+  return {
+    transcript: buildTranscript(scenario.id),
+    rawOutput: { adapter: 'local-stub', scenarioId: scenario.id },
+    exitKind: 'completed',
+    durationMs: 25,
+  };
+}
+
+module.exports = { run };

--- a/.internal/bootstrap-validator/lib/assertions.js
+++ b/.internal/bootstrap-validator/lib/assertions.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+
+function exists(repoPath, relPath) {
+  return fs.existsSync(path.join(repoPath, relPath));
+}
+
+function listRuleFiles(repoPath) {
+  const rulesDir = path.join(repoPath, '.governance', 'rules');
+  if (!fs.existsSync(rulesDir)) return [];
+  return fs.readdirSync(rulesDir).sort();
+}
+
+const EXPECTED_RULES = [
+  'gov-01-instructions.mdc',
+  'gov-02-workflow.mdc',
+  'gov-03-communication.mdc',
+  'gov-04-quality.mdc',
+  'gov-05-testing.mdc',
+  'gov-06-issues.mdc',
+  'gov-07-tasks.mdc',
+  'gov-08-exploratory-review.mdc',
+];
+
+function makeResult(id, passed, severity, note, evidence) {
+  return { id, passed, severity, note, evidence };
+}
+
+const handlers = {
+  governanceDirsExist(ctx) {
+    const required = ['.governance/rules', '.governance/project', '.governance/specs'];
+    const missing = required.filter((item) => !exists(ctx.repoPath, item));
+    return makeResult('governanceDirsExist', missing.length === 0, 'hard', missing.length ? `Missing: ${missing.join(', ')}` : 'Governance directories present.', missing);
+  },
+  govRuleSetPresent(ctx) {
+    const files = listRuleFiles(ctx.repoPath);
+    const missing = EXPECTED_RULES.filter((item) => !files.includes(item));
+    return makeResult('govRuleSetPresent', missing.length === 0, 'hard', missing.length ? `Missing rules: ${missing.join(', ')}` : 'GOV-01 through GOV-08 present.', files);
+  },
+  projectIntentCreated(ctx) {
+    const candidates = ['.governance/project/PROJECT.md', '.governance/project/PROJECT_TEMPLATE.md'];
+    const found = candidates.filter((item) => exists(ctx.repoPath, item));
+    return makeResult('projectIntentCreated', found.length > 0, 'hard', found.length ? 'Project intent artifact present.' : 'Missing project intent artifact.', found);
+  },
+  firstSpecCreated(ctx) {
+    const specDir = path.join(ctx.repoPath, '.governance', 'specs');
+    const files = fs.existsSync(specDir) ? fs.readdirSync(specDir).filter((name) => name !== 'SPEC_TEMPLATE.md') : [];
+    return makeResult('firstSpecCreated', files.length > 0, 'hard', files.length ? 'First spec artifact present.' : 'Missing first spec artifact.', files);
+  },
+  noProductCodeChanges(ctx) {
+    const changedProductCode = [...ctx.diff.categories.created, ...ctx.diff.categories.modified, ...ctx.diff.categories.deleted]
+      .filter((item) => item.category === 'product-code')
+      .map((item) => item.path);
+    return makeResult('noProductCodeChanges', changedProductCode.length === 0, 'hard', changedProductCode.length ? 'Product code changed during bootstrap scenario.' : 'No product code changed.', changedProductCode);
+  },
+  governanceSourcesReported(ctx) {
+    const ok = /Active governance sources:/i.test(ctx.transcript);
+    return makeResult('governanceSourcesReported', ok, 'hard', ok ? 'Transcript reports governance sources.' : 'Transcript missing governance source report.', []);
+  },
+  bootstrapStopDeclared(ctx) {
+    const ok = /stopping before product implementation|stopped before product-code implementation/i.test(ctx.transcript);
+    return makeResult('bootstrapStopDeclared', ok, 'hard', ok ? 'Transcript declares bootstrap stop gate.' : 'Transcript missing stop declaration.', []);
+  },
+};
+
+function runAssertions(assertionIds, context) {
+  return assertionIds.map((id) => {
+    const fn = handlers[id];
+    if (!fn) return makeResult(id, false, 'hard', `Unknown assertion: ${id}`, []);
+    return fn(context);
+  });
+}
+
+module.exports = { runAssertions };

--- a/.internal/bootstrap-validator/lib/fixtures.js
+++ b/.internal/bootstrap-validator/lib/fixtures.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { copyDir, ensureDir, makeTempRunDir, writeText } = require('./fs-utils');
+
+function fixtureDir(validatorDir, fixtureName) {
+  return path.join(validatorDir, 'fixtures', fixtureName);
+}
+
+function seedFixtureIfNeeded(fixtureName, workingDir) {
+  if (fixtureName === 'empty-repo') {
+    ensureDir(path.join(workingDir, 'src'));
+    writeText(path.join(workingDir, 'src', 'app.js'), "console.log('fixture app');\n");
+    writeText(path.join(workingDir, 'README.md'), '# Empty Repo Fixture\n');
+  }
+}
+
+function initGitRepo(runDir) {
+  execFileSync('git', ['init', '-b', 'main'], { cwd: runDir, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.name', 'VibeGov Validator'], { cwd: runDir, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'validator@example.invalid'], { cwd: runDir, stdio: 'ignore' });
+}
+
+function prepareFixture(validatorDir, fixtureName) {
+  const sourceDir = fixtureDir(validatorDir, fixtureName);
+  const runDir = makeTempRunDir(`vibegov-${fixtureName}`);
+  copyDir(sourceDir, runDir);
+  seedFixtureIfNeeded(fixtureName, runDir);
+  initGitRepo(runDir);
+  return runDir;
+}
+
+module.exports = { prepareFixture };

--- a/.internal/bootstrap-validator/lib/fs-utils.js
+++ b/.internal/bootstrap-validator/lib/fs-utils.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function copyDir(src, dest) {
+  ensureDir(dest);
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDir(srcPath, destPath);
+    else fs.copyFileSync(srcPath, destPath);
+  }
+}
+
+function removeDir(dirPath) {
+  if (fs.existsSync(dirPath)) fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function hashFile(filePath) {
+  const data = fs.readFileSync(filePath);
+  return crypto.createHash('sha1').update(data).digest('hex');
+}
+
+function createManifest(rootDir) {
+  const manifest = {};
+  function walk(currentDir) {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+      const fullPath = path.join(currentDir, entry.name);
+      const relPath = path.relative(rootDir, fullPath).replace(/\\/g, '/');
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else {
+        manifest[relPath] = {
+          size: fs.statSync(fullPath).size,
+          hash: hashFile(fullPath),
+        };
+      }
+    }
+  }
+  walk(rootDir);
+  return manifest;
+}
+
+function categorizePath(relPath) {
+  const normalized = relPath.replace(/\\/g, '/');
+  if (normalized.startsWith('.governance/')) return 'governance';
+  if (normalized.startsWith('.internal/')) return 'internal';
+  if (/^(src|app|components|pages|api|domain)\//.test(normalized)) return 'product-code';
+  if (/^(README|docs\/|blog\/)/.test(normalized)) return 'docs';
+  return 'other';
+}
+
+function diffManifests(before, after) {
+  const created = [];
+  const modified = [];
+  const deleted = [];
+  const allPaths = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const relPath of [...allPaths].sort()) {
+    if (!before[relPath]) created.push(relPath);
+    else if (!after[relPath]) deleted.push(relPath);
+    else if (before[relPath].hash !== after[relPath].hash) modified.push(relPath);
+  }
+  return {
+    created,
+    modified,
+    deleted,
+    categories: {
+      created: created.map((p) => ({ path: p, category: categorizePath(p) })),
+      modified: modified.map((p) => ({ path: p, category: categorizePath(p) })),
+      deleted: deleted.map((p) => ({ path: p, category: categorizePath(p) })),
+    },
+  };
+}
+
+function makeTempRunDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+}
+
+function writeJson(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeText(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, value, 'utf8');
+}
+
+module.exports = { ensureDir, copyDir, removeDir, createManifest, diffManifests, makeTempRunDir, writeJson, writeText, categorizePath };

--- a/.internal/bootstrap-validator/lib/report.js
+++ b/.internal/bootstrap-validator/lib/report.js
@@ -1,0 +1,56 @@
+const path = require('path');
+const { ensureDir, writeJson, writeText } = require('./fs-utils');
+
+function nowStamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function classify(score) {
+  if (score >= 90) return 'production-ready';
+  if (score >= 75) return 'needs-hardening';
+  if (score >= 50) return 'inconsistent';
+  return 'untrusted';
+}
+
+function computeScore(assertions) {
+  if (!assertions.length) return 0;
+  const passed = assertions.filter((item) => item.passed).length;
+  return Math.round((passed / assertions.length) * 100);
+}
+
+function writeReport({ validatorDir, scenarioId, transcript, manifestBefore, manifestAfter, diff, assertions, artifacts, durationMs, adapterId, provider, model, exitKind, rawOutput }) {
+  const reportDir = path.join(validatorDir, 'reports', `${nowStamp()}-${scenarioId}`);
+  ensureDir(reportDir);
+  const score = computeScore(assertions);
+  const hardFailure = assertions.some((item) => item.severity === 'hard' && !item.passed);
+  const result = {
+    scenarioId,
+    adapterId,
+    provider,
+    model,
+    passed: !hardFailure,
+    hardFailure,
+    score,
+    classification: classify(score),
+    durationMs,
+    exitKind,
+    rawOutput,
+    assertions,
+    artifacts,
+    evidence: {
+      transcriptPath: path.join(reportDir, 'transcript.md'),
+      manifestBeforePath: path.join(reportDir, 'manifest-before.json'),
+      manifestAfterPath: path.join(reportDir, 'manifest-after.json'),
+      diffPath: path.join(reportDir, 'diff.json'),
+    },
+    reportDir,
+  };
+  writeText(path.join(reportDir, 'transcript.md'), transcript);
+  writeJson(path.join(reportDir, 'manifest-before.json'), manifestBefore);
+  writeJson(path.join(reportDir, 'manifest-after.json'), manifestAfter);
+  writeJson(path.join(reportDir, 'diff.json'), diff);
+  writeJson(path.join(reportDir, 'result.json'), result);
+  return result;
+}
+
+module.exports = { writeReport };

--- a/.internal/bootstrap-validator/lib/runner.js
+++ b/.internal/bootstrap-validator/lib/runner.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const { loadScenario, loadSuite } = require('./scenarios');
+const { prepareFixture } = require('./fixtures');
+const { createManifest, diffManifests, removeDir } = require('./fs-utils');
+const { runAssertions } = require('./assertions');
+const { writeReport } = require('./report');
+
+function getAdapter(adapterId) {
+  if (adapterId === 'local-stub') return require('./adapters/local-stub');
+  if (adapterId === 'codex-cli') return require('./adapters/codex-cli');
+  throw new Error(`Unsupported adapter: ${adapterId}`);
+}
+
+function collectArtifacts(repoPath, diff) {
+  const filesCreated = diff.created;
+  const filesModified = diff.modified;
+  const issues = [];
+  const specGaps = [];
+  return { filesCreated, filesModified, issues, specGaps, repoPath };
+}
+
+async function executeScenario({ validatorDir, rootDir, scenario, adapterId }) {
+  const repoPath = prepareFixture(validatorDir, scenario.fixture);
+  const manifestBefore = createManifest(repoPath);
+  const startedAt = Date.now();
+  let transcript = '';
+  try {
+    const adapter = getAdapter(adapterId);
+    const runResult = await adapter.run({ rootDir, validatorDir, repoPath, scenario });
+    transcript = runResult.transcript || '';
+    const manifestAfter = createManifest(repoPath);
+    const diff = diffManifests(manifestBefore, manifestAfter);
+    const assertions = runAssertions(scenario.assertions, {
+      repoPath,
+      transcript,
+      manifestBefore,
+      manifestAfter,
+      diff,
+      scenario,
+    });
+    return writeReport({
+      validatorDir,
+      scenarioId: scenario.id,
+      transcript,
+      manifestBefore,
+      manifestAfter,
+      diff,
+      assertions,
+      artifacts: collectArtifacts(repoPath, diff),
+      durationMs: Date.now() - startedAt,
+      adapterId,
+      provider: runResult.provider || adapterId,
+      model: runResult.model || 'n/a',
+      exitKind: runResult.exitKind,
+      rawOutput: runResult.rawOutput || null,
+    });
+  } finally {
+    removeDir(repoPath);
+  }
+}
+
+async function runScenarioById({ validatorDir, rootDir, scenarioId, adapterId }) {
+  const scenario = loadScenario(validatorDir, scenarioId);
+  return executeScenario({ validatorDir, rootDir, scenario, adapterId });
+}
+
+async function runSuiteById({ validatorDir, rootDir, suiteId, adapterId }) {
+  const suite = loadSuite(validatorDir, suiteId);
+  const results = [];
+  for (const scenarioId of suite.scenarios) {
+    results.push(await runScenarioById({ validatorDir, rootDir, scenarioId, adapterId }));
+  }
+  return {
+    suiteId: suite.id,
+    total: results.length,
+    passed: results.filter((item) => item.passed).length,
+    failed: results.filter((item) => !item.passed).length,
+    reportDirs: results.map((item) => item.reportDir),
+    results: results.map((item) => ({ scenarioId: item.scenarioId, passed: item.passed, score: item.score, reportDir: item.reportDir })),
+  };
+}
+
+module.exports = { runScenarioById, runSuiteById };

--- a/.internal/bootstrap-validator/lib/scenarios.js
+++ b/.internal/bootstrap-validator/lib/scenarios.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function scenariosDir(validatorDir) {
+  return path.join(validatorDir, 'scenarios');
+}
+
+function listFilesByPrefix(dir, prefix) {
+  return fs.readdirSync(dir)
+    .filter((name) => name.endsWith('.json') && name.startsWith(prefix))
+    .map((name) => name.replace(prefix, '').replace(/\.json$/, ''))
+    .sort();
+}
+
+function listScenarios(validatorDir) {
+  return fs.readdirSync(scenariosDir(validatorDir))
+    .filter((name) => name.endsWith('.json') && !name.startsWith('suite-'))
+    .map((name) => readJson(path.join(scenariosDir(validatorDir), name)).id)
+    .sort();
+}
+
+function listSuites(validatorDir) {
+  return listFilesByPrefix(scenariosDir(validatorDir), 'suite-');
+}
+
+function loadScenario(validatorDir, scenarioId) {
+  const dir = scenariosDir(validatorDir);
+  const file = fs.readdirSync(dir)
+    .find((name) => name.endsWith('.json') && !name.startsWith('suite-') && readJson(path.join(dir, name)).id === scenarioId);
+  if (!file) throw new Error(`Scenario not found: ${scenarioId}`);
+  return readJson(path.join(dir, file));
+}
+
+function loadSuite(validatorDir, suiteId) {
+  const filePath = path.join(scenariosDir(validatorDir), `suite-${suiteId}.json`);
+  if (!fs.existsSync(filePath)) throw new Error(`Suite not found: ${suiteId}`);
+  return readJson(filePath);
+}
+
+module.exports = { listScenarios, listSuites, loadScenario, loadSuite };

--- a/.internal/bootstrap-validator/prompts/bootstrap-gate-codex.txt
+++ b/.internal/bootstrap-validator/prompts/bootstrap-gate-codex.txt
@@ -1,0 +1,14 @@
+Bootstrap this repo with VibeGov using the local source made available to you.
+
+Before writing any product code:
+1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/` in the current repo.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+3. Create `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+4. Create `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+5. End your final report with the exact sentence: `Stopping before product implementation.`
+6. Include one final-report line that starts exactly with: `Active governance sources:` followed by the source(s) you used.
+7. Stop before implementation.
+
+Do not ask follow-up questions.
+Do not implement product code.
+At the end, provide a short plain-text report of what you created and the next step after the bootstrap gate.

--- a/.internal/bootstrap-validator/prompts/bootstrap-gate.txt
+++ b/.internal/bootstrap-validator/prompts/bootstrap-gate.txt
@@ -1,0 +1,4 @@
+Adopt VibeGov governance in this repo and stop before product implementation.
+Report readiness and next step once the bootstrap gate is satisfied.
+Include the exact sentence `Stopping before product implementation.` in your final report.
+Include one line that starts exactly with `Active governance sources:` in your final report.

--- a/.internal/bootstrap-validator/prompts/canonical-bootstrap.txt
+++ b/.internal/bootstrap-validator/prompts/canonical-bootstrap.txt
@@ -1,0 +1,15 @@
+Bootstrap this repo with VibeGov.
+Read and follow:
+- https://governance-foundation.github.io/vibegov.io/agent.txt
+- https://governance-foundation.github.io/vibegov.io/bootstrap.json
+
+Before writing product code:
+1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/`.
+2. Install the active VibeGov rule set.
+3. Create project intent.
+4. Create the first feature/change spec.
+5. Create or normalize a spec-mapped backlog.
+6. Mirror only into already-existing provider-native rules paths.
+7. Report active governance sources.
+
+Then stop before implementation.

--- a/.internal/bootstrap-validator/prompts/empty-repo-bootstrap-codex.txt
+++ b/.internal/bootstrap-validator/prompts/empty-repo-bootstrap-codex.txt
@@ -1,0 +1,13 @@
+Bootstrap this repo with VibeGov using the local source made available to you.
+
+Before writing any product code:
+1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/` in the current repo.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+3. Create `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+4. Create `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+5. End your response with an exact line starting with: `Active governance sources:` followed by the source(s) you used.
+6. Stop before implementation.
+
+Do not ask follow-up questions.
+Do not implement product code.
+At the end, provide a short plain-text report of what you created.

--- a/.internal/bootstrap-validator/prompts/exploratory-route.txt
+++ b/.internal/bootstrap-validator/prompts/exploratory-route.txt
@@ -1,0 +1,4 @@
+Use VibeGov exploratory mode.
+Review exactly one route.
+Do not implement fixes.
+Report with route purpose, preconditions, elements found, scenario classifications, artifacts created, residual scope, completeness label, and next route.

--- a/.internal/bootstrap-validator/prompts/release-verification.txt
+++ b/.internal/bootstrap-validator/prompts/release-verification.txt
@@ -1,0 +1,2 @@
+Run a release / verification checkpoint for the current build.
+Report build/version, integrated scope, blockers or residual risks, and a go/no-go or next-step recommendation.

--- a/.internal/bootstrap-validator/prompts/under-specified-issue.txt
+++ b/.internal/bootstrap-validator/prompts/under-specified-issue.txt
@@ -1,0 +1,2 @@
+Use the active VibeGov rules.
+Fix the broken settings flow.

--- a/.internal/bootstrap-validator/reports/.gitkeep
+++ b/.internal/bootstrap-validator/reports/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/diff.json
@@ -1,0 +1,10 @@
+{
+  "created": [],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/manifest-after.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/result.json
@@ -1,0 +1,92 @@
+{
+  "scenarioId": "empty-repo-bootstrap",
+  "adapterId": "codex-cli",
+  "provider": "openai-codex",
+  "model": "gpt-5.4",
+  "passed": false,
+  "hardFailure": true,
+  "score": 17,
+  "classification": "untrusted",
+  "durationMs": 14,
+  "exitKind": "failed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "failed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 1,
+          "signal": null,
+          "error": "spawnSync C:\\WINDOWS\\system32\\cmd.exe EPERM",
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing: .governance/rules, .governance/project, .governance/specs",
+      "evidence": [
+        ".governance/rules",
+        ".governance/project",
+        ".governance/specs"
+      ]
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing rules: gov-01-instructions.mdc, gov-02-workflow.mdc, gov-03-communication.mdc, gov-04-quality.mdc, gov-05-testing.mdc, gov-06-issues.mdc, gov-07-tasks.mdc, gov-08-exploratory-review.mdc",
+      "evidence": []
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing project intent artifact.",
+      "evidence": []
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing first spec artifact.",
+      "evidence": []
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "governanceSourcesReported",
+      "passed": false,
+      "severity": "hard",
+      "note": "Transcript missing governance source report.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-gWHO3K"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-47-17-873Z-empty-repo-bootstrap\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-47-17-873Z-empty-repo-bootstrap\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-47-17-873Z-empty-repo-bootstrap\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-47-17-873Z-empty-repo-bootstrap\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-47-17-873Z-empty-repo-bootstrap"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-47-17-873Z-empty-repo-bootstrap/transcript.md
@@ -1,0 +1,9 @@
+Attempt default: provider=openai-codex model=gpt-5.4 exitKind=failed
+{
+  "attemptId": "default",
+  "status": 1,
+  "signal": null,
+  "error": "spawnSync C:\\WINDOWS\\system32\\cmd.exe EPERM",
+  "completedFromLastMessage": false,
+  "shellPlanApplied": false
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/diff.json
@@ -1,0 +1,62 @@
+{
+  "created": [
+    ".governance/project/PROJECT.md",
+    ".governance/rules/gov-01-instructions.mdc",
+    ".governance/rules/gov-02-workflow.mdc",
+    ".governance/rules/gov-03-communication.mdc",
+    ".governance/rules/gov-04-quality.mdc",
+    ".governance/rules/gov-05-testing.mdc",
+    ".governance/rules/gov-06-issues.mdc",
+    ".governance/rules/gov-07-tasks.mdc",
+    ".governance/rules/gov-08-exploratory-review.mdc",
+    ".governance/specs/SPEC-001.md"
+  ],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [
+      {
+        "path": ".governance/project/PROJECT.md",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-01-instructions.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-02-workflow.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-03-communication.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-04-quality.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-05-testing.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-06-issues.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-07-tasks.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-08-exploratory-review.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/specs/SPEC-001.md",
+        "category": "governance"
+      }
+    ],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/manifest-after.json
@@ -1,0 +1,126 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  ".governance/project/PROJECT.md": {
+    "size": 61,
+    "hash": "902eb1bbc6ce79b6ec71ddf11346b6790fd5bfca"
+  },
+  ".governance/rules/gov-01-instructions.mdc": {
+    "size": 1633,
+    "hash": "765b01b9fa0ccc27aa0855739f253ae7d1625930"
+  },
+  ".governance/rules/gov-02-workflow.mdc": {
+    "size": 8912,
+    "hash": "07415c257043377e81f3bd263b0ad835dc60faa7"
+  },
+  ".governance/rules/gov-03-communication.mdc": {
+    "size": 1262,
+    "hash": "fa0f94a3cb84a8e00def84225ea7cb5941635dca"
+  },
+  ".governance/rules/gov-04-quality.mdc": {
+    "size": 1341,
+    "hash": "5a27e26f87dec191107802e86d5d242c82af7b14"
+  },
+  ".governance/rules/gov-05-testing.mdc": {
+    "size": 1462,
+    "hash": "8f46f137b4b1f6cf3603f976de230c90a9c68ad0"
+  },
+  ".governance/rules/gov-06-issues.mdc": {
+    "size": 2063,
+    "hash": "bd969b77c76d18360e1747da342eca451cfe92b0"
+  },
+  ".governance/rules/gov-07-tasks.mdc": {
+    "size": 1064,
+    "hash": "e6bee2a5111be78bd2fda08df3549958c87023c6"
+  },
+  ".governance/rules/gov-08-exploratory-review.mdc": {
+    "size": 9073,
+    "hash": "742b23c22dee435dc326c6067b062dc27c4edc15"
+  },
+  ".governance/specs/SPEC-001.md": {
+    "size": 57,
+    "hash": "6d00aebe1ed016d59d3a35ca0ac8d9f9ba96400d"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/result.json
@@ -1,0 +1,98 @@
+{
+  "scenarioId": "empty-repo-bootstrap",
+  "adapterId": "local-stub",
+  "provider": "local-stub",
+  "model": "n/a",
+  "passed": true,
+  "hardFailure": false,
+  "score": 100,
+  "classification": "production-ready",
+  "durationMs": 14,
+  "exitKind": "completed",
+  "rawOutput": {
+    "adapter": "local-stub",
+    "scenarioId": "empty-repo-bootstrap"
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": true,
+      "severity": "hard",
+      "note": "Governance directories present.",
+      "evidence": []
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": true,
+      "severity": "hard",
+      "note": "GOV-01 through GOV-08 present.",
+      "evidence": [
+        "gov-01-instructions.mdc",
+        "gov-02-workflow.mdc",
+        "gov-03-communication.mdc",
+        "gov-04-quality.mdc",
+        "gov-05-testing.mdc",
+        "gov-06-issues.mdc",
+        "gov-07-tasks.mdc",
+        "gov-08-exploratory-review.mdc"
+      ]
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "Project intent artifact present.",
+      "evidence": [
+        ".governance/project/PROJECT.md"
+      ]
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "First spec artifact present.",
+      "evidence": [
+        "SPEC-001.md"
+      ]
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "governanceSourcesReported",
+      "passed": true,
+      "severity": "hard",
+      "note": "Transcript reports governance sources.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [
+      ".governance/project/PROJECT.md",
+      ".governance/rules/gov-01-instructions.mdc",
+      ".governance/rules/gov-02-workflow.mdc",
+      ".governance/rules/gov-03-communication.mdc",
+      ".governance/rules/gov-04-quality.mdc",
+      ".governance/rules/gov-05-testing.mdc",
+      ".governance/rules/gov-06-issues.mdc",
+      ".governance/rules/gov-07-tasks.mdc",
+      ".governance/rules/gov-08-exploratory-review.mdc",
+      ".governance/specs/SPEC-001.md"
+    ],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-thJI8B"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-19-798Z-empty-repo-bootstrap\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-19-798Z-empty-repo-bootstrap\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-19-798Z-empty-repo-bootstrap\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-19-798Z-empty-repo-bootstrap\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-19-798Z-empty-repo-bootstrap"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-19-798Z-empty-repo-bootstrap/transcript.md
@@ -1,0 +1,6 @@
+Bootstrap validator local-stub run
+Scenario: empty-repo-bootstrap
+Created .governance/rules/, .governance/project/, and .governance/specs/.
+Installed GOV-01 through GOV-08.
+Active governance sources: .governance/rules/*.mdc (canonical); no provider-native mirror path present.
+Stopped before product-code implementation.

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/diff.json
@@ -1,0 +1,10 @@
+{
+  "created": [],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/manifest-after.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/result.json
@@ -1,0 +1,92 @@
+{
+  "scenarioId": "empty-repo-bootstrap",
+  "adapterId": "codex-cli",
+  "provider": "openai-codex",
+  "model": "gpt-5.4",
+  "passed": false,
+  "hardFailure": true,
+  "score": 17,
+  "classification": "untrusted",
+  "durationMs": 1766,
+  "exitKind": "completed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing: .governance/rules, .governance/project, .governance/specs",
+      "evidence": [
+        ".governance/rules",
+        ".governance/project",
+        ".governance/specs"
+      ]
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing rules: gov-01-instructions.mdc, gov-02-workflow.mdc, gov-03-communication.mdc, gov-04-quality.mdc, gov-05-testing.mdc, gov-06-issues.mdc, gov-07-tasks.mdc, gov-08-exploratory-review.mdc",
+      "evidence": []
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing project intent artifact.",
+      "evidence": []
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing first spec artifact.",
+      "evidence": []
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "governanceSourcesReported",
+      "passed": false,
+      "severity": "hard",
+      "note": "Transcript missing governance source report.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-xaivL8"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-43-837Z-empty-repo-bootstrap\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-43-837Z-empty-repo-bootstrap\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-43-837Z-empty-repo-bootstrap\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-43-837Z-empty-repo-bootstrap\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-48-43-837Z-empty-repo-bootstrap"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-48-43-837Z-empty-repo-bootstrap/transcript.md
@@ -1,0 +1,9 @@
+Attempt default: provider=openai-codex model=gpt-5.4 exitKind=completed
+{
+  "attemptId": "default",
+  "status": 0,
+  "signal": null,
+  "error": null,
+  "completedFromLastMessage": false,
+  "shellPlanApplied": false
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/diff.json
@@ -1,0 +1,17 @@
+{
+  "created": [
+    "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+  ],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [
+      {
+        "path": "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+        "category": "other"
+      }
+    ],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/manifest-after.json
@@ -1,0 +1,90 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "Microsoft/Windows/PowerShell/ModuleAnalysisCache": {
+    "size": 8703,
+    "hash": "5843efa45c123e570092c6da5284e72d5ebdb90c"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/result.json
@@ -1,0 +1,94 @@
+{
+  "scenarioId": "empty-repo-bootstrap",
+  "adapterId": "codex-cli",
+  "provider": "openai-codex",
+  "model": "gpt-5.4",
+  "passed": false,
+  "hardFailure": true,
+  "score": 17,
+  "classification": "untrusted",
+  "durationMs": 26351,
+  "exitKind": "completed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing: .governance/rules, .governance/project, .governance/specs",
+      "evidence": [
+        ".governance/rules",
+        ".governance/project",
+        ".governance/specs"
+      ]
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing rules: gov-01-instructions.mdc, gov-02-workflow.mdc, gov-03-communication.mdc, gov-04-quality.mdc, gov-05-testing.mdc, gov-06-issues.mdc, gov-07-tasks.mdc, gov-08-exploratory-review.mdc",
+      "evidence": []
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing project intent artifact.",
+      "evidence": []
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing first spec artifact.",
+      "evidence": []
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "governanceSourcesReported",
+      "passed": false,
+      "severity": "hard",
+      "note": "Transcript missing governance source report.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [
+      "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+    ],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-EY1fYL"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-50-19-867Z-empty-repo-bootstrap\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-50-19-867Z-empty-repo-bootstrap\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-50-19-867Z-empty-repo-bootstrap\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-50-19-867Z-empty-repo-bootstrap\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-50-19-867Z-empty-repo-bootstrap"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-50-19-867Z-empty-repo-bootstrap/transcript.md
@@ -1,0 +1,9 @@
+Attempt default: provider=openai-codex model=gpt-5.4 exitKind=completed
+{
+  "attemptId": "default",
+  "status": 0,
+  "signal": null,
+  "error": null,
+  "completedFromLastMessage": false,
+  "shellPlanApplied": false
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/diff.json
@@ -1,0 +1,67 @@
+{
+  "created": [
+    ".governance/project/PROJECT.md",
+    ".governance/rules/gov-01-instructions.mdc",
+    ".governance/rules/gov-02-workflow.mdc",
+    ".governance/rules/gov-03-communication.mdc",
+    ".governance/rules/gov-04-quality.mdc",
+    ".governance/rules/gov-05-testing.mdc",
+    ".governance/rules/gov-06-issues.mdc",
+    ".governance/rules/gov-07-tasks.mdc",
+    ".governance/rules/gov-08-exploratory-review.mdc",
+    ".governance/specs/bootstrap-governance-setup.md",
+    "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+  ],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [
+      {
+        "path": ".governance/project/PROJECT.md",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-01-instructions.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-02-workflow.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-03-communication.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-04-quality.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-05-testing.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-06-issues.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-07-tasks.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-08-exploratory-review.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/specs/bootstrap-governance-setup.md",
+        "category": "governance"
+      },
+      {
+        "path": "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+        "category": "other"
+      }
+    ],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/manifest-after.json
@@ -1,0 +1,130 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  ".governance/project/PROJECT.md": {
+    "size": 757,
+    "hash": "c2d1390bdb0d475a6a5e0b9c73a50a5b5907ae45"
+  },
+  ".governance/rules/gov-01-instructions.mdc": {
+    "size": 1633,
+    "hash": "765b01b9fa0ccc27aa0855739f253ae7d1625930"
+  },
+  ".governance/rules/gov-02-workflow.mdc": {
+    "size": 8912,
+    "hash": "07415c257043377e81f3bd263b0ad835dc60faa7"
+  },
+  ".governance/rules/gov-03-communication.mdc": {
+    "size": 1262,
+    "hash": "fa0f94a3cb84a8e00def84225ea7cb5941635dca"
+  },
+  ".governance/rules/gov-04-quality.mdc": {
+    "size": 1341,
+    "hash": "5a27e26f87dec191107802e86d5d242c82af7b14"
+  },
+  ".governance/rules/gov-05-testing.mdc": {
+    "size": 1462,
+    "hash": "8f46f137b4b1f6cf3603f976de230c90a9c68ad0"
+  },
+  ".governance/rules/gov-06-issues.mdc": {
+    "size": 2063,
+    "hash": "bd969b77c76d18360e1747da342eca451cfe92b0"
+  },
+  ".governance/rules/gov-07-tasks.mdc": {
+    "size": 1064,
+    "hash": "e6bee2a5111be78bd2fda08df3549958c87023c6"
+  },
+  ".governance/rules/gov-08-exploratory-review.mdc": {
+    "size": 9073,
+    "hash": "742b23c22dee435dc326c6067b062dc27c4edc15"
+  },
+  ".governance/specs/bootstrap-governance-setup.md": {
+    "size": 690,
+    "hash": "17b2d00f2550bec9b6f20082e07ba03f8757e065"
+  },
+  "Microsoft/Windows/PowerShell/ModuleAnalysisCache": {
+    "size": 8703,
+    "hash": "5843efa45c123e570092c6da5284e72d5ebdb90c"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/result.json
@@ -1,0 +1,127 @@
+{
+  "scenarioId": "empty-repo-bootstrap",
+  "adapterId": "codex-cli",
+  "provider": "ollama",
+  "model": "qwen2.5-coder:14b",
+  "passed": true,
+  "hardFailure": false,
+  "score": 100,
+  "classification": "production-ready",
+  "durationMs": 50588,
+  "exitKind": "completed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      },
+      {
+        "id": "ollama",
+        "provider": "ollama",
+        "model": "qwen2.5-coder:14b",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "ollama",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": true
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": true,
+      "severity": "hard",
+      "note": "Governance directories present.",
+      "evidence": []
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": true,
+      "severity": "hard",
+      "note": "GOV-01 through GOV-08 present.",
+      "evidence": [
+        "gov-01-instructions.mdc",
+        "gov-02-workflow.mdc",
+        "gov-03-communication.mdc",
+        "gov-04-quality.mdc",
+        "gov-05-testing.mdc",
+        "gov-06-issues.mdc",
+        "gov-07-tasks.mdc",
+        "gov-08-exploratory-review.mdc"
+      ]
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "Project intent artifact present.",
+      "evidence": [
+        ".governance/project/PROJECT.md"
+      ]
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "First spec artifact present.",
+      "evidence": [
+        "bootstrap-governance-setup.md"
+      ]
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "governanceSourcesReported",
+      "passed": true,
+      "severity": "hard",
+      "note": "Transcript reports governance sources.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [
+      ".governance/project/PROJECT.md",
+      ".governance/rules/gov-01-instructions.mdc",
+      ".governance/rules/gov-02-workflow.mdc",
+      ".governance/rules/gov-03-communication.mdc",
+      ".governance/rules/gov-04-quality.mdc",
+      ".governance/rules/gov-05-testing.mdc",
+      ".governance/rules/gov-06-issues.mdc",
+      ".governance/rules/gov-07-tasks.mdc",
+      ".governance/rules/gov-08-exploratory-review.mdc",
+      ".governance/specs/bootstrap-governance-setup.md",
+      "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+    ],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-iJZE02"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-51-47-271Z-empty-repo-bootstrap\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-51-47-271Z-empty-repo-bootstrap\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-51-47-271Z-empty-repo-bootstrap\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-51-47-271Z-empty-repo-bootstrap\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-51-47-271Z-empty-repo-bootstrap"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-51-47-271Z-empty-repo-bootstrap/transcript.md
@@ -1,0 +1,178 @@
+--- attempt ollama:qwen2.5-coder:14b ---
+
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules/",
+      "mkdir -p .governance/project/",
+      "mkdir -p .governance/specs/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Report:**
+The following directories and files were created:
+- `.governance/rules/`
+- `.governance/project/PROJECT.md`
+- `.governance/specs/bootstrap-governance-setup.md`
+
+Active governance sources:
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+
+--- stderr ---
+OpenAI Codex v0.115.0-alpha.27 (research preview)
+--------
+workdir: C:\Users\MAXBAR~1\AppData\Local\Temp\vibegov-empty-repo-iJZE02
+model: qwen2.5-coder:14b
+provider: ollama
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, C:\projects\governance-foundation\vibegov-issue-9, \\?\C:\Users\maxbarrass\AppData\Local\Temp\vibegov-codex-home-d5ae01fe-8ccf-4197-b6f4-1a215228c01f\memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019d2467-efe8-7623-beee-75a436dfd282
+--------
+user
+Bootstrap this repo with VibeGov using the local source made available to you.
+
+Before writing any product code:
+1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/` in the current repo.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+3. Create `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+4. Create `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+5. End your response with an exact line starting with: `Active governance sources:` followed by the source(s) you used.
+6. Stop before implementation.
+
+Do not ask follow-up questions.
+Do not implement product code.
+At the end, provide a short plain-text report of what you created.
+
+Local VibeGov source available for reference at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+Local VibeGov rules directory: C:/projects/governance-foundation/vibegov-issue-9/.governance/rules
+Local project template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+Local spec template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+Read governance/templates from those local source paths instead of using remote URLs when possible.
+
+Validator constraints:
+- You are running inside a temporary fixture repo used only for bootstrap validation.
+- Follow the prompt literally.
+- If the scenario is bootstrap-only, stop before product implementation.
+- At the end, explicitly report the active governance sources you used.
+- Do not emit markdown fences unless needed.
+- If your runtime cannot execute tools directly, emit one JSON object with name set to shell and arguments.commands set to an ordered array of the exact file-system commands needed, then include the required plain-text report.
+Create at least one non-template spec file under .governance/specs/ (for example: bootstrap-governance-setup.md).
+
+
+warning: Disabled `js_repl` for this session because the configured Node runtime is unavailable or incompatible. Node runtime too old for js_repl (resolved C:\data\apps\#dev\nvm\node\v16.20.2\node.exe): found v16.20.2, requires >= v22.22.0. Install/update Node or set js_repl_node_path to a newer runtime.
+mcp startup: no servers
+warning: Model metadata for `qwen2.5-coder:14b` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.
+codex
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules/",
+      "mkdir -p .governance/project/",
+      "mkdir -p .governance/specs/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Report:**
+The following directories and files were created:
+- `.governance/rules/`
+- `.governance/project/PROJECT.md`
+- `.governance/specs/bootstrap-governance-setup.md`
+
+Active governance sources:
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+tokens used
+4,382
+
+--- last message ---
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules/",
+      "mkdir -p .governance/project/",
+      "mkdir -p .governance/specs/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Report:**
+The following directories and files were created:
+- `.governance/rules/`
+- `.governance/project/PROJECT.md`
+- `.governance/specs/bootstrap-governance-setup.md`
+
+Active governance sources:
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+- C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+
+--- adapter shell-plan execution ---
+$ mkdir -p .governance/rules/
+Created directories: .governance/rules/
+$ mkdir -p .governance/project/
+Created directories: .governance/project/
+$ mkdir -p .governance/specs/
+Created directories: .governance/specs/
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-iJZE02/.governance/rules/ (8 item(s)).
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-iJZE02/.governance/project/PROJECT.md (1 item(s)).
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-iJZE02/.governance/specs/bootstrap-governance-setup.md (1 item(s)).
+
+--- adapter attempts summary ---
+[
+  {
+    "id": "default",
+    "provider": "openai-codex",
+    "model": "gpt-5.4",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "default",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": false
+    }
+  },
+  {
+    "id": "ollama",
+    "provider": "ollama",
+    "model": "qwen2.5-coder:14b",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "ollama",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": true
+    }
+  }
+]

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/diff.json
@@ -1,0 +1,102 @@
+{
+  "created": [
+    "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+    "tmp/bootstrap-repo/.governance/project/PROJECT_TEMPLATE.md",
+    "tmp/bootstrap-repo/.governance/rules/gov-01-instructions.mdc",
+    "tmp/bootstrap-repo/.governance/rules/gov-02-workflow.mdc",
+    "tmp/bootstrap-repo/.governance/rules/gov-03-communication.mdc",
+    "tmp/bootstrap-repo/.governance/rules/gov-04-quality.mdc",
+    "tmp/bootstrap-repo/.governance/rules/gov-05-testing.mdc",
+    "tmp/bootstrap-repo/.governance/rules/gov-06-issues.mdc",
+    "tmp/bootstrap-repo/.governance/rules/gov-07-tasks.mdc",
+    "tmp/bootstrap-repo/.governance/rules/gov-08-exploratory-review.mdc",
+    "tmp/bootstrap-repo/.governance/specs/SPEC_TEMPLATE.md",
+    "tmp/bootstrap-repo/.governance/specs/bootstrap-governance-setup.md",
+    "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-live-adapter.md",
+    "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-phase-1.md",
+    "tmp/bootstrap-repo/.governance/specs/explicit-orchestration-bounded-work.md",
+    "tmp/bootstrap-repo/.governance/specs/ownership-continuity-and-follow-through.md",
+    "tmp/bootstrap-repo/.governance/specs/vibegov-sdlc-explainer.md",
+    "tmp/bootstrap-repo/README.md"
+  ],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [
+      {
+        "path": "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/project/PROJECT_TEMPLATE.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-01-instructions.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-02-workflow.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-03-communication.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-04-quality.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-05-testing.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-06-issues.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-07-tasks.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/rules/gov-08-exploratory-review.mdc",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/specs/SPEC_TEMPLATE.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/specs/bootstrap-governance-setup.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-live-adapter.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-phase-1.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/specs/explicit-orchestration-bounded-work.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/specs/ownership-continuity-and-follow-through.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/.governance/specs/vibegov-sdlc-explainer.md",
+        "category": "other"
+      },
+      {
+        "path": "tmp/bootstrap-repo/README.md",
+        "category": "other"
+      }
+    ],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/manifest-after.json
@@ -1,0 +1,158 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "Microsoft/Windows/PowerShell/ModuleAnalysisCache": {
+    "size": 8703,
+    "hash": "5843efa45c123e570092c6da5284e72d5ebdb90c"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  },
+  "tmp/bootstrap-repo/.governance/project/PROJECT_TEMPLATE.md": {
+    "size": 757,
+    "hash": "c2d1390bdb0d475a6a5e0b9c73a50a5b5907ae45"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-01-instructions.mdc": {
+    "size": 1633,
+    "hash": "765b01b9fa0ccc27aa0855739f253ae7d1625930"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-02-workflow.mdc": {
+    "size": 8912,
+    "hash": "07415c257043377e81f3bd263b0ad835dc60faa7"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-03-communication.mdc": {
+    "size": 1262,
+    "hash": "fa0f94a3cb84a8e00def84225ea7cb5941635dca"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-04-quality.mdc": {
+    "size": 1341,
+    "hash": "5a27e26f87dec191107802e86d5d242c82af7b14"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-05-testing.mdc": {
+    "size": 1462,
+    "hash": "8f46f137b4b1f6cf3603f976de230c90a9c68ad0"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-06-issues.mdc": {
+    "size": 2063,
+    "hash": "bd969b77c76d18360e1747da342eca451cfe92b0"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-07-tasks.mdc": {
+    "size": 1064,
+    "hash": "e6bee2a5111be78bd2fda08df3549958c87023c6"
+  },
+  "tmp/bootstrap-repo/.governance/rules/gov-08-exploratory-review.mdc": {
+    "size": 9073,
+    "hash": "742b23c22dee435dc326c6067b062dc27c4edc15"
+  },
+  "tmp/bootstrap-repo/.governance/specs/bootstrap-governance-setup.md": {
+    "size": 29,
+    "hash": "3b28508b0367384b7715096922b7a5035d412f78"
+  },
+  "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-live-adapter.md": {
+    "size": 2297,
+    "hash": "651929646bfc6f15da8cff93917a62b50eacec84"
+  },
+  "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-phase-1.md": {
+    "size": 3001,
+    "hash": "d13efdbe88467bf3f13a81314f61e18501d2917f"
+  },
+  "tmp/bootstrap-repo/.governance/specs/explicit-orchestration-bounded-work.md": {
+    "size": 2693,
+    "hash": "25ee3290013aa039b061c081162606fd9f6b1abd"
+  },
+  "tmp/bootstrap-repo/.governance/specs/ownership-continuity-and-follow-through.md": {
+    "size": 2458,
+    "hash": "28836bab8134b259a4466bab876da8e9e6b1d340"
+  },
+  "tmp/bootstrap-repo/.governance/specs/SPEC_TEMPLATE.md": {
+    "size": 690,
+    "hash": "17b2d00f2550bec9b6f20082e07ba03f8757e065"
+  },
+  "tmp/bootstrap-repo/.governance/specs/vibegov-sdlc-explainer.md": {
+    "size": 2612,
+    "hash": "57c4e51d0cced8e9de0236b2ba3594341c2c0094"
+  },
+  "tmp/bootstrap-repo/README.md": {
+    "size": 40,
+    "hash": "48a19ed0ccd6d7f7b50bdf25d850855eb34c3ff9"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/result.json
@@ -1,0 +1,125 @@
+{
+  "scenarioId": "bootstrap-gate",
+  "adapterId": "codex-cli",
+  "provider": "ollama",
+  "model": "qwen2.5-coder:14b",
+  "passed": false,
+  "hardFailure": true,
+  "score": 17,
+  "classification": "untrusted",
+  "durationMs": 40464,
+  "exitKind": "completed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      },
+      {
+        "id": "ollama",
+        "provider": "ollama",
+        "model": "qwen2.5-coder:14b",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "ollama",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": true
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing: .governance/rules, .governance/project, .governance/specs",
+      "evidence": [
+        ".governance/rules",
+        ".governance/project",
+        ".governance/specs"
+      ]
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing rules: gov-01-instructions.mdc, gov-02-workflow.mdc, gov-03-communication.mdc, gov-04-quality.mdc, gov-05-testing.mdc, gov-06-issues.mdc, gov-07-tasks.mdc, gov-08-exploratory-review.mdc",
+      "evidence": []
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing project intent artifact.",
+      "evidence": []
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing first spec artifact.",
+      "evidence": []
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "bootstrapStopDeclared",
+      "passed": false,
+      "severity": "hard",
+      "note": "Transcript missing stop declaration.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [
+      "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+      "tmp/bootstrap-repo/.governance/project/PROJECT_TEMPLATE.md",
+      "tmp/bootstrap-repo/.governance/rules/gov-01-instructions.mdc",
+      "tmp/bootstrap-repo/.governance/rules/gov-02-workflow.mdc",
+      "tmp/bootstrap-repo/.governance/rules/gov-03-communication.mdc",
+      "tmp/bootstrap-repo/.governance/rules/gov-04-quality.mdc",
+      "tmp/bootstrap-repo/.governance/rules/gov-05-testing.mdc",
+      "tmp/bootstrap-repo/.governance/rules/gov-06-issues.mdc",
+      "tmp/bootstrap-repo/.governance/rules/gov-07-tasks.mdc",
+      "tmp/bootstrap-repo/.governance/rules/gov-08-exploratory-review.mdc",
+      "tmp/bootstrap-repo/.governance/specs/SPEC_TEMPLATE.md",
+      "tmp/bootstrap-repo/.governance/specs/bootstrap-governance-setup.md",
+      "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-live-adapter.md",
+      "tmp/bootstrap-repo/.governance/specs/bootstrap-validator-phase-1.md",
+      "tmp/bootstrap-repo/.governance/specs/explicit-orchestration-bounded-work.md",
+      "tmp/bootstrap-repo/.governance/specs/ownership-continuity-and-follow-through.md",
+      "tmp/bootstrap-repo/.governance/specs/vibegov-sdlc-explainer.md",
+      "tmp/bootstrap-repo/README.md"
+    ],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-Eersh7"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-52-39-647Z-bootstrap-gate\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-52-39-647Z-bootstrap-gate\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-52-39-647Z-bootstrap-gate\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-52-39-647Z-bootstrap-gate\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-52-39-647Z-bootstrap-gate"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-52-39-647Z-bootstrap-gate/transcript.md
@@ -1,0 +1,19 @@
+Attempt default: provider=openai-codex model=gpt-5.4 exitKind=completed
+{
+  "attemptId": "default",
+  "status": 0,
+  "signal": null,
+  "error": null,
+  "completedFromLastMessage": false,
+  "shellPlanApplied": false
+}
+
+Attempt ollama: provider=ollama model=qwen2.5-coder:14b exitKind=completed
+{
+  "attemptId": "ollama",
+  "status": 0,
+  "signal": null,
+  "error": null,
+  "completedFromLastMessage": false,
+  "shellPlanApplied": true
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/diff.json
@@ -1,0 +1,27 @@
+{
+  "created": [
+    ".governance/specs/bootstrap-governance-setup.md",
+    "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+    "bootstrap_report.txt"
+  ],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [
+      {
+        "path": ".governance/specs/bootstrap-governance-setup.md",
+        "category": "governance"
+      },
+      {
+        "path": "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+        "category": "other"
+      },
+      {
+        "path": "bootstrap_report.txt",
+        "category": "other"
+      }
+    ],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/manifest-after.json
@@ -1,0 +1,98 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  ".governance/specs/bootstrap-governance-setup.md": {
+    "size": 690,
+    "hash": "17b2d00f2550bec9b6f20082e07ba03f8757e065"
+  },
+  "bootstrap_report.txt": {
+    "size": 129,
+    "hash": "848779459d43ae2d4eb31b30b6d545b40e62243c"
+  },
+  "Microsoft/Windows/PowerShell/ModuleAnalysisCache": {
+    "size": 8703,
+    "hash": "5843efa45c123e570092c6da5284e72d5ebdb90c"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/result.json
@@ -1,0 +1,111 @@
+{
+  "scenarioId": "bootstrap-gate",
+  "adapterId": "codex-cli",
+  "provider": "ollama",
+  "model": "qwen2.5-coder:14b",
+  "passed": false,
+  "hardFailure": true,
+  "score": 50,
+  "classification": "inconsistent",
+  "durationMs": 38416,
+  "exitKind": "completed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      },
+      {
+        "id": "ollama",
+        "provider": "ollama",
+        "model": "qwen2.5-coder:14b",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "ollama",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": true
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing: .governance/rules, .governance/project",
+      "evidence": [
+        ".governance/rules",
+        ".governance/project"
+      ]
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing rules: gov-01-instructions.mdc, gov-02-workflow.mdc, gov-03-communication.mdc, gov-04-quality.mdc, gov-05-testing.mdc, gov-06-issues.mdc, gov-07-tasks.mdc, gov-08-exploratory-review.mdc",
+      "evidence": []
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": false,
+      "severity": "hard",
+      "note": "Missing project intent artifact.",
+      "evidence": []
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "First spec artifact present.",
+      "evidence": [
+        "bootstrap-governance-setup.md"
+      ]
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "bootstrapStopDeclared",
+      "passed": true,
+      "severity": "hard",
+      "note": "Transcript declares bootstrap stop gate.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [
+      ".governance/specs/bootstrap-governance-setup.md",
+      "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+      "bootstrap_report.txt"
+    ],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-YuAsEi"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-54-28-665Z-bootstrap-gate\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-54-28-665Z-bootstrap-gate\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-54-28-665Z-bootstrap-gate\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-54-28-665Z-bootstrap-gate\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-54-28-665Z-bootstrap-gate"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-54-28-665Z-bootstrap-gate/transcript.md
@@ -1,0 +1,174 @@
+--- attempt default-provider ---
+
+--- stderr ---
+OpenAI Codex v0.115.0-alpha.27 (research preview)
+--------
+workdir: C:\Users\MAXBAR~1\AppData\Local\Temp\vibegov-empty-repo-YuAsEi
+model: gpt-5.4
+provider: openai
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, C:\projects\governance-foundation\vibegov-issue-9, \\?\C:\Users\maxbarrass\AppData\Local\Temp\vibegov-codex-home-4c3ca08e-7b0c-4eb0-92d8-977eed6d7bb4\memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019d246a-2ce3-7cc1-b8a8-648a15f5c66a
+--------
+user
+Adopt VibeGov governance in this repo and stop before product implementation.
+Report readiness and next step once the bootstrap gate is satisfied.
+Include the exact sentence `Stopping before product implementation.` in your final report.
+Include one line that starts exactly with `Active governance sources:` in your final report.
+
+Local VibeGov source available for reference at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+Local VibeGov rules directory: C:/projects/governance-foundation/vibegov-issue-9/.governance/rules
+Local project template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+Local spec template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+Read governance/templates from those local source paths instead of using remote URLs when possible.
+
+Validator constraints:
+- You are running inside a temporary fixture repo used only for bootstrap validation.
+- Follow the prompt literally.
+- If the scenario is bootstrap-only, stop before product implementation.
+- At the end, explicitly report the active governance sources you used.
+- Do not emit markdown fences unless needed.
+- If your runtime cannot execute tools directly, emit one JSON object with name set to shell and arguments.commands set to an ordered array of the exact file-system commands needed, then include the required plain-text report.
+Create at least one non-template spec file under .governance/specs/ (for example: bootstrap-governance-setup.md).
+For this bootstrap-gate scenario, your final report must include the exact sentence: Stopping before product implementation.
+Your final report must also include one line that starts exactly with: Active governance sources:
+
+warning: Disabled `js_repl` for this session because the configured Node runtime is unavailable or incompatible. Node runtime too old for js_repl (resolved C:\data\apps\#dev\nvm\node\v16.20.2\node.exe): found v16.20.2, requires >= v22.22.0. Install/update Node or set js_repl_node_path to a newer runtime.
+mcp startup: no servers
+Reconnecting... 1/5 (stream disconnected before completion: error sending request for url (https://api.openai.com/v1/responses))
+Reconnecting... 2/5 (stream disconnected before completion: error sending request for url (https://api.openai.com/v1/responses))
+Reconnecting... 3/5 (stream disconnected before completion: error sending request for url (https://api.openai.com/v1/responses))
+Reconnecting... 4/5 (stream disconnected before completion: error sending request for url (https://api.openai.com/v1/responses))
+Reconnecting... 5/5 (stream disconnected before completion: error sending request for url (https://api.openai.com/v1/responses))
+ERROR: stream disconnected before completion: error sending request for url (https://api.openai.com/v1/responses)
+Warning: no last agent message; wrote empty content to C:\Users\MAXBAR~1\AppData\Local\Temp\vibegov-codex-3b2b41e4-c1f8-4611-8600-e5e05942ab42-last-message.txt
+
+--- attempt ollama:qwen2.5-coder:14b ---
+
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/specs/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md",
+      "echo 'Stopping before product implementation.' > bootstrap_report.txt",
+      "echo 'Active governance sources: C:/projects/governance-foundation/vibegov-issue-9/.governance' >> bootstrap_report.txt"
+    ]
+  }
+}
+```
+
+--- stderr ---
+OpenAI Codex v0.115.0-alpha.27 (research preview)
+--------
+workdir: C:\Users\MAXBAR~1\AppData\Local\Temp\vibegov-empty-repo-YuAsEi
+model: qwen2.5-coder:14b
+provider: ollama
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, C:\projects\governance-foundation\vibegov-issue-9, \\?\C:\Users\maxbarrass\AppData\Local\Temp\vibegov-codex-home-6d0e205a-a813-449a-a1b1-52c240cf91ae\memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019d246a-9490-7d51-80b1-f0234140df10
+--------
+user
+Adopt VibeGov governance in this repo and stop before product implementation.
+Report readiness and next step once the bootstrap gate is satisfied.
+Include the exact sentence `Stopping before product implementation.` in your final report.
+Include one line that starts exactly with `Active governance sources:` in your final report.
+
+Local VibeGov source available for reference at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+Local VibeGov rules directory: C:/projects/governance-foundation/vibegov-issue-9/.governance/rules
+Local project template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+Local spec template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+Read governance/templates from those local source paths instead of using remote URLs when possible.
+
+Validator constraints:
+- You are running inside a temporary fixture repo used only for bootstrap validation.
+- Follow the prompt literally.
+- If the scenario is bootstrap-only, stop before product implementation.
+- At the end, explicitly report the active governance sources you used.
+- Do not emit markdown fences unless needed.
+- If your runtime cannot execute tools directly, emit one JSON object with name set to shell and arguments.commands set to an ordered array of the exact file-system commands needed, then include the required plain-text report.
+Create at least one non-template spec file under .governance/specs/ (for example: bootstrap-governance-setup.md).
+For this bootstrap-gate scenario, your final report must include the exact sentence: Stopping before product implementation.
+Your final report must also include one line that starts exactly with: Active governance sources:
+
+warning: Disabled `js_repl` for this session because the configured Node runtime is unavailable or incompatible. Node runtime too old for js_repl (resolved C:\data\apps\#dev\nvm\node\v16.20.2\node.exe): found v16.20.2, requires >= v22.22.0. Install/update Node or set js_repl_node_path to a newer runtime.
+mcp startup: no servers
+warning: Model metadata for `qwen2.5-coder:14b` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.
+codex
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/specs/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md",
+      "echo 'Stopping before product implementation.' > bootstrap_report.txt",
+      "echo 'Active governance sources: C:/projects/governance-foundation/vibegov-issue-9/.governance' >> bootstrap_report.txt"
+    ]
+  }
+}
+```
+tokens used
+4,222
+
+--- last message ---
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/specs/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md",
+      "echo 'Stopping before product implementation.' > bootstrap_report.txt",
+      "echo 'Active governance sources: C:/projects/governance-foundation/vibegov-issue-9/.governance' >> bootstrap_report.txt"
+    ]
+  }
+}
+```
+
+--- adapter shell-plan execution ---
+$ mkdir -p .governance/specs/
+Created directories: .governance/specs/
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-YuAsEi/.governance/specs/bootstrap-governance-setup.md (1 item(s)).
+$ echo 'Stopping before product implementation.' > bootstrap_report.txt
+Wrote C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-YuAsEi/bootstrap_report.txt.
+$ echo 'Active governance sources: C:/projects/governance-foundation/vibegov-issue-9/.governance' >> bootstrap_report.txt
+Appended to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-YuAsEi/bootstrap_report.txt.
+
+--- adapter attempts summary ---
+[
+  {
+    "id": "default",
+    "provider": "openai-codex",
+    "model": "gpt-5.4",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "default",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": false
+    }
+  },
+  {
+    "id": "ollama",
+    "provider": "ollama",
+    "model": "qwen2.5-coder:14b",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "ollama",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": true
+    }
+  }
+]

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/diff.json
@@ -1,0 +1,67 @@
+{
+  "created": [
+    ".governance/project/PROJECT.md",
+    ".governance/rules/gov-01-instructions.mdc",
+    ".governance/rules/gov-02-workflow.mdc",
+    ".governance/rules/gov-03-communication.mdc",
+    ".governance/rules/gov-04-quality.mdc",
+    ".governance/rules/gov-05-testing.mdc",
+    ".governance/rules/gov-06-issues.mdc",
+    ".governance/rules/gov-07-tasks.mdc",
+    ".governance/rules/gov-08-exploratory-review.mdc",
+    ".governance/specs/bootstrap-governance-setup.md",
+    "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+  ],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [
+      {
+        "path": ".governance/project/PROJECT.md",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-01-instructions.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-02-workflow.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-03-communication.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-04-quality.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-05-testing.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-06-issues.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-07-tasks.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-08-exploratory-review.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/specs/bootstrap-governance-setup.md",
+        "category": "governance"
+      },
+      {
+        "path": "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+        "category": "other"
+      }
+    ],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/manifest-after.json
@@ -1,0 +1,130 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  ".governance/project/PROJECT.md": {
+    "size": 757,
+    "hash": "c2d1390bdb0d475a6a5e0b9c73a50a5b5907ae45"
+  },
+  ".governance/rules/gov-01-instructions.mdc": {
+    "size": 1633,
+    "hash": "765b01b9fa0ccc27aa0855739f253ae7d1625930"
+  },
+  ".governance/rules/gov-02-workflow.mdc": {
+    "size": 8912,
+    "hash": "07415c257043377e81f3bd263b0ad835dc60faa7"
+  },
+  ".governance/rules/gov-03-communication.mdc": {
+    "size": 1262,
+    "hash": "fa0f94a3cb84a8e00def84225ea7cb5941635dca"
+  },
+  ".governance/rules/gov-04-quality.mdc": {
+    "size": 1341,
+    "hash": "5a27e26f87dec191107802e86d5d242c82af7b14"
+  },
+  ".governance/rules/gov-05-testing.mdc": {
+    "size": 1462,
+    "hash": "8f46f137b4b1f6cf3603f976de230c90a9c68ad0"
+  },
+  ".governance/rules/gov-06-issues.mdc": {
+    "size": 2063,
+    "hash": "bd969b77c76d18360e1747da342eca451cfe92b0"
+  },
+  ".governance/rules/gov-07-tasks.mdc": {
+    "size": 1064,
+    "hash": "e6bee2a5111be78bd2fda08df3549958c87023c6"
+  },
+  ".governance/rules/gov-08-exploratory-review.mdc": {
+    "size": 9073,
+    "hash": "742b23c22dee435dc326c6067b062dc27c4edc15"
+  },
+  ".governance/specs/bootstrap-governance-setup.md": {
+    "size": 690,
+    "hash": "17b2d00f2550bec9b6f20082e07ba03f8757e065"
+  },
+  "Microsoft/Windows/PowerShell/ModuleAnalysisCache": {
+    "size": 8703,
+    "hash": "5843efa45c123e570092c6da5284e72d5ebdb90c"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/result.json
@@ -1,0 +1,127 @@
+{
+  "scenarioId": "bootstrap-gate",
+  "adapterId": "codex-cli",
+  "provider": "ollama",
+  "model": "qwen2.5-coder:14b",
+  "passed": true,
+  "hardFailure": false,
+  "score": 100,
+  "classification": "production-ready",
+  "durationMs": 47796,
+  "exitKind": "completed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      },
+      {
+        "id": "ollama",
+        "provider": "ollama",
+        "model": "qwen2.5-coder:14b",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "ollama",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": true
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": true,
+      "severity": "hard",
+      "note": "Governance directories present.",
+      "evidence": []
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": true,
+      "severity": "hard",
+      "note": "GOV-01 through GOV-08 present.",
+      "evidence": [
+        "gov-01-instructions.mdc",
+        "gov-02-workflow.mdc",
+        "gov-03-communication.mdc",
+        "gov-04-quality.mdc",
+        "gov-05-testing.mdc",
+        "gov-06-issues.mdc",
+        "gov-07-tasks.mdc",
+        "gov-08-exploratory-review.mdc"
+      ]
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "Project intent artifact present.",
+      "evidence": [
+        ".governance/project/PROJECT.md"
+      ]
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "First spec artifact present.",
+      "evidence": [
+        "bootstrap-governance-setup.md"
+      ]
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "bootstrapStopDeclared",
+      "passed": true,
+      "severity": "hard",
+      "note": "Transcript declares bootstrap stop gate.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [
+      ".governance/project/PROJECT.md",
+      ".governance/rules/gov-01-instructions.mdc",
+      ".governance/rules/gov-02-workflow.mdc",
+      ".governance/rules/gov-03-communication.mdc",
+      ".governance/rules/gov-04-quality.mdc",
+      ".governance/rules/gov-05-testing.mdc",
+      ".governance/rules/gov-06-issues.mdc",
+      ".governance/rules/gov-07-tasks.mdc",
+      ".governance/rules/gov-08-exploratory-review.mdc",
+      ".governance/specs/bootstrap-governance-setup.md",
+      "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+    ],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-3EZr07"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-55-52-467Z-bootstrap-gate\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-55-52-467Z-bootstrap-gate\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-55-52-467Z-bootstrap-gate\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-55-52-467Z-bootstrap-gate\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-55-52-467Z-bootstrap-gate"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-55-52-467Z-bootstrap-gate/transcript.md
@@ -1,0 +1,171 @@
+--- attempt ollama:qwen2.5-coder:14b ---
+
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules",
+      "mkdir -p .governance/project",
+      "mkdir -p .governance/specs",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Final Report:**
+- Created directories: `.governance/rules`, `.governance/project`, and `.governance/specs`.
+- Copied VibeGov rule set (`GOV-01` through `GOV-08`) to `.governance/rules/`.
+- Created `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+- Created `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+Stopping before product implementation.
+Active governance sources: C:/projects/governance-foundation/vibegov-issue-9/.governance
+
+--- stderr ---
+OpenAI Codex v0.115.0-alpha.27 (research preview)
+--------
+workdir: C:\Users\MAXBAR~1\AppData\Local\Temp\vibegov-empty-repo-3EZr07
+model: qwen2.5-coder:14b
+provider: ollama
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, C:\projects\governance-foundation\vibegov-issue-9, \\?\C:\Users\maxbarrass\AppData\Local\Temp\vibegov-codex-home-527e8f9e-4e32-4f82-97c9-d993942b442b\memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019d246b-b79e-7322-8776-e984bc024e47
+--------
+user
+Bootstrap this repo with VibeGov using the local source made available to you.
+
+Before writing any product code:
+1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/` in the current repo.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+3. Create `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+4. Create `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+5. End your final report with the exact sentence: `Stopping before product implementation.`
+6. Include one final-report line that starts exactly with: `Active governance sources:` followed by the source(s) you used.
+7. Stop before implementation.
+
+Do not ask follow-up questions.
+Do not implement product code.
+At the end, provide a short plain-text report of what you created and the next step after the bootstrap gate.
+
+Local VibeGov source available for reference at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+Local VibeGov rules directory: C:/projects/governance-foundation/vibegov-issue-9/.governance/rules
+Local project template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+Local spec template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+Read governance/templates from those local source paths instead of using remote URLs when possible.
+
+Validator constraints:
+- You are running inside a temporary fixture repo used only for bootstrap validation.
+- Follow the prompt literally.
+- If the scenario is bootstrap-only, stop before product implementation.
+- At the end, explicitly report the active governance sources you used.
+- Do not emit markdown fences unless needed.
+- If your runtime cannot execute tools directly, emit one JSON object with name set to shell and arguments.commands set to an ordered array of the exact file-system commands needed, then include the required plain-text report.
+Create at least one non-template spec file under .governance/specs/ (for example: bootstrap-governance-setup.md).
+For this bootstrap-gate scenario, your final report must include the exact sentence: Stopping before product implementation.
+Your final report must also include one line that starts exactly with: Active governance sources:
+
+warning: Disabled `js_repl` for this session because the configured Node runtime is unavailable or incompatible. Node runtime too old for js_repl (resolved C:\data\apps\#dev\nvm\node\v16.20.2\node.exe): found v16.20.2, requires >= v22.22.0. Install/update Node or set js_repl_node_path to a newer runtime.
+mcp startup: no servers
+warning: Model metadata for `qwen2.5-coder:14b` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.
+codex
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules",
+      "mkdir -p .governance/project",
+      "mkdir -p .governance/specs",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Final Report:**
+- Created directories: `.governance/rules`, `.governance/project`, and `.governance/specs`.
+- Copied VibeGov rule set (`GOV-01` through `GOV-08`) to `.governance/rules/`.
+- Created `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+- Created `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+Stopping before product implementation.
+Active governance sources: C:/projects/governance-foundation/vibegov-issue-9/.governance
+tokens used
+4,392
+
+--- last message ---
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules",
+      "mkdir -p .governance/project",
+      "mkdir -p .governance/specs",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Final Report:**
+- Created directories: `.governance/rules`, `.governance/project`, and `.governance/specs`.
+- Copied VibeGov rule set (`GOV-01` through `GOV-08`) to `.governance/rules/`.
+- Created `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+- Created `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+Stopping before product implementation.
+Active governance sources: C:/projects/governance-foundation/vibegov-issue-9/.governance
+
+--- adapter shell-plan execution ---
+$ mkdir -p .governance/rules
+Created directories: .governance/rules
+$ mkdir -p .governance/project
+Created directories: .governance/project
+$ mkdir -p .governance/specs
+Created directories: .governance/specs
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-3EZr07/.governance/rules/ (8 item(s)).
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-3EZr07/.governance/project/PROJECT.md (1 item(s)).
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-3EZr07/.governance/specs/bootstrap-governance-setup.md (1 item(s)).
+
+--- adapter attempts summary ---
+[
+  {
+    "id": "default",
+    "provider": "openai-codex",
+    "model": "gpt-5.4",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "default",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": false
+    }
+  },
+  {
+    "id": "ollama",
+    "provider": "ollama",
+    "model": "qwen2.5-coder:14b",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "ollama",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": true
+    }
+  }
+]

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/diff.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/diff.json
@@ -1,0 +1,67 @@
+{
+  "created": [
+    ".governance/project/PROJECT.md",
+    ".governance/rules/gov-01-instructions.mdc",
+    ".governance/rules/gov-02-workflow.mdc",
+    ".governance/rules/gov-03-communication.mdc",
+    ".governance/rules/gov-04-quality.mdc",
+    ".governance/rules/gov-05-testing.mdc",
+    ".governance/rules/gov-06-issues.mdc",
+    ".governance/rules/gov-07-tasks.mdc",
+    ".governance/rules/gov-08-exploratory-review.mdc",
+    ".governance/specs/bootstrap-governance-setup.md",
+    "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+  ],
+  "modified": [],
+  "deleted": [],
+  "categories": {
+    "created": [
+      {
+        "path": ".governance/project/PROJECT.md",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-01-instructions.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-02-workflow.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-03-communication.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-04-quality.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-05-testing.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-06-issues.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-07-tasks.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/rules/gov-08-exploratory-review.mdc",
+        "category": "governance"
+      },
+      {
+        "path": ".governance/specs/bootstrap-governance-setup.md",
+        "category": "governance"
+      },
+      {
+        "path": "Microsoft/Windows/PowerShell/ModuleAnalysisCache",
+        "category": "other"
+      }
+    ],
+    "modified": [],
+    "deleted": []
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/manifest-after.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/manifest-after.json
@@ -1,0 +1,130 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  ".governance/project/PROJECT.md": {
+    "size": 757,
+    "hash": "c2d1390bdb0d475a6a5e0b9c73a50a5b5907ae45"
+  },
+  ".governance/rules/gov-01-instructions.mdc": {
+    "size": 1633,
+    "hash": "765b01b9fa0ccc27aa0855739f253ae7d1625930"
+  },
+  ".governance/rules/gov-02-workflow.mdc": {
+    "size": 8912,
+    "hash": "07415c257043377e81f3bd263b0ad835dc60faa7"
+  },
+  ".governance/rules/gov-03-communication.mdc": {
+    "size": 1262,
+    "hash": "fa0f94a3cb84a8e00def84225ea7cb5941635dca"
+  },
+  ".governance/rules/gov-04-quality.mdc": {
+    "size": 1341,
+    "hash": "5a27e26f87dec191107802e86d5d242c82af7b14"
+  },
+  ".governance/rules/gov-05-testing.mdc": {
+    "size": 1462,
+    "hash": "8f46f137b4b1f6cf3603f976de230c90a9c68ad0"
+  },
+  ".governance/rules/gov-06-issues.mdc": {
+    "size": 2063,
+    "hash": "bd969b77c76d18360e1747da342eca451cfe92b0"
+  },
+  ".governance/rules/gov-07-tasks.mdc": {
+    "size": 1064,
+    "hash": "e6bee2a5111be78bd2fda08df3549958c87023c6"
+  },
+  ".governance/rules/gov-08-exploratory-review.mdc": {
+    "size": 9073,
+    "hash": "742b23c22dee435dc326c6067b062dc27c4edc15"
+  },
+  ".governance/specs/bootstrap-governance-setup.md": {
+    "size": 690,
+    "hash": "17b2d00f2550bec9b6f20082e07ba03f8757e065"
+  },
+  "Microsoft/Windows/PowerShell/ModuleAnalysisCache": {
+    "size": 8703,
+    "hash": "5843efa45c123e570092c6da5284e72d5ebdb90c"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/manifest-before.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/manifest-before.json
@@ -1,0 +1,86 @@
+{
+  ".git/config": {
+    "size": 198,
+    "hash": "7afa364c6485b5400aa6de67a4ec7107180d4cc8"
+  },
+  ".git/description": {
+    "size": 73,
+    "hash": "9635f1b7e12c045212819dd934d809ef07efa2f4"
+  },
+  ".git/HEAD": {
+    "size": 21,
+    "hash": "9f1df7eea4156be8a871c292b549b3325e425aa2"
+  },
+  ".git/hooks/applypatch-msg.sample": {
+    "size": 478,
+    "hash": "4de88eb95a5e93fd27e78b5fb3b5231a8d8917dd"
+  },
+  ".git/hooks/commit-msg.sample": {
+    "size": 896,
+    "hash": "ee1ed5aad98a435f2020b6de35c173b75d9affac"
+  },
+  ".git/hooks/fsmonitor-watchman.sample": {
+    "size": 4726,
+    "hash": "0ec0ec9ac11111433d17ea79e0ae8cec650dcfa4"
+  },
+  ".git/hooks/post-update.sample": {
+    "size": 189,
+    "hash": "b614c2f63da7dca9f1db2e7ade61ef30448fc96c"
+  },
+  ".git/hooks/pre-applypatch.sample": {
+    "size": 424,
+    "hash": "f208287c1a92525de9f5462e905a9d31de1e2d75"
+  },
+  ".git/hooks/pre-commit.sample": {
+    "size": 1649,
+    "hash": "8093d68e142db52dcab2215e770ba0bbe4cfbf24"
+  },
+  ".git/hooks/pre-merge-commit.sample": {
+    "size": 416,
+    "hash": "04c64e58bc25c149482ed45dbd79e40effb89eb7"
+  },
+  ".git/hooks/pre-push.sample": {
+    "size": 1374,
+    "hash": "a599b773b930ca83dbc3a5c7c13059ac4a6eaedc"
+  },
+  ".git/hooks/pre-rebase.sample": {
+    "size": 4898,
+    "hash": "288efdc0027db4cfd8b7c47c4aeddba09b6ded12"
+  },
+  ".git/hooks/pre-receive.sample": {
+    "size": 544,
+    "hash": "705a17d259e7896f0082fe2e9f2c0c3b127be5ac"
+  },
+  ".git/hooks/prepare-commit-msg.sample": {
+    "size": 1492,
+    "hash": "2584806ba147152ae005cb675aa4f01d5d068456"
+  },
+  ".git/hooks/push-to-checkout.sample": {
+    "size": 2783,
+    "hash": "508240328c8b55f8157c93c43bf5e291e5d2fbcb"
+  },
+  ".git/hooks/sendemail-validate.sample": {
+    "size": 2308,
+    "hash": "74cf1d5415a5c03c110240f749491297d65c4c98"
+  },
+  ".git/hooks/update.sample": {
+    "size": 3650,
+    "hash": "730e6bd5225478bab6147b7a62a6e2ae21d40507"
+  },
+  ".git/info/exclude": {
+    "size": 240,
+    "hash": "c879df015d97615050afa7b9641e3352a1e701ac"
+  },
+  ".gitkeep": {
+    "size": 12,
+    "hash": "12abdd31cf62e1aa0544a8ee68e9bddeef51ff5f"
+  },
+  "README.md": {
+    "size": 21,
+    "hash": "691182258b53156ed45c753aa9a1c0e99d949283"
+  },
+  "src/app.js": {
+    "size": 28,
+    "hash": "4afda54707202f7bc7b0af8b8e14004e232c2946"
+  }
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/result.json
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/result.json
@@ -1,0 +1,127 @@
+{
+  "scenarioId": "empty-repo-bootstrap",
+  "adapterId": "codex-cli",
+  "provider": "ollama",
+  "model": "qwen2.5-coder:14b",
+  "passed": true,
+  "hardFailure": false,
+  "score": 100,
+  "classification": "production-ready",
+  "durationMs": 48058,
+  "exitKind": "completed",
+  "rawOutput": {
+    "attempts": [
+      {
+        "id": "default",
+        "provider": "openai-codex",
+        "model": "gpt-5.4",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "default",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": false
+        }
+      },
+      {
+        "id": "ollama",
+        "provider": "ollama",
+        "model": "qwen2.5-coder:14b",
+        "exitKind": "completed",
+        "rawOutput": {
+          "attemptId": "ollama",
+          "status": 0,
+          "signal": null,
+          "error": null,
+          "completedFromLastMessage": false,
+          "shellPlanApplied": true
+        }
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "id": "governanceDirsExist",
+      "passed": true,
+      "severity": "hard",
+      "note": "Governance directories present.",
+      "evidence": []
+    },
+    {
+      "id": "govRuleSetPresent",
+      "passed": true,
+      "severity": "hard",
+      "note": "GOV-01 through GOV-08 present.",
+      "evidence": [
+        "gov-01-instructions.mdc",
+        "gov-02-workflow.mdc",
+        "gov-03-communication.mdc",
+        "gov-04-quality.mdc",
+        "gov-05-testing.mdc",
+        "gov-06-issues.mdc",
+        "gov-07-tasks.mdc",
+        "gov-08-exploratory-review.mdc"
+      ]
+    },
+    {
+      "id": "projectIntentCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "Project intent artifact present.",
+      "evidence": [
+        ".governance/project/PROJECT.md"
+      ]
+    },
+    {
+      "id": "firstSpecCreated",
+      "passed": true,
+      "severity": "hard",
+      "note": "First spec artifact present.",
+      "evidence": [
+        "bootstrap-governance-setup.md"
+      ]
+    },
+    {
+      "id": "noProductCodeChanges",
+      "passed": true,
+      "severity": "hard",
+      "note": "No product code changed.",
+      "evidence": []
+    },
+    {
+      "id": "governanceSourcesReported",
+      "passed": true,
+      "severity": "hard",
+      "note": "Transcript reports governance sources.",
+      "evidence": []
+    }
+  ],
+  "artifacts": {
+    "filesCreated": [
+      ".governance/project/PROJECT.md",
+      ".governance/rules/gov-01-instructions.mdc",
+      ".governance/rules/gov-02-workflow.mdc",
+      ".governance/rules/gov-03-communication.mdc",
+      ".governance/rules/gov-04-quality.mdc",
+      ".governance/rules/gov-05-testing.mdc",
+      ".governance/rules/gov-06-issues.mdc",
+      ".governance/rules/gov-07-tasks.mdc",
+      ".governance/rules/gov-08-exploratory-review.mdc",
+      ".governance/specs/bootstrap-governance-setup.md",
+      "Microsoft/Windows/PowerShell/ModuleAnalysisCache"
+    ],
+    "filesModified": [],
+    "issues": [],
+    "specGaps": [],
+    "repoPath": "C:\\Users\\MAXBAR~1\\AppData\\Local\\Temp\\vibegov-empty-repo-Ee0GWS"
+  },
+  "evidence": {
+    "transcriptPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-56-53-322Z-empty-repo-bootstrap\\transcript.md",
+    "manifestBeforePath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-56-53-322Z-empty-repo-bootstrap\\manifest-before.json",
+    "manifestAfterPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-56-53-322Z-empty-repo-bootstrap\\manifest-after.json",
+    "diffPath": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-56-53-322Z-empty-repo-bootstrap\\diff.json"
+  },
+  "reportDir": "C:\\projects\\governance-foundation\\vibegov-issue-9\\.internal\\bootstrap-validator\\reports\\2026-03-25T09-56-53-322Z-empty-repo-bootstrap"
+}

--- a/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/transcript.md
+++ b/.internal/bootstrap-validator/reports/2026-03-25T09-56-53-322Z-empty-repo-bootstrap/transcript.md
@@ -1,0 +1,181 @@
+--- attempt ollama:qwen2.5-coder:14b ---
+
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules",
+      "mkdir -p .governance/project",
+      "mkdir -p .governance/specs",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Plain-text report:**
+Created the following directories and files in the current repo:
+- `.governance/rules/`
+- `.governance/project/`
+- `.governance/specs/`
+Installed active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+Created `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+Created `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+
+Active governance sources:
+- Local VibeGov source at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+
+--- stderr ---
+OpenAI Codex v0.115.0-alpha.27 (research preview)
+--------
+workdir: C:\Users\MAXBAR~1\AppData\Local\Temp\vibegov-empty-repo-Ee0GWS
+model: qwen2.5-coder:14b
+provider: ollama
+approval: never
+sandbox: workspace-write [workdir, /tmp, $TMPDIR, C:\projects\governance-foundation\vibegov-issue-9, \\?\C:\Users\maxbarrass\AppData\Local\Temp\vibegov-codex-home-2fbe0259-29f0-4fdc-b54f-167bde0a8be2\memories]
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019d246c-a373-75c1-92af-34cf6ce0e68e
+--------
+user
+Bootstrap this repo with VibeGov using the local source made available to you.
+
+Before writing any product code:
+1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/` in the current repo.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+3. Create `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+4. Create `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+5. End your response with an exact line starting with: `Active governance sources:` followed by the source(s) you used.
+6. Stop before implementation.
+
+Do not ask follow-up questions.
+Do not implement product code.
+At the end, provide a short plain-text report of what you created.
+
+Local VibeGov source available for reference at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+Local VibeGov rules directory: C:/projects/governance-foundation/vibegov-issue-9/.governance/rules
+Local project template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md
+Local spec template path: C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md
+Read governance/templates from those local source paths instead of using remote URLs when possible.
+
+Validator constraints:
+- You are running inside a temporary fixture repo used only for bootstrap validation.
+- Follow the prompt literally.
+- If the scenario is bootstrap-only, stop before product implementation.
+- At the end, explicitly report the active governance sources you used.
+- Do not emit markdown fences unless needed.
+- If your runtime cannot execute tools directly, emit one JSON object with name set to shell and arguments.commands set to an ordered array of the exact file-system commands needed, then include the required plain-text report.
+Create at least one non-template spec file under .governance/specs/ (for example: bootstrap-governance-setup.md).
+
+
+warning: Disabled `js_repl` for this session because the configured Node runtime is unavailable or incompatible. Node runtime too old for js_repl (resolved C:\data\apps\#dev\nvm\node\v16.20.2\node.exe): found v16.20.2, requires >= v22.22.0. Install/update Node or set js_repl_node_path to a newer runtime.
+mcp startup: no servers
+warning: Model metadata for `qwen2.5-coder:14b` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.
+codex
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules",
+      "mkdir -p .governance/project",
+      "mkdir -p .governance/specs",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Plain-text report:**
+Created the following directories and files in the current repo:
+- `.governance/rules/`
+- `.governance/project/`
+- `.governance/specs/`
+Installed active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+Created `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+Created `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+
+Active governance sources:
+- Local VibeGov source at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+tokens used
+4,405
+
+--- last message ---
+```json
+{
+  "name": "shell",
+  "arguments": {
+    "commands": [
+      "mkdir -p .governance/rules",
+      "mkdir -p .governance/project",
+      "mkdir -p .governance/specs",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md",
+      "cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md"
+    ]
+  }
+}
+```
+
+**Plain-text report:**
+Created the following directories and files in the current repo:
+- `.governance/rules/`
+- `.governance/project/`
+- `.governance/specs/`
+Installed active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+Created `.governance/project/PROJECT.md` from the local `PROJECT_TEMPLATE.md`.
+Created `.governance/specs/bootstrap-governance-setup.md` from the local `SPEC_TEMPLATE.md`.
+
+Active governance sources:
+- Local VibeGov source at: C:/projects/governance-foundation/vibegov-issue-9/.governance
+
+--- adapter shell-plan execution ---
+$ mkdir -p .governance/rules
+Created directories: .governance/rules
+$ mkdir -p .governance/project
+Created directories: .governance/project
+$ mkdir -p .governance/specs
+Created directories: .governance/specs
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* .governance/rules/
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/rules/* to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-Ee0GWS/.governance/rules/ (8 item(s)).
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md .governance/project/PROJECT.md
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/project/PROJECT_TEMPLATE.md to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-Ee0GWS/.governance/project/PROJECT.md (1 item(s)).
+$ cp C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md .governance/specs/bootstrap-governance-setup.md
+Copied C:/projects/governance-foundation/vibegov-issue-9/.governance/specs/SPEC_TEMPLATE.md to C:/Users/MAXBAR~1/AppData/Local/Temp/vibegov-empty-repo-Ee0GWS/.governance/specs/bootstrap-governance-setup.md (1 item(s)).
+
+--- adapter attempts summary ---
+[
+  {
+    "id": "default",
+    "provider": "openai-codex",
+    "model": "gpt-5.4",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "default",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": false
+    }
+  },
+  {
+    "id": "ollama",
+    "provider": "ollama",
+    "model": "qwen2.5-coder:14b",
+    "exitKind": "completed",
+    "rawOutput": {
+      "attemptId": "ollama",
+      "status": 0,
+      "signal": null,
+      "error": null,
+      "completedFromLastMessage": false,
+      "shellPlanApplied": true
+    }
+  }
+]

--- a/.internal/bootstrap-validator/runners/README.md
+++ b/.internal/bootstrap-validator/runners/README.md
@@ -1,0 +1,14 @@
+# Runners
+
+This directory is reserved for bootstrap-validator runner code.
+
+Suggested entrypoints:
+- `run-scenario.ts` — run one scenario against one fixture
+- `run-suite.ts` — run a named set of scenarios and aggregate results
+
+A future runner should:
+1. reset a fixture into a temp repo
+2. execute a prompt through an agent adapter
+3. collect transcript + filesystem diff
+4. run assertions
+5. emit result JSON + evidence bundle

--- a/.internal/bootstrap-validator/scenarios/bootstrap-gate.json
+++ b/.internal/bootstrap-validator/scenarios/bootstrap-gate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../schemas/scenario.schema.json",
+  "id": "bootstrap-gate",
+  "fixture": "empty-repo",
+  "prompt": "bootstrap-gate.txt",
+  "mode": "bootstrap",
+  "timeoutMs": 300000,
+  "assertions": [
+    "governanceDirsExist",
+    "govRuleSetPresent",
+    "projectIntentCreated",
+    "firstSpecCreated",
+    "noProductCodeChanges",
+    "bootstrapStopDeclared"
+  ],
+  "weights": {
+    "bootstrapActivation": 25,
+    "noPrematureImplementation": 20,
+    "completionHonesty": 5
+  },
+  "notes": "Validates that bootstrap-only prompts stop before implementation."
+}

--- a/.internal/bootstrap-validator/scenarios/empty-repo-bootstrap.json
+++ b/.internal/bootstrap-validator/scenarios/empty-repo-bootstrap.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../schemas/scenario.schema.json",
+  "id": "empty-repo-bootstrap",
+  "fixture": "empty-repo",
+  "prompt": "canonical-bootstrap.txt",
+  "mode": "bootstrap",
+  "timeoutMs": 300000,
+  "assertions": [
+    "governanceDirsExist",
+    "govRuleSetPresent",
+    "projectIntentCreated",
+    "firstSpecCreated",
+    "noProductCodeChanges",
+    "governanceSourcesReported"
+  ],
+  "weights": {
+    "bootstrapActivation": 25,
+    "noPrematureImplementation": 20,
+    "governanceSourceHandling": 10
+  },
+  "notes": "Baseline bootstrap scenario for a repo with no governance present."
+}

--- a/.internal/bootstrap-validator/scenarios/exploratory-route.json
+++ b/.internal/bootstrap-validator/scenarios/exploratory-route.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schemas/scenario.schema.json",
+  "id": "exploratory-route",
+  "fixture": "bootstrapped-repo",
+  "prompt": "exploratory-route.txt",
+  "mode": "exploratory",
+  "timeoutMs": 240000,
+  "assertions": [
+    "exploratoryClassificationCoverage",
+    "artifactsForNonValidatedFindings",
+    "honestCompletenessLabel"
+  ],
+  "weights": {
+    "exploratoryRigor": 10,
+    "artifactQuality": 15,
+    "completionHonesty": 5
+  },
+  "notes": "Checks that a single-route exploratory review produces governed output rather than vague commentary."
+}

--- a/.internal/bootstrap-validator/scenarios/persistence-false-green.json
+++ b/.internal/bootstrap-validator/scenarios/persistence-false-green.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schemas/scenario.schema.json",
+  "id": "persistence-false-green",
+  "fixture": "persistence-false-green",
+  "prompt": "exploratory-route.txt",
+  "mode": "exploratory",
+  "timeoutMs": 240000,
+  "assertions": [
+    "persistenceVerificationMentioned",
+    "artifactsForNonValidatedFindings",
+    "honestCompletenessLabel"
+  ],
+  "weights": {
+    "exploratoryRigor": 10,
+    "artifactQuality": 15,
+    "completionHonesty": 5
+  },
+  "notes": "Tests that UI success is not accepted as proof when persistence actually fails."
+}

--- a/.internal/bootstrap-validator/scenarios/suite-core.json
+++ b/.internal/bootstrap-validator/scenarios/suite-core.json
@@ -1,0 +1,11 @@
+{
+  "id": "core",
+  "description": "Minimum useful bootstrap-validator scenario set",
+  "scenarios": [
+    "empty-repo-bootstrap",
+    "bootstrap-gate",
+    "under-specified-issue",
+    "exploratory-route",
+    "persistence-false-green"
+  ]
+}

--- a/.internal/bootstrap-validator/scenarios/suite-phase1.json
+++ b/.internal/bootstrap-validator/scenarios/suite-phase1.json
@@ -1,0 +1,8 @@
+{
+  "id": "phase1",
+  "description": "Runnable phase-1 bootstrap validator MVP scenarios",
+  "scenarios": [
+    "empty-repo-bootstrap",
+    "bootstrap-gate"
+  ]
+}

--- a/.internal/bootstrap-validator/scenarios/under-specified-issue.json
+++ b/.internal/bootstrap-validator/scenarios/under-specified-issue.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schemas/scenario.schema.json",
+  "id": "under-specified-issue",
+  "fixture": "bootstrapped-repo",
+  "prompt": "under-specified-issue.txt",
+  "mode": "development",
+  "timeoutMs": 240000,
+  "assertions": [
+    "specGapOrRequirementBinding",
+    "issueQualitySufficient",
+    "noProductCodeChanges"
+  ],
+  "weights": {
+    "artifactQuality": 15,
+    "modeCorrectness": 15,
+    "noPrematureImplementation": 20
+  },
+  "notes": "Ensures a vague implementation request is hardened before code changes begin."
+}

--- a/.internal/bootstrap-validator/schemas/result.schema.json
+++ b/.internal/bootstrap-validator/schemas/result.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://governance-foundation.github.io/vibegov.io/schemas/bootstrap-validator/result.schema.json",
+  "title": "Bootstrap Validator Result",
+  "type": "object",
+  "required": ["scenarioId", "passed", "hardFailure", "score", "assertions"],
+  "properties": {
+    "scenarioId": { "type": "string" },
+    "provider": { "type": "string" },
+    "model": { "type": "string" },
+    "passed": { "type": "boolean" },
+    "hardFailure": { "type": "boolean" },
+    "score": { "type": "number", "minimum": 0, "maximum": 100 },
+    "classification": { "type": "string" },
+    "durationMs": { "type": "integer", "minimum": 0 },
+    "assertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "passed", "severity"],
+        "properties": {
+          "id": { "type": "string" },
+          "passed": { "type": "boolean" },
+          "severity": { "type": "string", "enum": ["hard", "soft"] },
+          "note": { "type": "string" },
+          "evidence": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "properties": {
+        "filesCreated": { "type": "array", "items": { "type": "string" } },
+        "filesModified": { "type": "array", "items": { "type": "string" } },
+        "issues": { "type": "array", "items": { "type": "string" } },
+        "specGaps": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.internal/bootstrap-validator/schemas/scenario.schema.json
+++ b/.internal/bootstrap-validator/schemas/scenario.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://governance-foundation.github.io/vibegov.io/schemas/bootstrap-validator/scenario.schema.json",
+  "title": "Bootstrap Validator Scenario",
+  "type": "object",
+  "required": ["id", "fixture", "prompt", "mode", "assertions"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "fixture": { "type": "string", "minLength": 1 },
+    "prompt": { "type": "string", "minLength": 1 },
+    "mode": { "type": "string", "enum": ["bootstrap", "exploratory", "development", "release-verification"] },
+    "timeoutMs": { "type": "integer", "minimum": 1 },
+    "assertions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "weights": {
+      "type": "object",
+      "additionalProperties": { "type": "number", "minimum": 0 }
+    },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add the bootstrap-validator harness and codex-cli live adapter implementation
- include the prompt/scenario/assertion/reporting scaffolding for bootstrap validation
- harden bootstrap-gate behavior and preserve evidence capture

## Closes
- closes #9

## Validation
- npm ci
- npm run build

## Notes
This is an older branch carrying the bootstrap-validator work; I’ve revalidated the branch locally before opening the PR.