### PR TITLE
Add clean-session bootstrap validation

### DIFF
--- a/.governance/specs/bootstrap-validator-live-adapter.md
+++ b/.governance/specs/bootstrap-validator-live-adapter.md
@@ -11,6 +11,8 @@ In scope:
 - `BV-LA-004` prepare temporary fixture repos so the chosen live agent can execute safely
 - `BV-LA-005` document how to run the validator with the live adapter
 - `BV-LA-006` validate at least one real-agent bootstrap scenario and preserve evidence under `.internal/bootstrap-validator/reports/`
+- `BV-CS-002` execute a real-agent bootstrap scenario against explicit clean-session conditions using an isolated temporary session home
+- `BV-CS-003` document the clean-session validation command and evidence contract truthfully
 
 Out of scope:
 - multi-provider orchestration
@@ -25,10 +27,13 @@ Out of scope:
 - `BV-LA-004` temporary fixture repos are initialized in a way compatible with the chosen agent runtime.
 - `BV-LA-005` `.internal/bootstrap-validator/README.md` documents live-adapter execution and limitations.
 - `BV-LA-006` a successful real-agent report bundle is generated and referenced in issue evidence.
+- `BV-CS-002` the live adapter records the isolated temp repo/session-home boundaries used for a clean-session run.
+- `BV-CS-003` README and public validation docs name the clean-session command/path and its `session.json` evidence contract.
 
 ## Tests and Evidence
 - `npm run bootstrap-validator -- --scenario empty-repo-bootstrap --adapter codex-cli`
 - `npm run bootstrap-validator -- --scenario bootstrap-gate --adapter codex-cli`
+- `npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session --adapter codex-cli`
 - `npm run bootstrap-validator -- --suite phase1 --adapter local-stub`
 - `npm run typecheck`
 - `npm run build`

--- a/.governance/specs/bootstrap-validator-phase-1.md
+++ b/.governance/specs/bootstrap-validator-phase-1.md
@@ -13,6 +13,7 @@ In scope:
 - `BV-P1-006` core assertion engine for bootstrap-only checks
 - `BV-P1-007` result JSON plus evidence bundle output under `.internal/bootstrap-validator/reports/`
 - `BV-P1-008` npm scripts and internal run documentation
+- `BV-CS-001` explicit clean-session bootstrap scenario metadata and report evidence for fresh-session validation
 
 Out of scope:
 - real external provider execution
@@ -29,10 +30,12 @@ Out of scope:
 - `BV-P1-006` assertions cover governance directories, rule set presence, project intent creation, first spec creation, product-code protection, governance source reporting, and bootstrap stop declaration.
 - `BV-P1-007` each run writes a normalized result object and transcript/evidence files below `.internal/bootstrap-validator/reports/`.
 - `BV-P1-008` execution steps are documented in `.internal/bootstrap-validator/README.md`.
+- `BV-CS-001` the harness can load a clean-session bootstrap scenario and emit explicit `session.json` evidence alongside the standard report bundle.
 
 ## Tests and Evidence
 - `npm run bootstrap-validator -- --scenario empty-repo-bootstrap`
 - `npm run bootstrap-validator -- --scenario bootstrap-gate`
+- `npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session`
 - `npm run bootstrap-validator -- --suite phase1`
 - `npm run typecheck`
 

--- a/.internal/bootstrap-validator/README.md
+++ b/.internal/bootstrap-validator/README.md
@@ -14,6 +14,7 @@ It validates bootstrap behavior programmatically using:
 
 Runnable now:
 - `empty-repo-bootstrap`
+- `empty-repo-bootstrap-clean-session`
 - `bootstrap-gate`
 - suite: `phase1`
 
@@ -33,9 +34,11 @@ From repo root:
 ```bash
 npm run bootstrap-validator -- --list
 npm run bootstrap-validator -- --scenario empty-repo-bootstrap
+npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session
 npm run bootstrap-validator -- --scenario bootstrap-gate
 npm run bootstrap-validator -- --suite phase1
 npm run bootstrap-validator -- --scenario empty-repo-bootstrap --adapter codex-cli
+npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session --adapter codex-cli
 npm run bootstrap-validator -- --scenario bootstrap-gate --adapter codex-cli
 ```
 
@@ -46,8 +49,9 @@ For each runnable scenario, the harness:
 2. captures a pre-run manifest
 3. runs the selected adapter (`local-stub` or `codex-cli` today)
 4. captures a post-run manifest and diff
-5. executes core assertions
-6. writes an evidence bundle under `.internal/bootstrap-validator/reports/`
+5. for `cleanSession: true` scenarios, records explicit session-isolation evidence
+6. executes core assertions
+7. writes an evidence bundle under `.internal/bootstrap-validator/reports/`
 
 ## Evidence bundle contents
 
@@ -57,6 +61,7 @@ Each run writes a timestamped report directory containing:
 - `manifest-after.json`
 - `diff.json`
 - `result.json`
+- `session.json` for clean-session scenarios
 
 ## Assertion coverage in phase 1
 
@@ -68,6 +73,7 @@ Implemented assertions:
 - `noProductCodeChanges`
 - `governanceSourcesReported`
 - `bootstrapStopDeclared`
+- `cleanSessionIsolationConfirmed`
 
 ## Layout
 
@@ -85,6 +91,7 @@ Implemented assertions:
 - `codex-cli` is the first live adapter, but scope is still bootstrap-only
 - bootstrap-only scenarios are the only supported live flows today
 - live-agent behavior can vary by model/runtime availability and prompt fidelity
+- clean-session validation proves only fresh-session bootstrap conditions encoded by the harness today: temp fixture repo plus isolated temp `CODEX_HOME`/`HOME`/`USERPROFILE`, with `session.json` written as evidence
 - `codex-cli` may retry against a local Ollama runtime when the default provider cannot complete the bootstrap run
 - no advanced schema validation or HTML reporting yet
 

--- a/.internal/bootstrap-validator/index.js
+++ b/.internal/bootstrap-validator/index.js
@@ -16,7 +16,7 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log(`VibeGov Bootstrap Validator\n\nUsage:\n  npm run bootstrap-validator -- --scenario <id> [--adapter local-stub|codex-cli]\n  npm run bootstrap-validator -- --suite <id> [--adapter local-stub|codex-cli]\n  npm run bootstrap-validator -- --list\n\nExamples:\n  npm run bootstrap-validator -- --scenario empty-repo-bootstrap\n  npm run bootstrap-validator -- --scenario bootstrap-gate\n  npm run bootstrap-validator -- --scenario empty-repo-bootstrap --adapter codex-cli\n  npm run bootstrap-validator -- --suite phase1\n`);
+  console.log(`VibeGov Bootstrap Validator\n\nUsage:\n  npm run bootstrap-validator -- --scenario <id> [--adapter local-stub|codex-cli]\n  npm run bootstrap-validator -- --suite <id> [--adapter local-stub|codex-cli]\n  npm run bootstrap-validator -- --list\n\nExamples:\n  npm run bootstrap-validator -- --scenario empty-repo-bootstrap\n  npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session\n  npm run bootstrap-validator -- --scenario bootstrap-gate\n  npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session --adapter codex-cli\n  npm run bootstrap-validator -- --suite phase1\n`);
 }
 
 async function main() {

--- a/.internal/bootstrap-validator/lib/adapters/codex-cli.js
+++ b/.internal/bootstrap-validator/lib/adapters/codex-cli.js
@@ -345,16 +345,18 @@ function resolveCodexRuntime() {
 function createIsolatedCodexHome(sourceHome) {
   const isolatedHome = path.join(os.tmpdir(), `vibegov-codex-home-${randomUUID()}`);
   ensureDir(isolatedHome);
-  if (!sourceHome || !fs.existsSync(sourceHome)) return isolatedHome;
+  const copiedFiles = [];
+  if (!sourceHome || !fs.existsSync(sourceHome)) return { isolatedHome, copiedFiles };
 
   for (const fileName of ['config.toml', 'auth.json']) {
     const sourceFile = path.join(sourceHome, fileName);
     if (fs.existsSync(sourceFile)) {
       fs.copyFileSync(sourceFile, path.join(isolatedHome, fileName));
+      copiedFiles.push(fileName);
     }
   }
 
-  return isolatedHome;
+  return { isolatedHome, copiedFiles };
 }
 
 function hasAuth(sourceHome) {
@@ -411,7 +413,7 @@ function hasBootstrapArtifacts(repoPath) {
 }
 
 async function runCodexAttempt({ runtime, prompt, rootDir, repoPath, scenario, attempt, timeoutMs }) {
-  const isolatedHome = createIsolatedCodexHome(runtime.codexHome);
+  const { isolatedHome, copiedFiles } = createIsolatedCodexHome(runtime.codexHome);
   const lastMessagePath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-last-message.txt`);
   const promptPath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-prompt.txt`);
   const scriptPath = path.join(os.tmpdir(), `vibegov-codex-${randomUUID()}-runner.ps1`);
@@ -529,6 +531,17 @@ async function runCodexAttempt({ runtime, prompt, rootDir, repoPath, scenario, a
       transcript,
       shellPlanApplied,
       hasBootstrapArtifacts: hasBootstrapArtifacts(repoPath),
+      sessionEvidence: {
+        requested: Boolean(scenario.cleanSession),
+        adapter: 'codex-cli',
+        repoPath,
+        repoPathIsTemp: repoPath.startsWith(os.tmpdir()),
+        isolatedHomePath: isolatedHome,
+        isolatedHomeIsTemp: isolatedHome.startsWith(os.tmpdir()),
+        sourceCodexHome: runtime.codexHome || null,
+        copiedFiles,
+        homeEnvOverrides: ['CODEX_HOME', 'HOME', 'USERPROFILE'],
+      },
       rawOutput: {
         attemptId: attempt.id,
         status: exitInfo.exitCode,
@@ -600,6 +613,7 @@ async function run({ rootDir, validatorDir, repoPath, scenario }) {
         adapterId: 'codex-cli',
         provider: result.provider,
         model: result.model,
+        sessionEvidence: result.sessionEvidence,
       };
     }
   }
@@ -617,6 +631,7 @@ async function run({ rootDir, validatorDir, repoPath, scenario }) {
     adapterId: 'codex-cli',
     provider: fallback.provider,
     model: fallback.model,
+    sessionEvidence: attemptResults[attemptResults.length - 1]?.sessionEvidence || null,
   };
 }
 

--- a/.internal/bootstrap-validator/lib/adapters/local-stub.js
+++ b/.internal/bootstrap-validator/lib/adapters/local-stub.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { ensureDir, writeText } = require('../fs-utils');
 
 function copyFile(src, dest) {
@@ -38,15 +39,28 @@ function buildTranscript(scenarioId) {
 }
 
 async function run({ rootDir, repoPath, scenario }) {
-  if (!['empty-repo-bootstrap', 'bootstrap-gate'].includes(scenario.id)) {
+  if (!['empty-repo-bootstrap', 'bootstrap-gate', 'empty-repo-bootstrap-clean-session'].includes(scenario.id)) {
     throw new Error(`local-stub adapter does not support scenario: ${scenario.id}`);
   }
   installGovernance(rootDir, repoPath);
+  const sessionEvidence = scenario.cleanSession
+    ? {
+        requested: true,
+        adapter: 'local-stub',
+        repoPath,
+        repoPathIsTemp: repoPath.startsWith(os.tmpdir()),
+        isolatedHomePath: path.join(os.tmpdir(), 'local-stub-clean-session'),
+        isolatedHomeIsTemp: true,
+        homeEnvOverrides: ['CODEX_HOME', 'HOME', 'USERPROFILE'],
+        note: 'local-stub models clean-session evidence deterministically for harness coverage.',
+      }
+    : null;
   return {
     transcript: buildTranscript(scenario.id),
     rawOutput: { adapter: 'local-stub', scenarioId: scenario.id },
     exitKind: 'completed',
     durationMs: 25,
+    sessionEvidence,
   };
 }
 

--- a/.internal/bootstrap-validator/lib/assertions.js
+++ b/.internal/bootstrap-validator/lib/assertions.js
@@ -26,6 +26,10 @@ function makeResult(id, passed, severity, note, evidence) {
   return { id, passed, severity, note, evidence };
 }
 
+function isTruthyPath(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+
 const handlers = {
   governanceDirsExist(ctx) {
     const required = ['.governance/rules', '.governance/project', '.governance/specs'];
@@ -60,6 +64,28 @@ const handlers = {
   bootstrapStopDeclared(ctx) {
     const ok = /stopping before product implementation|stopped before product-code implementation/i.test(ctx.transcript);
     return makeResult('bootstrapStopDeclared', ok, 'hard', ok ? 'Transcript declares bootstrap stop gate.' : 'Transcript missing stop declaration.', []);
+  },
+  cleanSessionIsolationConfirmed(ctx) {
+    if (!ctx.scenario.cleanSession) {
+      return makeResult('cleanSessionIsolationConfirmed', true, 'soft', 'Scenario does not request clean-session validation.', []);
+    }
+    const evidence = ctx.sessionEvidence || {};
+    const checks = [
+      ['requested', evidence.requested === true],
+      ['repoPath', isTruthyPath(evidence.repoPath)],
+      ['repoPathIsTemp', evidence.repoPathIsTemp === true],
+      ['isolatedHomePath', isTruthyPath(evidence.isolatedHomePath)],
+      ['isolatedHomeIsTemp', evidence.isolatedHomeIsTemp === true],
+      ['homeEnvOverrides', Array.isArray(evidence.homeEnvOverrides) && evidence.homeEnvOverrides.includes('CODEX_HOME') && evidence.homeEnvOverrides.includes('HOME') && evidence.homeEnvOverrides.includes('USERPROFILE')],
+    ];
+    const missing = checks.filter(([, passed]) => !passed).map(([name]) => name);
+    return makeResult(
+      'cleanSessionIsolationConfirmed',
+      missing.length === 0,
+      'hard',
+      missing.length ? `Missing clean-session evidence: ${missing.join(', ')}` : 'Clean-session isolation evidence recorded.',
+      Object.entries(evidence).map(([key, value]) => `${key}=${Array.isArray(value) ? value.join(',') : value}`),
+    );
   },
 };
 

--- a/.internal/bootstrap-validator/lib/report.js
+++ b/.internal/bootstrap-validator/lib/report.js
@@ -18,7 +18,7 @@ function computeScore(assertions) {
   return Math.round((passed / assertions.length) * 100);
 }
 
-function writeReport({ validatorDir, scenarioId, transcript, manifestBefore, manifestAfter, diff, assertions, artifacts, durationMs, adapterId, provider, model, exitKind, rawOutput }) {
+function writeReport({ validatorDir, scenarioId, transcript, manifestBefore, manifestAfter, diff, assertions, artifacts, durationMs, adapterId, provider, model, exitKind, rawOutput, sessionEvidence }) {
   const reportDir = path.join(validatorDir, 'reports', `${nowStamp()}-${scenarioId}`);
   ensureDir(reportDir);
   const score = computeScore(assertions);
@@ -42,6 +42,7 @@ function writeReport({ validatorDir, scenarioId, transcript, manifestBefore, man
       manifestBeforePath: path.join(reportDir, 'manifest-before.json'),
       manifestAfterPath: path.join(reportDir, 'manifest-after.json'),
       diffPath: path.join(reportDir, 'diff.json'),
+      ...(sessionEvidence ? { sessionPath: path.join(reportDir, 'session.json') } : {}),
     },
     reportDir,
   };
@@ -49,6 +50,7 @@ function writeReport({ validatorDir, scenarioId, transcript, manifestBefore, man
   writeJson(path.join(reportDir, 'manifest-before.json'), manifestBefore);
   writeJson(path.join(reportDir, 'manifest-after.json'), manifestAfter);
   writeJson(path.join(reportDir, 'diff.json'), diff);
+  if (sessionEvidence) writeJson(path.join(reportDir, 'session.json'), sessionEvidence);
   writeJson(path.join(reportDir, 'result.json'), result);
   return result;
 }

--- a/.internal/bootstrap-validator/lib/runner.js
+++ b/.internal/bootstrap-validator/lib/runner.js
@@ -29,6 +29,7 @@ async function executeScenario({ validatorDir, rootDir, scenario, adapterId }) {
     const adapter = getAdapter(adapterId);
     const runResult = await adapter.run({ rootDir, validatorDir, repoPath, scenario });
     transcript = runResult.transcript || '';
+    const sessionEvidence = runResult.sessionEvidence || null;
     const manifestAfter = createManifest(repoPath);
     const diff = diffManifests(manifestBefore, manifestAfter);
     const assertions = runAssertions(scenario.assertions, {
@@ -38,6 +39,7 @@ async function executeScenario({ validatorDir, rootDir, scenario, adapterId }) {
       manifestAfter,
       diff,
       scenario,
+      sessionEvidence,
     });
     return writeReport({
       validatorDir,
@@ -54,6 +56,7 @@ async function executeScenario({ validatorDir, rootDir, scenario, adapterId }) {
       model: runResult.model || 'n/a',
       exitKind: runResult.exitKind,
       rawOutput: runResult.rawOutput || null,
+      sessionEvidence,
     });
   } finally {
     removeDir(repoPath);

--- a/.internal/bootstrap-validator/scenarios/empty-repo-bootstrap-clean-session.json
+++ b/.internal/bootstrap-validator/scenarios/empty-repo-bootstrap-clean-session.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../schemas/scenario.schema.json",
+  "id": "empty-repo-bootstrap-clean-session",
+  "fixture": "empty-repo",
+  "prompt": "canonical-bootstrap.txt",
+  "mode": "bootstrap",
+  "timeoutMs": 300000,
+  "cleanSession": true,
+  "assertions": [
+    "governanceDirsExist",
+    "govRuleSetPresent",
+    "projectIntentCreated",
+    "firstSpecCreated",
+    "noProductCodeChanges",
+    "governanceSourcesReported",
+    "cleanSessionIsolationConfirmed"
+  ],
+  "weights": {
+    "bootstrapActivation": 25,
+    "noPrematureImplementation": 20,
+    "governanceSourceHandling": 10
+  },
+  "notes": "Runs empty-repo bootstrap with explicit clean-session isolation evidence and reporting. Prefer --adapter codex-cli for live validation."
+}

--- a/.internal/bootstrap-validator/scenarios/suite-phase1.json
+++ b/.internal/bootstrap-validator/scenarios/suite-phase1.json
@@ -3,6 +3,7 @@
   "description": "Runnable phase-1 bootstrap validator MVP scenarios",
   "scenarios": [
     "empty-repo-bootstrap",
+    "empty-repo-bootstrap-clean-session",
     "bootstrap-gate"
   ]
 }

--- a/.internal/bootstrap-validator/schemas/scenario.schema.json
+++ b/.internal/bootstrap-validator/schemas/scenario.schema.json
@@ -10,6 +10,7 @@
     "prompt": { "type": "string", "minLength": 1 },
     "mode": { "type": "string", "enum": ["bootstrap", "exploratory", "development", "release-verification"] },
     "timeoutMs": { "type": "integer", "minimum": 1 },
+    "cleanSession": { "type": "boolean" },
     "assertions": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 },

--- a/docs/bootstrap-validation.md
+++ b/docs/bootstrap-validation.md
@@ -165,11 +165,28 @@ Report what governance sources are active when done.
 - assert no product code files were changed
 - assert transcript includes governance-source report
 
+### Clean-session contract
+For first-run bootstrap confidence, this scenario also needs an explicit fresh-session path.
+
+A **clean session** means:
+- the repo under test is a newly prepared temporary fixture repo
+- the live adapter runs with an isolated temporary session home instead of reusing the caller's warmed runtime state
+- only minimal runtime bootstrap material needed to authenticate/configure the agent may be copied in
+- the evidence bundle records those session-isolation conditions for audit
+
+Recommended live command:
+- `npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session --adapter codex-cli`
+
+Expected clean-session evidence:
+- report directory contains `session.json`
+- `session.json` records temp repo path, isolated temp home path, and the overridden home/session environment variables
+
 ### Fail conditions
 - product code edited
 - missing rule files
 - no spec/project artifact
 - governance sources not reported
+- clean-session run reuses an unbounded prior session home without recording the isolation boundary
 
 ---
 

--- a/docs/bootstrap-validator-harness.md
+++ b/docs/bootstrap-validator-harness.md
@@ -203,6 +203,7 @@ Suggested scenario JSON shape:
   "prompt": "canonical-bootstrap.txt",
   "mode": "bootstrap",
   "timeoutMs": 300000,
+  "cleanSession": false,
   "assertions": [
     "governanceDirsExist",
     "govRuleSetPresent",
@@ -217,6 +218,8 @@ Suggested scenario JSON shape:
   }
 }
 ```
+
+For live-agent bootstrap confidence, `cleanSession: true` means the adapter must prove it used a fresh temporary fixture repo plus an isolated temporary session home, then write that proof into the evidence bundle.
 
 ## Result schema
 
@@ -256,7 +259,8 @@ Suggested shape:
     "transcriptPath": "reports/.../transcript.md",
     "diffPath": "reports/.../diff.json",
     "manifestBeforePath": "reports/.../before.json",
-    "manifestAfterPath": "reports/.../after.json"
+    "manifestAfterPath": "reports/.../after.json",
+    "sessionPath": "reports/.../session.json"
   }
 }
 ```
@@ -283,6 +287,9 @@ These are the first assertions worth implementing:
 - `honestCompletenessLabel`
 - `releaseDecisionPresent`
 - `blockerClassificationPresent`
+
+### Session isolation
+- `cleanSessionIsolationConfirmed`
 
 ### Artifact quality
 - `exploratoryArtifactsLinked`
@@ -370,6 +377,7 @@ A lightweight CLI could look like this:
 
 ```text
 npm run bootstrap-validator -- --scenario empty-repo-bootstrap
+npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session --adapter codex-cli
 npm run bootstrap-validator -- --suite core
 npm run bootstrap-validator -- --suite full --provider openclaw-main
 npm run bootstrap-validator -- --scenario exploratory-route --report


### PR DESCRIPTION
## Summary
- add explicit clean-session bootstrap validation coverage
- record session-isolation evidence in validator reports
- update docs/spec traceability for the clean-session contract

## Closes
- closes #11

## Validation
- npm run bootstrap-validator -- --scenario empty-repo-bootstrap
- npm run bootstrap-validator -- --scenario empty-repo-bootstrap-clean-session
- npm run build

## Notes
The live codex clean-session path now produces explicit session evidence, but the current environment still has a provider/auth issue preventing a full green live run.