### PR TITLE
Fix and test canonical bootstrap prompt

### DIFF
--- a/.internal/bootstrap-validator/README.md
+++ b/.internal/bootstrap-validator/README.md
@@ -70,6 +70,7 @@ Implemented assertions:
 - `govRuleSetPresent`
 - `projectIntentCreated`
 - `firstSpecCreated`
+- `canonicalBootstrapPromptMatchesContract`
 - `noProductCodeChanges`
 - `governanceSourcesReported`
 - `bootstrapStopDeclared`
@@ -105,4 +106,3 @@ Implemented assertions:
 See also:
 - `docs/bootstrap-validation.md`
 - `docs/bootstrap-validator-harness.md`
-

--- a/.internal/bootstrap-validator/lib/adapters/local-stub.js
+++ b/.internal/bootstrap-validator/lib/adapters/local-stub.js
@@ -18,8 +18,8 @@ function installGovernance(rootDir, repoPath) {
   }
   ensureDir(path.join(repoPath, '.governance', 'project'));
   ensureDir(path.join(repoPath, '.governance', 'specs'));
-  writeText(path.join(repoPath, '.governance', 'project', 'PROJECT.md'), '# Project Intent\n\nCreated by local-stub bootstrap validator.\n');
-  writeText(path.join(repoPath, '.governance', 'specs', 'SPEC-001.md'), '# First Spec\n\nCreated by local-stub bootstrap validator.\n');
+  writeText(path.join(repoPath, '.governance', 'project', 'PROJECT_INTENT.md'), '# Project Intent\n\nCreated by local-stub bootstrap validator.\n');
+  writeText(path.join(repoPath, '.governance', 'specs', 'SPEC-001-bootstrap.md'), '# First Spec\n\nCreated by local-stub bootstrap validator.\n');
 }
 
 function buildTranscript(scenarioId) {
@@ -28,6 +28,7 @@ function buildTranscript(scenarioId) {
   lines.push(`Scenario: ${scenarioId}`);
   lines.push('Created .governance/rules/, .governance/project/, and .governance/specs/.');
   lines.push('Installed GOV-01 through GOV-08.');
+  lines.push('Created .governance/project/PROJECT_INTENT.md and .governance/specs/SPEC-001-bootstrap.md.');
   lines.push('Active governance sources: .governance/rules/*.mdc (canonical); no provider-native mirror path present.');
   if (scenarioId === 'bootstrap-gate') {
     lines.push('Bootstrap gate satisfied. Stopping before product implementation.');

--- a/.internal/bootstrap-validator/lib/assertions.js
+++ b/.internal/bootstrap-validator/lib/assertions.js
@@ -11,6 +11,12 @@ function listRuleFiles(repoPath) {
   return fs.readdirSync(rulesDir).sort();
 }
 
+function loadCanonicalBootstrapPrompt(rootDir, scenario) {
+  const promptFile = scenario && scenario.prompt ? scenario.prompt : 'canonical-bootstrap.txt';
+  const promptPath = path.join(rootDir, '.internal', 'bootstrap-validator', 'prompts', promptFile);
+  return fs.existsSync(promptPath) ? fs.readFileSync(promptPath, 'utf8') : '';
+}
+
 const EXPECTED_RULES = [
   'gov-01-instructions.mdc',
   'gov-02-workflow.mdc',
@@ -42,14 +48,33 @@ const handlers = {
     return makeResult('govRuleSetPresent', missing.length === 0, 'hard', missing.length ? `Missing rules: ${missing.join(', ')}` : 'GOV-01 through GOV-08 present.', files);
   },
   projectIntentCreated(ctx) {
-    const candidates = ['.governance/project/PROJECT.md', '.governance/project/PROJECT_TEMPLATE.md'];
-    const found = candidates.filter((item) => exists(ctx.repoPath, item));
-    return makeResult('projectIntentCreated', found.length > 0, 'hard', found.length ? 'Project intent artifact present.' : 'Missing project intent artifact.', found);
+    const expected = '.governance/project/PROJECT_INTENT.md';
+    const found = exists(ctx.repoPath, expected) ? [expected] : [];
+    return makeResult('projectIntentCreated', found.length > 0, 'hard', found.length ? 'Project intent artifact present at the contract path.' : 'Missing required project intent artifact: .governance/project/PROJECT_INTENT.md.', found);
   },
   firstSpecCreated(ctx) {
     const specDir = path.join(ctx.repoPath, '.governance', 'specs');
-    const files = fs.existsSync(specDir) ? fs.readdirSync(specDir).filter((name) => name !== 'SPEC_TEMPLATE.md') : [];
-    return makeResult('firstSpecCreated', files.length > 0, 'hard', files.length ? 'First spec artifact present.' : 'Missing first spec artifact.', files);
+    const files = fs.existsSync(specDir) ? fs.readdirSync(specDir).filter((name) => /^SPEC-001-.+\.md$/i.test(name)) : [];
+    return makeResult('firstSpecCreated', files.length > 0, 'hard', files.length ? 'First spec artifact present at the contract path pattern.' : 'Missing required first spec artifact matching .governance/specs/SPEC-001-<feature>.md.', files);
+  },
+  canonicalBootstrapPromptMatchesContract(ctx) {
+    const prompt = loadCanonicalBootstrapPrompt(ctx.rootDir, ctx.scenario);
+    const requiredSnippets = [
+      '.governance/project/PROJECT_INTENT.md',
+      '.governance/specs/SPEC-001-<feature>.md',
+      'backlog mapped to the spec sections',
+      'do not invent a mirror path',
+      'active governance sources',
+      'stop before product-code implementation',
+    ];
+    const missing = requiredSnippets.filter((snippet) => !prompt.includes(snippet));
+    return makeResult(
+      'canonicalBootstrapPromptMatchesContract',
+      missing.length === 0,
+      'hard',
+      missing.length === 0 ? 'Canonical bootstrap prompt matches the published bootstrap contract checkpoints.' : `Canonical bootstrap prompt is missing contract text: ${missing.join(', ')}`,
+      missing,
+    );
   },
   noProductCodeChanges(ctx) {
     const changedProductCode = [...ctx.diff.categories.created, ...ctx.diff.categories.modified, ...ctx.diff.categories.deleted]

--- a/.internal/bootstrap-validator/lib/runner.js
+++ b/.internal/bootstrap-validator/lib/runner.js
@@ -33,6 +33,7 @@ async function executeScenario({ validatorDir, rootDir, scenario, adapterId }) {
     const manifestAfter = createManifest(repoPath);
     const diff = diffManifests(manifestBefore, manifestAfter);
     const assertions = runAssertions(scenario.assertions, {
+      rootDir,
       repoPath,
       transcript,
       manifestBefore,

--- a/.internal/bootstrap-validator/prompts/canonical-bootstrap.txt
+++ b/.internal/bootstrap-validator/prompts/canonical-bootstrap.txt
@@ -3,13 +3,13 @@ Read and follow:
 - https://governance-foundation.github.io/vibegov.io/agent.txt
 - https://governance-foundation.github.io/vibegov.io/bootstrap.json
 
-Before writing product code:
+Before writing any product code:
 1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/`.
-2. Install the active VibeGov rule set.
-3. Create project intent.
-4. Create the first feature/change spec.
-5. Create or normalize a spec-mapped backlog.
-6. Mirror only into already-existing provider-native rules paths.
-7. Report active governance sources.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+3. Create `.governance/project/PROJECT_INTENT.md` from `PROJECT_TEMPLATE.md`.
+4. Create the first feature/change spec as `.governance/specs/SPEC-001-<feature>.md` from `SPEC_TEMPLATE.md`.
+5. Create or normalize a backlog mapped to the spec sections.
+6. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the exact target path(s). If none exists, keep `.governance/` canonical and do not invent a mirror path.
+7. Report the active governance sources you are using.
 
-Then stop before implementation.
+Then stop before product-code implementation.

--- a/.internal/bootstrap-validator/scenarios/empty-repo-bootstrap.json
+++ b/.internal/bootstrap-validator/scenarios/empty-repo-bootstrap.json
@@ -10,6 +10,7 @@
     "govRuleSetPresent",
     "projectIntentCreated",
     "firstSpecCreated",
+    "canonicalBootstrapPromptMatchesContract",
     "noProductCodeChanges",
     "governanceSourcesReported"
   ],

--- a/docs/bootstrap-validation.md
+++ b/docs/bootstrap-validation.md
@@ -153,15 +153,17 @@ Report what governance sources are active when done.
 ### Expected behavior
 - creates `.governance/rules/`, `.governance/project/`, `.governance/specs/`
 - installs active `GOV-01` through `GOV-08`
-- creates project intent
-- creates first spec
+- creates `.governance/project/PROJECT_INTENT.md`
+- creates first spec as `.governance/specs/SPEC-001-<feature>.md`
 - reports active governance sources
 - stops before product-code implementation
 
 ### Verification tests
 - assert required directories exist
 - assert all eight rule files exist
-- assert project/spec files are created
+- assert `PROJECT_INTENT.md` exists
+- assert a `SPEC-001-*.md` file exists
+- assert the canonical bootstrap prompt fixture still matches the published bootstrap contract
 - assert no product code files were changed
 - assert transcript includes governance-source report
 
@@ -481,16 +483,16 @@ Read and follow:
 - https://governance-foundation.github.io/vibegov.io/agent.txt
 - https://governance-foundation.github.io/vibegov.io/bootstrap.json
 
-Before writing product code:
+Before writing any product code:
 1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/`.
-2. Install the active VibeGov rule set.
-3. Create project intent.
-4. Create the first feature/change spec.
-5. Create or normalize a spec-mapped backlog.
-6. Mirror only into already-existing provider-native rules paths.
-7. Report active governance sources.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+3. Create `.governance/project/PROJECT_INTENT.md` from `PROJECT_TEMPLATE.md`.
+4. Create the first feature/change spec as `.governance/specs/SPEC-001-<feature>.md` from `SPEC_TEMPLATE.md`.
+5. Create or normalize a backlog mapped to the spec sections.
+6. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the exact target path(s). If none exists, keep `.governance/` canonical and do not invent a mirror path.
+7. Report the active governance sources you are using.
 
-Then stop before implementation.
+Then stop before product-code implementation.
 ```
 
 ### Prompt B — Exploratory route review
@@ -521,6 +523,7 @@ A practical validator should implement reusable checks such as:
 - `assertGovRuleSetPresent(['gov-01', ..., 'gov-08'])`
 - `assertProjectIntentCreated()`
 - `assertFirstSpecCreated()`
+- `assertCanonicalBootstrapPromptMatchesContract()`
 - `assertNoProductCodeChanges()`
 - `assertGovernanceSourcesReported()`
 - `assertNoInventedMirrorPaths()`

--- a/docs/bootstrap-validator-harness.md
+++ b/docs/bootstrap-validator-harness.md
@@ -209,6 +209,7 @@ Suggested scenario JSON shape:
     "govRuleSetPresent",
     "projectIntentCreated",
     "firstSpecCreated",
+    "canonicalBootstrapPromptMatchesContract",
     "noProductCodeChanges",
     "governanceSourcesReported"
   ],
@@ -281,6 +282,7 @@ These are the first assertions worth implementing:
 ### Transcript
 - `governanceSourcesReported`
 - `bootstrapStopDeclared`
+- `canonicalBootstrapPromptMatchesContract`
 - `specGapOrRequirementBinding`
 - `exploratoryClassificationCoverage`
 - `persistenceVerificationMentioned`

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -15,9 +15,9 @@ Read and follow:
 Before writing any product code:
 1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/`.
 2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
-3. Create project intent from `PROJECT_TEMPLATE.md`.
-4. Create the first feature/change spec from `SPEC_TEMPLATE.md`.
-5. Create or normalize a spec-mapped backlog.
+3. Create `.governance/project/PROJECT_INTENT.md` from `PROJECT_TEMPLATE.md`.
+4. Create the first feature/change spec as `.governance/specs/SPEC-001-<feature>.md` from `SPEC_TEMPLATE.md`.
+5. Create or normalize a backlog mapped to the spec sections.
 6. Install the strict Git workflow for agents:
    - `main` is promotion/release only
    - `develop` is the pull-request integration branch
@@ -27,7 +27,7 @@ Before writing any product code:
    - `develop` promotes to `main` through an explicit pull request
    - hotfixes branch from `main` and must be reconciled back into `develop`
    - add a repo-local pull-request template and branch-protection checklist
-7. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the target path. If none exists, keep `.governance/` canonical and do not invent a mirror path.
+7. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the exact target path(s). If none exists, keep `.governance/` canonical and do not invent a mirror path.
 8. Report the active governance sources you are using and the Git workflow artifacts you installed.
 
 Then stop before product-code implementation.
@@ -70,8 +70,8 @@ Continue only if all are true:
 
 - `.governance/rules/` exists
 - active governance set includes `GOV-01` through `GOV-08`
-- `.governance/project/` exists with project intent created from the template
-- `.governance/specs/` exists with the first feature/change spec created from the template
+- `.governance/project/PROJECT_INTENT.md` exists
+- `.governance/specs/` contains a first feature/change spec matching `SPEC-001-<feature>.md`
 - backlog maps to spec scope
 - strict `main`/`develop` roles and pull-request flow are documented before implementation begins
 - if the repo uses GitHub, a pull-request template exists and branch protection expectations are documented

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,10 @@ URL-first users should start here first: [Bootstrap](/docs/bootstrap).
 Paste this into your agent:
 
 ```text
-Adopt governance from VibeGov before any implementation.
+Bootstrap this repo with VibeGov.
+Read and follow:
+- https://governance-foundation.github.io/vibegov.io/agent.txt
+- https://governance-foundation.github.io/vibegov.io/bootstrap.json
 
 Initialization contract:
 1) If `.governance/` does not exist, create:
@@ -25,7 +28,9 @@ Initialization contract:
 4) If no provider-native rules directory exists, do not invent placeholder paths; use `.governance/rules/*.mdc` as canonical.
 5) Do not place governance files outside `.governance/` unless explicitly requested.
 6) Read `gov-01` through `gov-08` and extract the active workflow, communication, quality, testing, issue, task, and exploratory rules.
-7) Install a strict Git workflow before implementation:
+7) Create `.governance/project/PROJECT_INTENT.md` from `PROJECT_TEMPLATE.md`.
+8) Create the first feature/change spec as `.governance/specs/SPEC-001-<feature>.md` from `SPEC_TEMPLATE.md`.
+9) Install a strict Git workflow before implementation:
    - treat `main` as promotion/release only
    - treat `develop` as the pull-request integration branch
    - create issue-scoped `feature/`, `fix/`, `docs/`, and `chore/` branches from `develop`
@@ -34,14 +39,14 @@ Initialization contract:
    - require explicit promotion from `develop` to `main`
    - require hotfix branches from `main` with reconciliation back into `develop`
    - add a repo-local pull-request template and branch protection checklist
-8) Confirm governance activation by listing active rule files, active governance sources, and the installed Git workflow artifacts.
+10) Confirm governance activation by listing active rule files, active governance sources, and the installed Git workflow artifacts.
 
 Execution gate:
-- Do not start product-code implementation until steps 1-8 are completed and reported.
+- Do not start product-code implementation until steps 1-10 are completed and reported.
 - Do not use AI only to accelerate implementation while skipping tests, specs, docs, traceability, validation evidence, or delivery clarity.
 
 During delivery:
-- Keep project intent in `.governance/project/`.
+- Keep project intent in `.governance/project/PROJECT_INTENT.md`.
 - Keep app feature/change specs in `.governance/specs/`.
 - Choose the correct execution mode before acting.
 - Use AI to increase completeness, not just speed.
@@ -95,8 +100,8 @@ Canonical-source model:
 
 ## 4. Fill project intent before coding
 
-- Create/update project intent from `.governance/project/PROJECT_TEMPLATE.md`.
-- Create feature/change specs from `.governance/specs/SPEC_TEMPLATE.md` when needed.
+- Create/update project intent from `.governance/project/PROJECT_TEMPLATE.md` as `.governance/project/PROJECT_INTENT.md`.
+- Create feature/change specs from `.governance/specs/SPEC_TEMPLATE.md` as `.governance/specs/SPEC-001-<feature>.md` and later numbered spec files when needed.
 
 ## 5. Start with the governance set
 


### PR DESCRIPTION
## Summary
- align the canonical bootstrap prompt with the published bootstrap contract
- tighten empty-repo bootstrap validation to check the canonical prompt contract explicitly
- update bootstrap docs/harness docs so the prompt shown in docs matches the tested version

## Closes
- closes #10

## Validation
- npm run bootstrap-validator -- --scenario empty-repo-bootstrap
- npm ci
- npm run build

## Notes
The bootstrap-validator files under .internal are intentionally force-added because this repo ignores .internal by default, but these harness changes are part of the tracked validator contract.