### PR TITLE
Add explicit test execution expectations to governance

### DIFF
--- a/.governance/rules/gov-04-quality.mdc
+++ b/.governance/rules/gov-04-quality.mdc
@@ -68,6 +68,12 @@ Do not confuse these with trustworthy completion:
 
 AI makes it easier to generate the appearance of completeness. Governance must distinguish appearance-of-completion from trustworthy completion.
 
+Verification review should also make explicit:
+- which scenario classes were exercised
+- what proof is direct vs surrogate-only
+- what remains unverified, blocked, or deferred
+- what follow-up artifact was created for missing completeness
+
 ## Definition of Done (Quality View)
 
 Done means:

--- a/.governance/rules/gov-05-testing.mdc
+++ b/.governance/rules/gov-05-testing.mdc
@@ -37,6 +37,63 @@ For governed delivery, link tests back to:
 OpenSpec-first rule:
 - if required behavior is not represented in OpenSpec, add/update requirement IDs before marking coverage complete.
 
+## Test Execution Expectations
+
+For each meaningful test run, explicitly consider:
+- the exact claim / requirement / acceptance criterion under test
+- which scenario classes were exercised
+- which scenario classes were blocked, deferred, or not applicable
+- what kind of evidence was produced
+- whether the evidence directly proves the claim or only a proxy
+- what remains unverified and what follow-up artifact was created
+
+## Scenario Coverage Expectations
+
+Consider these scenario classes where relevant:
+- happy path
+- invalid input
+- empty state
+- loading state
+- error state
+- cancel/back-out path
+- persistence/refresh behavior
+- downstream side effects
+- role/permission variation
+- keyboard/accessibility path
+
+Not every change needs every scenario class, but the execution record should make coverage boundaries visible.
+
+## Result Classification
+
+Meaningful test outcomes should be classifiable as:
+- `Verified`
+- `Invalidated`
+- `Blocked`
+- `Deferred`
+- `Not applicable`
+
+This helps prevent weak “green enough” reporting.
+
+## Proof Strength
+
+Evidence should be judged honestly:
+- **direct proof** — clearly proves the intended behavior
+- **partial proof** — proves only part of the claim
+- **surrogate-only proof** — proves a proxy, not the actual outcome
+
+Passing build output, a success toast, or a 200 response is not always direct proof of the intended behavior.
+
+## Persistence and Post-Action Proof
+
+When work changes persisted, synced, deleted, or otherwise durable state, verification should check the post-action reality where relevant:
+- refresh/reload state
+- source-of-truth state
+- downstream consumer state
+- deletion/removal persistence
+- sync behavior after the action
+
+UI-only success must not be treated as sufficient proof for mutation-heavy work.
+
 ## Execution Expectations
 
 - run targeted tests during iteration
@@ -45,6 +102,7 @@ OpenSpec-first rule:
 - avoid marking complete without evidence
 - generated tests only count when they actually prove the intended behavior or requirement
 - passing tests are evidence only when the asserted behavior matches the governed claim
+- if meaningful coverage is missing, create follow-up work instead of silently treating the gap as acceptable
 
 ## Test Quality Anti-Patterns
 
@@ -52,3 +110,5 @@ OpenSpec-first rule:
 - broad snapshot assertions without intent
 - coverage metrics used without behavioral relevance
 - tests that pass but do not prove the requirement
+- partial coverage reported as full validation
+- surrogate-only proof reported as direct proof

--- a/.governance/specs/test-execution-expectations.md
+++ b/.governance/specs/test-execution-expectations.md
@@ -1,0 +1,64 @@
+# Test Execution Expectations
+
+## Intent
+Define explicit test-execution expectations for VibeGov so teams know what to inspect, classify, and record when running tests. The goal is to make test execution reviewable, proportional to risk, and hard to overclaim.
+
+## Scope
+In scope:
+- define a reusable test execution checklist
+- define scenario classes that should be considered during meaningful test runs
+- define test result classifications
+- define proof-strength expectations
+- require persistence/post-action proof where relevant
+- require missing test completeness to become tracked follow-up work
+
+Out of scope:
+- framework-specific automation implementation details
+- replacing all current testing/validation docs
+- organization-specific reporting dashboards
+
+## Acceptance Criteria
+- `TEST-EXEC-001` VibeGov publishes a clear test execution expectations/checklist doc.
+- `TEST-EXEC-002` GOV-05 explicitly covers scenario classes, result classifications, proof strength, and persistence/post-action proof.
+- `TEST-EXEC-003` Governance requires missing test completeness to become tracked follow-up work rather than remain invisible.
+- `TEST-EXEC-004` Testing expectations remain proportional to work type and risk.
+- `TEST-EXEC-005` `npm run build` succeeds after the changes.
+
+## Core Execution Questions
+Every meaningful test run should be able to answer:
+1. What exact claim, requirement, or acceptance criterion is under test?
+2. Which scenario classes were exercised, and which were not applicable, deferred, or blocked?
+3. What kind of evidence was produced?
+4. Does the evidence directly prove the claimed behavior, or only a proxy?
+5. What remains unverified, blocked, or deferred?
+6. What follow-up work was created because of missing completeness?
+
+## Scenario Classes
+Scenario classes to consider where relevant:
+- happy path
+- invalid input
+- empty state
+- loading state
+- error state
+- cancel/back-out path
+- persistence/refresh behavior
+- downstream side effects
+- role/permission variation
+- keyboard/accessibility path
+
+## Result Classifications
+Expected execution classifications:
+- `Verified`
+- `Invalidated`
+- `Blocked`
+- `Deferred`
+- `Not applicable`
+
+## Proof Strength
+Evidence should be classified by strength where useful:
+- direct proof
+- partial proof
+- surrogate-only proof
+
+## Missing Completeness Rule
+If meaningful scenario coverage, persistence proof, or evidence clarity is missing, the gap must become tracked work (issue, debt item, blocker artifact, or explicit deferred follow-up).

--- a/docs/bootstrap-validation.md
+++ b/docs/bootstrap-validation.md
@@ -108,6 +108,14 @@ Check that issues/specs/tasks include:
 - verification path
 - explicit `SPEC_GAP` when contract is missing
 
+### 5. Test-execution assertions
+Check that meaningful validation output can answer:
+- what exact claim/requirement was under test
+- which scenario classes were exercised
+- which scenario classes were blocked, deferred, or not applicable
+- whether the proof is direct or only a proxy
+- what remains unverified and what follow-up artifact was created
+
 ## Scoring model
 
 Use a simple weighted score:

--- a/docs/test-execution-expectations.md
+++ b/docs/test-execution-expectations.md
@@ -1,0 +1,144 @@
+---
+sidebar_position: 11
+---
+
+# Test Execution Expectations
+
+This doc exists to answer a simple question:
+
+> When we execute a test, what exactly are we supposed to look for?
+
+VibeGov already treats tests as proof of delivery claims. This checklist makes the execution side more explicit so test runs become reviewable, comparable, and harder to overclaim.
+
+## Core rule
+
+A test run should not just say that something passed.
+It should say:
+- what claim was under test
+- which scenario classes were exercised
+- what kind of proof was produced
+- what remains unverified, blocked, or deferred
+- what follow-up work was created because of missing completeness
+
+## 1. Claim under test
+
+State the exact thing the test run is trying to prove:
+- requirement ID
+- acceptance criterion
+- behavior statement
+- contract statement
+
+Weak signal:
+- “ran tests”
+
+Strong signal:
+- “verified REQ-123 persistence behavior after save + reload”
+
+## 2. Scenario classes reviewed
+
+Consider these scenario classes where relevant:
+- happy path
+- invalid input
+- empty state
+- loading state
+- error state
+- cancel/back-out path
+- persistence/refresh behavior
+- downstream side effects
+- role/permission variation
+- keyboard/accessibility path
+
+Not every change needs every scenario class, but meaningful test execution should say which classes were:
+- exercised
+- not applicable
+- deferred
+- blocked
+
+## 3. Evidence type
+
+State what kind of evidence was used:
+- unit
+- integration
+- end-to-end
+- regression
+- manual proof
+- smoke/release verification
+- contract verification
+
+The point is not to maximize ceremony. The point is to make the proof legible.
+
+## 4. Result classification
+
+Use one of these classifications for each meaningful claim or scenario:
+- **Verified**
+- **Invalidated**
+- **Blocked**
+- **Deferred**
+- **Not applicable**
+
+This prevents weak “green enough” reporting.
+
+## 5. Proof strength
+
+Ask whether the evidence is:
+- **Direct proof** — clearly proves the claimed behavior
+- **Partial proof** — proves only part of the claim
+- **Surrogate-only proof** — proves a proxy, not the actual outcome
+
+Examples of weak surrogate-only proof:
+- success toast shown
+- API returned 200
+- page rendered
+- build passed
+
+Examples of stronger direct proof:
+- persisted state survives reload
+- downstream state/source-of-truth changed correctly
+- role restriction actually enforced
+- failure path behaves as specified
+
+## 6. Persistence and post-action proof
+
+When the work changes saved, synced, deleted, or otherwise durable state, testing should look beyond immediate UI feedback.
+
+Check for things like:
+- state after refresh/reload
+- source-of-truth state changed
+- downstream consumer sees the change
+- deleted item is actually gone
+- sync behavior is correct
+
+UI success alone is not enough proof for mutation-heavy work.
+
+## 7. Residuals and follow-up
+
+A strong test run should end by stating:
+- what remains unverified
+- what was blocked
+- what was deferred
+- what assumptions still exist
+- what follow-up artifact was created
+
+Missing test completeness must become tracked work, not invisible compromise.
+
+## Fast execution template
+
+Use this template when reviewing a meaningful test run:
+
+- **Claim under test:**
+- **Requirement / acceptance criterion:**
+- **Scenario classes exercised:**
+- **Scenario classes not applicable / deferred / blocked:**
+- **Evidence type:**
+- **Result classification:**
+- **Proof strength:**
+- **Persistence/post-action checks:**
+- **Residual risks / unverified items:**
+- **Follow-up artifact(s) created:**
+
+## Related docs
+
+- [Bootstrap Validation](/docs/bootstrap-validation)
+- [Workflow Quality Rubric](/docs/workflow-quality-rubric)
+- [Published GOV-05 Testing](/docs/published/gov-05-testing)
+- [Published GOV-04 Quality](/docs/published/gov-04-quality)

--- a/docs/workflow-quality-rubric.md
+++ b/docs/workflow-quality-rubric.md
@@ -39,6 +39,7 @@ Strong signal:
 Questions:
 - Does the workflow require a scenario matrix or only suggest one?
 - Are minimum scenario categories explicit?
+- Does test execution record which scenario classes were verified, blocked, deferred, or not applicable?
 
 Weak signal:
 - "test the main flow"
@@ -50,6 +51,7 @@ Strong signal:
 Questions:
 - Does the workflow require verification of resulting state after save/mutate/delete/sync actions?
 - Does it prevent UI-only success claims?
+- Does it distinguish direct proof from surrogate-only proof?
 
 Weak signal:
 - success toast treated as proof


### PR DESCRIPTION
## Summary
- add a dedicated test execution expectations doc
- add the supporting spec for test execution expectations
- harden GOV testing/quality/rubric docs around scenario classes, result classifications, proof strength, persistence proof, and tracked follow-up for missing test completeness

## Closes
- closes #32

## Validation
- npm ci
- npm run build

## Notes
This makes test execution expectations explicit so teams know what to inspect, classify, and record during meaningful test runs.