### PR TITLE
Add release artifact build and test-prep scripts

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build site
-        run: npm run build
+      - name: Build release artifact
+        run: npm run release:build
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ yarn-error.log*
 .internal/
 internal/
 dist/
+artifacts/
 

--- a/.governance/specs/release-artifact-and-test-prep.md
+++ b/.governance/specs/release-artifact-and-test-prep.md
@@ -1,0 +1,34 @@
+# Release Artifact and Test Prep
+
+## Intent
+Provide a canonical release-artifact build path and a reusable test-prep path so VibeGov can build the same release candidate locally and in CI, then package that candidate into a timestamped/SHA-stamped test-run folder with artifact identity, governance context, and result placeholders.
+
+## Scope
+In scope:
+- define a canonical release-artifact build script aligned to CI
+- define a test-prep script that consumes the release artifact
+- define the minimum files copied into the test-run folder
+- document how the scripts should be used
+
+Out of scope:
+- full deployment orchestration beyond current Pages build/upload behavior
+- framework-specific runtime test automation beyond packaging the candidate for execution
+
+## Acceptance Criteria
+- `REL-ART-001` A release-artifact script builds the release candidate and packages it under `artifacts/release/<sha>/`.
+- `REL-ART-002` The release artifact includes the built artifact, artifact manifest, and checksums.
+- `REL-ART-003` A test-prep script creates a timestamp+SHA test-run folder under `artifacts/test-runs/`.
+- `REL-ART-004` The test-run folder includes the release artifact plus governance references and execution/result placeholders.
+- `REL-ART-005` CI uses the same release-artifact build script instead of duplicating build logic.
+- `REL-ART-006` `npm run build` succeeds after the changes.
+
+## Minimum Test Prep Contents
+A prepared test-run folder should contain:
+- copied release artifact
+- `artifact-manifest.json`
+- `checksums.txt`
+- copied `.governance/specs/`
+- copied testing/completeness rubric references
+- test execution checklist template
+- prior-validation summary placeholder
+- result/log/screenshot folders

--- a/docs/release-artifact-and-test-prep.md
+++ b/docs/release-artifact-and-test-prep.md
@@ -1,0 +1,106 @@
+---
+sidebar_position: 10
+---
+
+# Release Artifact and Test Prep
+
+VibeGov now uses two linked scripts for release validation:
+
+1. **build the release artifact**
+2. **prepare a governed test-run folder from that artifact**
+
+The goal is simple: the candidate you test locally should come from the same build path used by CI, and the test run should start with enough context to be trustworthy and repeatable.
+
+## Scripts
+
+### Build release artifact
+
+```bash
+npm run release:build
+```
+
+This script:
+- runs the site build
+- packages the built artifact under `artifacts/release/<short-sha>/artifact/`
+- generates `artifact-manifest.json`
+- generates `checksums.txt`
+
+### Prepare test run
+
+```bash
+npm run test:prepare
+```
+
+This script:
+- locates the latest release artifact (or accepts an explicit one)
+- creates a timestamp + SHA folder under `artifacts/test-runs/`
+- copies the release artifact into that folder
+- copies governance references and checklists
+- creates result/log/screenshot placeholders for the run
+
+## Output structure
+
+### Release artifact output
+
+```text
+artifacts/
+  release/
+    <short-sha>/
+      artifact/
+      artifact-manifest.json
+      checksums.txt
+```
+
+### Test run output
+
+```text
+artifacts/
+  test-runs/
+    <timestamp>_<short-sha>/
+      artifact/
+      governance/
+        artifact-manifest.json
+        checksums.txt
+        specs/
+        test-execution-expectations.md
+        quality-scaffolding-and-completeness-rubric.md
+        change-summary.md
+      evidence/
+        prior-validation/
+          validation-summary.md
+      execution/
+        test-execution-checklist.md
+        results/
+        logs/
+        screenshots/
+      run-manifest.json
+```
+
+## What gets copied into the test folder
+
+The prepared folder copies:
+- the built release artifact
+- artifact identity metadata
+- checksums
+- `.governance/specs/`
+- testing expectations reference
+- quality/completeness rubric reference
+- a test execution checklist template
+- prior validation summary placeholder
+- empty result/log/screenshot folders
+
+This gives the test runner four immediate answers:
+1. what exact candidate is being tested
+2. what it is supposed to do
+3. what governance/testing context applies
+4. where to record the test run
+
+## CI alignment
+
+The GitHub Pages workflow should call the same release-artifact build script rather than duplicating build logic. That keeps local and CI candidates aligned.
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Test Execution Expectations](/docs/test-execution-expectations)
+- [Quality Scaffolding and Completeness Rubric](/docs/quality-scaffolding-and-completeness-rubric)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "start": "docusaurus start --host localhost",
     "start:3005": "docusaurus start --host localhost --port 3005",
     "build": "docusaurus build",
+    "release:build": "node scripts/build-release-artifact.js",
+    "test:prepare": "node scripts/prepare-test-run.js",
     "serve:test": "docusaurus serve --host localhost --port 3000",
     "serve:3005": "docusaurus serve --host localhost --port 3005",
     "test:e2e": "cypress run --spec cypress/e2e/site-smoke.cy.js",

--- a/scripts/build-release-artifact.js
+++ b/scripts/build-release-artifact.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const cp = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const buildDir = path.join(repoRoot, 'build');
+const artifactsRoot = path.join(repoRoot, 'artifacts', 'release');
+
+function run(command, args, options = {}) {
+  cp.execFileSync(command, args, {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+    ...options,
+  });
+}
+
+function capture(command, args, fallback = '') {
+  try {
+    return cp.execFileSync(command, args, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: process.platform === 'win32',
+    }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function removeDir(dir) {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function copyDir(src, dest) {
+  ensureDir(dest);
+  fs.cpSync(src, dest, { recursive: true, force: true });
+}
+
+function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+function walkFiles(dir, baseDir = dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath, baseDir));
+    } else {
+      files.push({
+        fullPath,
+        relativePath: path.relative(baseDir, fullPath).replace(/\\/g, '/'),
+      });
+    }
+  }
+  return files;
+}
+
+function checksumDirectory(dir) {
+  return walkFiles(dir).map(({ fullPath, relativePath }) => ({
+    path: relativePath,
+    sha256: sha256File(fullPath),
+    bytes: fs.statSync(fullPath).size,
+  }));
+}
+
+function main() {
+  const commitSha = capture('git', ['rev-parse', 'HEAD'], 'unknown');
+  const shortSha = capture('git', ['rev-parse', '--short', 'HEAD'], 'unknown');
+  const branch = capture('git', ['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown');
+  const timestamp = new Date().toISOString();
+
+  run('npm', ['run', 'build']);
+
+  if (!fs.existsSync(buildDir)) {
+    throw new Error('Expected build/ directory was not produced by npm run build.');
+  }
+
+  const releaseDir = path.join(artifactsRoot, shortSha);
+  const artifactDir = path.join(releaseDir, 'artifact');
+  removeDir(releaseDir);
+  ensureDir(releaseDir);
+  copyDir(buildDir, artifactDir);
+
+  const checksums = checksumDirectory(artifactDir);
+  const manifest = {
+    kind: 'vibegov-release-artifact',
+    createdAt: timestamp,
+    sourceRepo: 'governance-foundation/vibegov.io',
+    branch,
+    commitSha,
+    shortSha,
+    buildCommand: 'npm run build',
+    artifactRoot: 'artifact',
+    artifactType: 'docusaurus-static-site',
+    artifactFileCount: checksums.length,
+    artifactFiles: checksums,
+  };
+
+  fs.writeFileSync(path.join(releaseDir, 'artifact-manifest.json'), JSON.stringify(manifest, null, 2));
+  fs.writeFileSync(
+    path.join(releaseDir, 'checksums.txt'),
+    checksums.map((item) => `${item.sha256}  artifact/${item.path}`).join('\n') + '\n'
+  );
+
+  console.log(`Release artifact created: ${releaseDir}`);
+}
+
+main();

--- a/scripts/prepare-test-run.js
+++ b/scripts/prepare-test-run.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const cp = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const releaseRoot = path.join(repoRoot, 'artifacts', 'release');
+const testRoot = path.join(repoRoot, 'artifacts', 'test-runs');
+
+function capture(command, args, fallback = '') {
+  try {
+    return cp.execFileSync(command, args, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: process.platform === 'win32',
+    }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function copyIfExists(src, dest) {
+  if (!fs.existsSync(src)) return false;
+  ensureDir(path.dirname(dest));
+  fs.cpSync(src, dest, { recursive: true, force: true });
+  return true;
+}
+
+function latestReleaseDir() {
+  if (!fs.existsSync(releaseRoot)) {
+    throw new Error('No release artifacts found. Run npm run release:build first.');
+  }
+  const dirs = fs.readdirSync(releaseRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      name: entry.name,
+      fullPath: path.join(releaseRoot, entry.name),
+      mtimeMs: fs.statSync(path.join(releaseRoot, entry.name)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  if (!dirs.length) {
+    throw new Error('No release artifact directories found. Run npm run release:build first.');
+  }
+  return dirs[0].fullPath;
+}
+
+function main() {
+  const releaseDir = process.argv[2] ? path.resolve(repoRoot, process.argv[2]) : latestReleaseDir();
+  const manifestPath = path.join(releaseDir, 'artifact-manifest.json');
+
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`Missing artifact-manifest.json in release dir: ${releaseDir}`);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const ts = new Date().toISOString().replace(/[:]/g, '-').replace(/\..+$/, '');
+  const runDirName = `${ts}_${manifest.shortSha}`;
+  const runDir = path.join(testRoot, runDirName);
+
+  ensureDir(runDir);
+  ensureDir(path.join(runDir, 'artifact'));
+  ensureDir(path.join(runDir, 'governance', 'specs'));
+  ensureDir(path.join(runDir, 'evidence', 'prior-validation'));
+  ensureDir(path.join(runDir, 'execution', 'results'));
+  ensureDir(path.join(runDir, 'execution', 'logs'));
+  ensureDir(path.join(runDir, 'execution', 'screenshots'));
+
+  copyIfExists(path.join(releaseDir, 'artifact'), path.join(runDir, 'artifact'));
+  copyIfExists(path.join(releaseDir, 'artifact-manifest.json'), path.join(runDir, 'governance', 'artifact-manifest.json'));
+  copyIfExists(path.join(releaseDir, 'checksums.txt'), path.join(runDir, 'governance', 'checksums.txt'));
+  copyIfExists(path.join(repoRoot, '.governance', 'specs'), path.join(runDir, 'governance', 'specs'));
+  copyIfExists(path.join(repoRoot, 'docs', 'test-execution-expectations.md'), path.join(runDir, 'governance', 'test-execution-expectations.md'));
+  copyIfExists(path.join(repoRoot, 'docs', 'quality-scaffolding-and-completeness-rubric.md'), path.join(runDir, 'governance', 'quality-scaffolding-and-completeness-rubric.md'));
+
+  const issueSummary = [
+    '# Test Run Summary',
+    '',
+    `- Source repo: governance-foundation/vibegov.io`,
+    `- Commit SHA: ${manifest.commitSha}`,
+    `- Short SHA: ${manifest.shortSha}`,
+    `- Branch: ${manifest.branch}`,
+    `- Release artifact source: ${releaseDir}`,
+    '',
+    '## Testing focus',
+    '- Verify the candidate against the intended change set and relevant governance/spec expectations.',
+    '- Record verified, invalidated, blocked, deferred, and not-applicable results explicitly.',
+    '- Convert missing completeness into tracked follow-up work instead of leaving it invisible.',
+    '',
+  ].join('\n');
+
+  const checklist = [
+    '# Test Execution Checklist',
+    '',
+    '- Claim under test:',
+    '- Requirement / acceptance criterion:',
+    '- Scenario classes exercised:',
+    '- Scenario classes blocked / deferred / not applicable:',
+    '- Evidence type:',
+    '- Result classification (Verified / Invalidated / Blocked / Deferred / Not applicable):',
+    '- Proof strength (direct / partial / surrogate-only):',
+    '- Persistence / post-action checks:',
+    '- Residual risks / unverified items:',
+    '- Follow-up artifact(s) created:',
+    '',
+  ].join('\n');
+
+  const validationSummary = [
+    '# Prior Validation Summary',
+    '',
+    `- Build command: ${manifest.buildCommand}`,
+    '- Copy any existing test/build/bootstrap validation evidence into this folder if you want it bundled with the run.',
+    '',
+  ].join('\n');
+
+  fs.writeFileSync(path.join(runDir, 'governance', 'change-summary.md'), issueSummary);
+  fs.writeFileSync(path.join(runDir, 'evidence', 'prior-validation', 'validation-summary.md'), validationSummary);
+  fs.writeFileSync(path.join(runDir, 'execution', 'test-execution-checklist.md'), checklist);
+
+  const metadata = {
+    kind: 'vibegov-test-run',
+    createdAt: new Date().toISOString(),
+    commitSha: manifest.commitSha,
+    shortSha: manifest.shortSha,
+    branch: manifest.branch,
+    releaseDir,
+    runDir,
+  };
+  fs.writeFileSync(path.join(runDir, 'run-manifest.json'), JSON.stringify(metadata, null, 2));
+
+  console.log(`Prepared test run folder: ${runDir}`);
+}
+
+main();

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,7 @@ const sidebars = {
         'checkpoint-reporting',
         'blocker-escalation',
         'workflow-quality-rubric',
+        'release-artifact-and-test-prep',
       ],
     },
     {


### PR DESCRIPTION
## Summary
- add a canonical release-artifact build script aligned with the current CI build path
- add a test-prep script that creates a timestamped and SHA-stamped validation folder
- generate artifact manifest/checksums plus governed test-run scaffolding
- update Pages CI to call the reusable release build script

## Closes
- closes #34

## Validation
- npm ci
- npm run release:build
- npm run test:prepare
- npm run build

## Notes
This creates one reusable release-artifact path for both CI and local validation prep, instead of duplicating build logic in multiple places.