### PR TITLE
#43 fix homepage bootstrap entrypoints and FAQ

### DIFF
--- a/.governance/specs/homepage-bootstrap-entrypoints-and-faq.md
+++ b/.governance/specs/homepage-bootstrap-entrypoints-and-faq.md
@@ -1,0 +1,27 @@
+# Homepage Bootstrap Entrypoints and FAQ
+
+## Intent
+Make the public VibeGov homepage understandable to normal humans while preserving the short quick-path model for bootstrap entrypoints.
+
+## Scope
+In scope:
+- short homepage bootstrap init entrypoint
+- short homepage bootstrap update entrypoint
+- short homepage bootstrap feedback entrypoint
+- homepage FAQ section
+- clearer human-readable hero/tagline/lead copy
+- real linked docs/routes for the homepage entrypoints
+
+Out of scope:
+- broader site redesign
+- long inline prompt walls on the homepage
+- unrelated docs cleanup outside the homepage entrypoint flow
+
+## Acceptance Criteria
+- `HOME-BOOT-001` Homepage shows a short Bootstrap Init Prompt that points to a real canonical doc/route.
+- `HOME-BOOT-002` Homepage shows a short Bootstrap Update Prompt that points to a real canonical doc/route.
+- `HOME-BOOT-003` Homepage shows a short Bootstrap Feedback Prompt that points to a real canonical doc/route.
+- `HOME-BOOT-004` Homepage includes an FAQ section that answers the most basic user questions in plain language.
+- `HOME-BOOT-005` Homepage hero/tagline/lead copy is understandable to normal humans and explains what VibeGov is for.
+- `HOME-BOOT-006` Homepage-linked entrypoint docs exist and match the intended init/update/feedback behavior.
+- `HOME-BOOT-007` `npm run build` succeeds after the changes.

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 5
+---
+
+# Bootstrap Feedback Prompt
+
+Use this after a fresh bootstrap or bootstrap-update run when you want an agent to tell you what VibeGov still underspecified.
+
+```text
+Please review the bootstrap/setup process you just executed for this repo and tell me what VibeGov could do better.
+
+Focus on:
+- what was underspecified or ambiguous
+- what prerequisites or permissions were missing
+- what should have been checked earlier
+- what artifacts or files should have been created earlier
+- what branch / board / GitHub behavior was unclear
+- what assumptions you had to invent
+- what should be mandatory next time
+- what exact wording or rules would have made bootstrap smoother
+
+Return:
+1. a short summary of the biggest problems
+2. a bullet list of concrete improvements VibeGov should make
+3. any exact prompt/rule wording you recommend
+```

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 3
+---
+
+# Bootstrap Update
+
+Copy this as message 1 in any coding agent when the repo already has some VibeGov bootstrap state and you want the agent to repair, tighten, or normalize it.
+
+```text
+Update this repo's VibeGov bootstrap state.
+Read and follow:
+- https://governance-foundation.github.io/vibegov.io/agent.txt
+- https://governance-foundation.github.io/vibegov.io/bootstrap.json
+
+This is an update/remediation pass, not a fresh bootstrap.
+Do not restart from scratch if useful governance artifacts already exist.
+
+Before writing any product code:
+1. Inspect the existing `.governance/`, `AGENTS.md`, project intent, specs, and backlog state.
+2. Repair or normalize missing or weak bootstrap artifacts while preserving valid existing work.
+3. Keep `.governance/` canonical and report the active governance sources in use.
+4. If project intent or the first spec is weak, tighten it honestly instead of inventing fake product direction.
+5. Normalize backlog/spec traceability so the repo is ready for governed next-step work.
+6. If a provider-native rules directory already exists, keep it aligned with `.governance/rules/*.mdc` and report the exact target path(s).
+7. Report exactly what was repaired, what was preserved, and what still needs follow-up.
+
+Then stop before product-code implementation.
+```

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -33,6 +33,17 @@ Use the [Branch Protection Checklist](/docs/branch-protection-checklist) when se
 - After a hotfix lands in `main`, back-merge or otherwise reconcile it into `develop` immediately.
 - Record promotion scope, hotfix reason, and any back-merge reference in the related pull request.
 
+## Bootstrap adoption feedback
+
+If you have just run a fresh bootstrap or an update/remediation pass, use the [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt) and paste the result into an issue.
+
+That feedback is especially useful when it captures:
+- what was underspecified or ambiguous
+- what files should have been created earlier
+- what GitHub scopes or permissions were missing
+- what branch / board / PR behavior was unclear
+- what exact wording would have made bootstrap smoother
+
 ## Strong contribution targets
 
 Especially useful contributions include:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'VibeGov',
-  tagline: 'Portable delivery judgement for AI-assisted software.',
+  tagline: 'Governance for AI-assisted software delivery.',
   favicon: 'img/vibegov-icon.svg',
 
   // Set the production url of your site here

--- a/sidebars.js
+++ b/sidebars.js
@@ -16,7 +16,9 @@ const sidebars = {
   docsSidebar: [
     'intro',
     'bootstrap',
+    'bootstrap-update',
     'quickstart',
+    'bootstrap-feedback-prompt',
     'branch-protection-checklist',
     'vibegov-sdlc',
     'contribute',

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -39,13 +39,6 @@
   line-height: 1.6;
 }
 
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
-    text-align: center;
-  }
-}
-
 .actions {
   display: flex;
   gap: 0.8rem;
@@ -53,32 +46,75 @@
   margin-top: 1.3rem;
 }
 
-
-.quickStart {
-  padding: 2.5rem 0;
-  background: #ffffff;
+.section,
+.sectionAlt {
+  padding: 4rem 0;
 }
 
-[data-theme='dark'] .quickStart {
-  background: #0f172a;
+.sectionAlt {
+  background: var(--ifm-color-emphasis-100);
 }
 
-.promptBlock {
-  margin-top: 1rem;
-  background: #0b1220;
-  color: #dbeafe;
-  border-radius: 0.7rem;
-  padding: 1rem;
-  border: 1px solid #1e293b;
-  overflow-x: auto;
+.sectionHeader {
+  max-width: 52rem;
+  margin-bottom: 2rem;
+}
+
+.sectionHeader h2 {
+  margin-bottom: 0.5rem;
+}
+
+.sectionHeader p {
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+.cardGrid,
+.faqList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+
+.card,
+.faqItem {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: var(--ifm-background-surface-color);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
+}
+
+.card h3,
+.faqItem h3 {
+  margin-bottom: 0.75rem;
+}
+
+.card p,
+.faqItem p {
+  color: var(--ifm-color-emphasis-700);
+}
+
+.codeBlock {
+  min-height: 112px;
   white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 12px;
+  padding: 0.9rem;
+  margin: 1rem 0;
+  font-size: 0.9rem;
 }
 
 @media screen and (max-width: 996px) {
+  .heroBanner {
+    padding: 2rem;
+    text-align: center;
+  }
+
   .actions {
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
   }
-
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,63 @@ import HomepageFeatures from '@site/src/components/HomepageFeatures';
 
 import styles from './index.module.css';
 
+type PromptCard = {
+  title: string;
+  description: string;
+  prompt: string;
+  href: string;
+};
+
+type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+const promptCards: PromptCard[] = [
+  {
+    title: 'Bootstrap Init Prompt',
+    description: 'Use this when a repo does not have VibeGov installed yet.',
+    prompt: `Bootstrap this repo with VibeGov.\nRead and follow:\n- https://governance-foundation.github.io/vibegov.io/docs/bootstrap\n\nThen stop before product-code implementation.`,
+    href: '/docs/bootstrap',
+  },
+  {
+    title: 'Bootstrap Update Prompt',
+    description: 'Use this when a repo already has some bootstrap state.',
+    prompt: `Update this repo's VibeGov bootstrap state.\nRead and follow:\n- https://governance-foundation.github.io/vibegov.io/docs/bootstrap-update\n\nThen stop before product-code implementation.`,
+    href: '/docs/bootstrap-update',
+  },
+  {
+    title: 'Bootstrap Feedback Prompt',
+    description:
+      'Use this after bootstrap/init or bootstrap/update to learn what VibeGov still underspecified.',
+    prompt: `Review the bootstrap/setup process you just executed for this repo.\nRead and follow:\n- https://governance-foundation.github.io/vibegov.io/docs/bootstrap-feedback-prompt`,
+    href: '/docs/bootstrap-feedback-prompt',
+  },
+];
+
+const faqItems: FaqItem[] = [
+  {
+    question: 'What is VibeGov?',
+    answer:
+      'VibeGov gives AI coding agents clearer rules, specs, and workflow guidance so software work is more traceable, reviewable, and less hand-wavey.',
+  },
+  {
+    question: 'When do I use bootstrap init?',
+    answer:
+      'Use bootstrap init when a repo does not have VibeGov installed yet and you want the agent to set up the initial governance structure.',
+  },
+  {
+    question: 'When do I use bootstrap update?',
+    answer:
+      'Use bootstrap update when a repo already has some bootstrap state and you want the agent to repair, normalize, or tighten it instead of starting over.',
+  },
+  {
+    question: 'When do I use the feedback prompt?',
+    answer:
+      'Use the feedback prompt after a bootstrap run when you want the agent to tell you what was underspecified, awkward, or missing so VibeGov can improve.',
+  },
+];
+
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
   return (
@@ -15,13 +72,11 @@ function HomepageHeader() {
         <h1 className="hero__title">{siteConfig.title}</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <p className={styles.lead}>
-          Publish governance guidance one page at a time while keeping the site
-          live and feedback-driven.
+          Bootstrap a repo with clear rules, specs, and workflow guidance so AI
+          agents work in a more traceable, reviewable way.
         </p>
         <div className={styles.actions}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/intro">
+          <Link className="button button--secondary button--lg" to="/docs/intro">
             Read Docs
           </Link>
           <Link
@@ -35,58 +90,69 @@ function HomepageHeader() {
   );
 }
 
+function PromptSection() {
+  return (
+    <section className={styles.section}>
+      <div className="container">
+        <div className={styles.sectionHeader}>
+          <h2>Quick paths</h2>
+          <p>
+            Keep the homepage short. Jump to the right bootstrap entrypoint and
+            let the linked doc carry the detail.
+          </p>
+        </div>
+        <div className={styles.cardGrid}>
+          {promptCards.map((card) => (
+            <article key={card.title} className={styles.card}>
+              <h3>{card.title}</h3>
+              <p>{card.description}</p>
+              <pre className={styles.codeBlock}>
+                <code>{card.prompt}</code>
+              </pre>
+              <Link className="button button--primary button--sm" to={card.href}>
+                Open doc
+              </Link>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FaqSection() {
+  return (
+    <section className={styles.sectionAlt}>
+      <div className="container">
+        <div className={styles.sectionHeader}>
+          <h2>FAQ</h2>
+          <p>Short answers for the basic questions a human will ask first.</p>
+        </div>
+        <div className={styles.faqList}>
+          {faqItems.map((item) => (
+            <article key={item.question} className={styles.faqItem}>
+              <h3>{item.question}</h3>
+              <p>{item.answer}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export default function Home() {
   const {siteConfig} = useDocusaurusContext();
-  const quickStartPrompt = `Adopt VibeGov governance from https://governance-foundation.github.io/vibegov.io before any implementation.
-
-Read:
-- https://governance-foundation.github.io/vibegov.io/agent.txt
-- https://governance-foundation.github.io/vibegov.io/bootstrap.json
-
-Initialization contract:
-1) Ensure \`.governance/\` exists with:
-   - \`.governance/rules/\`
-   - \`.governance/project/\`
-   - \`.governance/specs/\`
-2) Treat \`.governance/rules/*.mdc\` as governance-only constraints.
-3) Treat \`.governance/specs/*\` as the only feature/change spec source.
-4) Detect any provider-native rules directory that already exists in the repo. If found, sync \`.governance/rules/*.mdc\` into it and report the exact target(s).
-5) If none exist, do not invent placeholder paths; continue with \`.governance/rules/*.mdc\` only.
-6) Before coding, create:
-   - \`.governance/project/PROJECT_INTENT.md\`
-   - \`.governance/specs/SPEC-001-<feature>.md\`
-   - backlog/tasks mapped to spec sections.
-7) List active rule files before coding.
-
-Execution gate:
-- Do not start coding until initialization is complete and reported.
-
-Completion report:
-- summarize applied governance rules
-- report validation evidence
-- list ambiguity/conflicts/deviations`;
-
   return (
     <Layout
       title={siteConfig.title}
-      description="Portable delivery judgement for AI-assisted software development.">
+      description="Governance for AI-assisted software delivery.">
       <HomepageHeader />
       <main>
-        <section className={styles.quickStart}>
-          <div className="container">
-            <h2>Quick Start Prompt</h2>
-            <p>
-              Copy this into your IDE agent to adopt VibeGov behavior quickly.
-            </p>
-            <pre className={styles.promptBlock}>
-              <code>{quickStartPrompt}</code>
-            </pre>
-          </div>
-        </section>
+        <PromptSection />
+        <FaqSection />
         <HomepageFeatures />
       </main>
     </Layout>
   );
 }
-
-


### PR DESCRIPTION
## Summary\n- restore the homepage to three short bootstrap quick paths: init, update, and feedback\n- add a homepage FAQ section and clearer human-readable messaging\n- add the linked bootstrap update + bootstrap feedback docs and wire them into docs/contribute/sidebar\n\n## OpenSpec\n- .governance/specs/homepage-bootstrap-entrypoints-and-faq.md\n- HOME-BOOT-001 through HOME-BOOT-007\n\n## Validation\n- npm run build\n\nCloses #43