### PR TITLE
#49 harden bootstrap feedback issue and PII guidance

### DIFF
--- a/.governance/specs/bootstrap-feedback-submission-safety.md
+++ b/.governance/specs/bootstrap-feedback-submission-safety.md
@@ -1,0 +1,20 @@
+# Bootstrap Feedback Submission Safety
+
+## Intent
+Make the bootstrap feedback flow complete and safe by explicitly directing users to raise a GitHub issue and to scrub or obfuscate PII, secrets, and sensitive environment data before sharing.
+
+## Scope
+In scope:
+- bootstrap feedback doc wording
+- contribution-page feedback wording
+- homepage wording if needed to reinforce the flow
+
+Out of scope:
+- broader privacy policy work
+- automated PII detection tooling
+
+## Acceptance Criteria
+- `FB-001` Bootstrap feedback guidance explicitly tells users to raise a GitHub issue with the resulting feedback.
+- `FB-002` Bootstrap feedback guidance explicitly tells users to remove or obfuscate PII, secrets, tokens, emails, usernames, IDs, URLs, and environment-specific sensitive data before sharing.
+- `FB-003` Contribute-page wording aligns with the feedback flow.
+- `FB-004` Published site/docs changes still pass `npm run build`.

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -6,6 +6,15 @@ sidebar_position: 5
 
 Use this after a fresh bootstrap or bootstrap-update run when you want an agent to tell you what VibeGov still underspecified.
 
+After you get the result, raise a GitHub issue with the feedback so it becomes durable, reviewable, and actionable.
+
+Before sharing anything publicly, remove or obfuscate:
+- PII
+- secrets/tokens/keys
+- emails, usernames, IDs, chat handles, and personal URLs
+- internal hostnames, private repo URLs, tenant IDs, or environment-specific sensitive details
+- any customer/user/project data that should not be public
+
 ```text
 Please review the bootstrap/setup process you just executed for this repo and tell me what VibeGov could do better.
 
@@ -19,8 +28,20 @@ Focus on:
 - what should be mandatory next time
 - what exact wording or rules would have made bootstrap smoother
 
+Before returning the feedback:
+- remove or obfuscate any PII, secrets, tokens, keys, emails, usernames, IDs, URLs, and environment-specific sensitive details
+- keep the feedback useful, but make it safe to share in a public GitHub issue
+
 Return:
 1. a short summary of the biggest problems
 2. a bullet list of concrete improvements VibeGov should make
 3. any exact prompt/rule wording you recommend
+4. a short suggested GitHub issue title the user can use when filing the feedback
 ```
+
+## What to do next
+
+1. Run the prompt.
+2. Review the result for anything sensitive the agent missed.
+3. Open a GitHub issue and paste the scrubbed feedback there.
+4. Link the affected page, prompt, or rule if you know it.

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -35,7 +35,9 @@ Use the [Branch Protection Checklist](/docs/branch-protection-checklist) when se
 
 ## Bootstrap adoption feedback
 
-If you have just run a fresh bootstrap or an update/remediation pass, use the [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt) and paste the result into an issue.
+If you have just run a fresh bootstrap or an update/remediation pass, use the [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt) and raise a GitHub issue with the scrubbed result.
+
+Before posting, remove or obfuscate PII, secrets, tokens, emails, usernames, IDs, URLs, and environment-specific sensitive details.
 
 That feedback is especially useful when it captures:
 - what was underspecified or ambiguous

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,7 +35,7 @@ const promptCards: PromptCard[] = [
   {
     title: 'Bootstrap Feedback Prompt',
     description:
-      'Use this after bootstrap/init or bootstrap/update to learn what VibeGov still underspecified.',
+      'Use this after bootstrap/init or bootstrap/update, then raise a scrubbed GitHub issue with the feedback.',
     prompt: `Review the bootstrap/setup process you just executed for this repo.\nRead and follow:\n- https://governance-foundation.github.io/vibegov.io/docs/bootstrap-feedback-prompt`,
     href: '/docs/bootstrap-feedback-prompt',
   },
@@ -60,7 +60,7 @@ const faqItems: FaqItem[] = [
   {
     question: 'When do I use the feedback prompt?',
     answer:
-      'Use the feedback prompt after a bootstrap run when you want the agent to tell you what was underspecified, awkward, or missing so VibeGov can improve.',
+      'Use the feedback prompt after a bootstrap run when you want the agent to tell you what was underspecified, awkward, or missing. Then raise a scrubbed GitHub issue so the feedback becomes durable and actionable.',
   },
 ];
 


### PR DESCRIPTION
## Summary\n- require the feedback flow to end in a GitHub issue\n- require PII/sensitive-data scrubbing before sharing\n- align homepage and contribute wording with the safer feedback flow\n\n## OpenSpec\n- .governance/specs/bootstrap-feedback-submission-safety.md\n- FB-001 through FB-004\n\n## Validation\n- npm run build\n\nCloses #49