### PR TITLE
#51 add FAQ pages and homepage prompt copy

### DIFF
--- a/.governance/specs/faq-pages-homepage-copy.md
+++ b/.governance/specs/faq-pages-homepage-copy.md
@@ -1,0 +1,21 @@
+# FAQ Pages, Homepage Surfacing, and Prompt Copy
+
+## Intent
+Make FAQ content first-class and reusable while improving the homepage bootstrap entrypoints with one-click copy.
+
+## Scope
+In scope:
+- FAQ as separate docs pages
+- homepage surfacing for selected FAQ items via frontmatter/tagging
+- copy buttons for homepage bootstrap prompt cards
+
+Out of scope:
+- full site redesign
+- complex CMS/search/filtering work
+
+## Acceptance Criteria
+- `FAQ-001` FAQ items exist as separate docs pages.
+- `FAQ-002` FAQ docs can opt into homepage surfacing via simple frontmatter/tagging.
+- `FAQ-003` Homepage automatically renders selected FAQ items from the tagged docs.
+- `FAQ-004` Homepage prompt cards provide a one-click copy action.
+- `FAQ-005` `npm run build` succeeds after the changes.

--- a/docs/faq/what-is-vibegov.md
+++ b/docs/faq/what-is-vibegov.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 1
+homepage: true
+question: What is VibeGov?
+---
+
+# What is VibeGov?
+
+VibeGov gives humans and AI coding agents a shared governance layer for software delivery.
+
+The goal is simple: move fast **without faking done**.
+
+VibeGov helps teams keep:
+- intent clear before implementation
+- specs and issues connected to the work
+- evidence attached to completion claims
+- blockers visible instead of hidden in chat
+- release/readiness behaviour inside the delivery loop
+
+It is not a replacement for judgement.
+It is a way to make delivery judgement more explicit and reusable.

--- a/docs/faq/when-do-i-use-bootstrap-init.md
+++ b/docs/faq/when-do-i-use-bootstrap-init.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 2
+homepage: true
+question: When do I use bootstrap init?
+---
+
+# When do I use bootstrap init?
+
+Use **bootstrap init** when a repo does not have VibeGov installed yet.
+
+This is the first-pass setup flow. It should create the initial governance structure, install the active rules, create project intent + first spec scaffolding, and then stop before product-code implementation.
+
+Use the homepage quick path or the canonical doc:
+- [Bootstrap](/docs/bootstrap)

--- a/docs/faq/when-do-i-use-bootstrap-update.md
+++ b/docs/faq/when-do-i-use-bootstrap-update.md
@@ -1,0 +1,14 @@
+---
+sidebar_position: 3
+homepage: true
+question: When do I use bootstrap update?
+---
+
+# When do I use bootstrap update?
+
+Use **bootstrap update** when a repo already has some VibeGov/bootstrap state and you want the agent to repair, normalize, or tighten it instead of starting over.
+
+This is the right recovery/remediation path for partially bootstrapped repos.
+
+Use the homepage quick path or the canonical doc:
+- [Bootstrap Update](/docs/bootstrap-update)

--- a/docs/faq/when-do-i-use-the-feedback-prompt.md
+++ b/docs/faq/when-do-i-use-the-feedback-prompt.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 4
+homepage: true
+question: When do I use the feedback prompt?
+---
+
+# When do I use the feedback prompt?
+
+Use the **bootstrap feedback prompt** after a bootstrap init or bootstrap update run when you want the agent to tell you what VibeGov still underspecified.
+
+Then raise a **GitHub issue** with the scrubbed result so the feedback becomes durable, reviewable, and actionable.
+
+Before posting, remove or obfuscate PII, secrets, tokens, emails, usernames, IDs, URLs, and environment-specific sensitive details.
+
+Use the canonical doc:
+- [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt)

--- a/sidebars.js
+++ b/sidebars.js
@@ -19,6 +19,16 @@ const sidebars = {
     'bootstrap-update',
     'quickstart',
     'bootstrap-feedback-prompt',
+    {
+      type: 'category',
+      label: 'FAQ',
+      items: [
+        'faq/what-is-vibegov',
+        'faq/when-do-i-use-bootstrap-init',
+        'faq/when-do-i-use-bootstrap-update',
+        'faq/when-do-i-use-the-feedback-prompt',
+      ],
+    },
     'branch-protection-checklist',
     'vibegov-sdlc',
     'contribute',

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -95,6 +95,16 @@
   color: var(--ifm-color-emphasis-700);
 }
 
+.cardActions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.copyButton {
+  cursor: pointer;
+}
+
 .codeBlock {
   min-height: 112px;
   white-space: pre-wrap;
@@ -116,5 +126,9 @@
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
+  }
+
+  .cardActions {
+    justify-content: center;
   }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,26 @@
-import React from 'react';
+import React, {useMemo, useState} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
+
+import {
+  frontMatter as whatIsFrontMatter,
+  metadata as whatIsMetadata,
+} from '@site/docs/faq/what-is-vibegov.md';
+import {
+  frontMatter as bootstrapInitFrontMatter,
+  metadata as bootstrapInitMetadata,
+} from '@site/docs/faq/when-do-i-use-bootstrap-init.md';
+import {
+  frontMatter as bootstrapUpdateFrontMatter,
+  metadata as bootstrapUpdateMetadata,
+} from '@site/docs/faq/when-do-i-use-bootstrap-update.md';
+import {
+  frontMatter as feedbackFrontMatter,
+  metadata as feedbackMetadata,
+} from '@site/docs/faq/when-do-i-use-the-feedback-prompt.md';
 
 import styles from './index.module.css';
 
@@ -16,7 +33,9 @@ type PromptCard = {
 
 type FaqItem = {
   question: string;
-  answer: string;
+  href: string;
+  summary: string;
+  homepage: boolean;
 };
 
 const promptCards: PromptCard[] = [
@@ -41,28 +60,32 @@ const promptCards: PromptCard[] = [
   },
 ];
 
-const faqItems: FaqItem[] = [
+const faqSource = [
   {
-    question: 'What is VibeGov?',
-    answer:
-      'VibeGov gives AI coding agents clearer rules, specs, and workflow guidance so software work is more traceable, reviewable, and less hand-wavey.',
+    frontMatter: whatIsFrontMatter,
+    metadata: whatIsMetadata,
+    summary:
+      'VibeGov gives humans and AI coding agents a shared governance layer so software delivery is more traceable, reviewable, and honest about done.',
   },
   {
-    question: 'When do I use bootstrap init?',
-    answer:
-      'Use bootstrap init when a repo does not have VibeGov installed yet and you want the agent to set up the initial governance structure.',
+    frontMatter: bootstrapInitFrontMatter,
+    metadata: bootstrapInitMetadata,
+    summary:
+      'Use bootstrap init for a repo that does not have VibeGov installed yet.',
   },
   {
-    question: 'When do I use bootstrap update?',
-    answer:
-      'Use bootstrap update when a repo already has some bootstrap state and you want the agent to repair, normalize, or tighten it instead of starting over.',
+    frontMatter: bootstrapUpdateFrontMatter,
+    metadata: bootstrapUpdateMetadata,
+    summary:
+      'Use bootstrap update when a repo already has partial bootstrap state and needs repair or normalization.',
   },
   {
-    question: 'When do I use the feedback prompt?',
-    answer:
-      'Use the feedback prompt after a bootstrap run when you want the agent to tell you what was underspecified, awkward, or missing. Then raise a scrubbed GitHub issue so the feedback becomes durable and actionable.',
+    frontMatter: feedbackFrontMatter,
+    metadata: feedbackMetadata,
+    summary:
+      'Use the feedback prompt after bootstrap work, then raise a scrubbed GitHub issue with the result.',
   },
-];
+] as const;
 
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
@@ -91,6 +114,14 @@ function HomepageHeader() {
 }
 
 function PromptSection() {
+  const [copiedTitle, setCopiedTitle] = useState<string | null>(null);
+
+  async function handleCopy(card: PromptCard) {
+    await navigator.clipboard.writeText(card.prompt);
+    setCopiedTitle(card.title);
+    window.setTimeout(() => setCopiedTitle((current) => (current === card.title ? null : current)), 1500);
+  }
+
   return (
     <section className={styles.section}>
       <div className="container">
@@ -109,9 +140,17 @@ function PromptSection() {
               <pre className={styles.codeBlock}>
                 <code>{card.prompt}</code>
               </pre>
-              <Link className="button button--primary button--sm" to={card.href}>
-                Open doc
-              </Link>
+              <div className={styles.cardActions}>
+                <Link className="button button--primary button--sm" to={card.href}>
+                  Open doc
+                </Link>
+                <button
+                  type="button"
+                  className={clsx('button button--secondary button--sm', styles.copyButton)}
+                  onClick={() => void handleCopy(card)}>
+                  {copiedTitle === card.title ? 'Copied' : 'Copy prompt'}
+                </button>
+              </div>
             </article>
           ))}
         </div>
@@ -121,18 +160,36 @@ function PromptSection() {
 }
 
 function FaqSection() {
+  const faqItems = useMemo<FaqItem[]>(
+    () =>
+      faqSource
+        .map(({frontMatter, metadata, summary}) => ({
+          question: String(frontMatter.question ?? metadata.title),
+          href: metadata.permalink,
+          summary,
+          homepage: Boolean(frontMatter.homepage),
+        }))
+        .filter((item) => item.homepage),
+    [],
+  );
+
   return (
     <section className={styles.sectionAlt}>
       <div className="container">
         <div className={styles.sectionHeader}>
           <h2>FAQ</h2>
-          <p>Short answers for the basic questions a human will ask first.</p>
+          <p>
+            FAQ items live as docs pages. Mark them for homepage surfacing and
+            they appear here automatically.
+          </p>
         </div>
         <div className={styles.faqList}>
           {faqItems.map((item) => (
             <article key={item.question} className={styles.faqItem}>
-              <h3>{item.question}</h3>
-              <p>{item.answer}</p>
+              <h3>
+                <Link to={item.href}>{item.question}</Link>
+              </h3>
+              <p>{item.summary}</p>
             </article>
           ))}
         </div>


### PR DESCRIPTION
## Summary\n- add FAQ as separate docs pages and sidebar section\n- surface homepage FAQ items from pages marked for homepage\n- add one-click copy buttons for homepage bootstrap prompt cards\n\n## OpenSpec\n- .governance/specs/faq-pages-homepage-copy.md\n- FAQ-001 through FAQ-005\n\n## Validation\n- npm run build\n\nCloses #51