### PR TITLE
#57 #58 #59 harden bootstrap contract for update/remediation runs

### DIFF
--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -63,6 +63,14 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-014` Existing open issues should be imported or attached to the GitHub board during adoption/bootstrap when project automation is available.
 - `GOV-02-GIT-015` Issue state on the GitHub board must move with actual delivery state rather than remaining static: `Backlog` -> `Ready` -> `In progress` -> `In review` -> `Done`, with `Blocked` used for proven blockers.
 - `GOV-02-GIT-016` If GitHub prerequisites or auth are missing, bootstrap should report the exact missing capability and degrade gracefully instead of pretending project-board setup succeeded.
+- `GOV-02-GIT-017` For GitHub-hosted repos, bootstrap must classify each board preflight dependency using explicit outcome states: `configured`, `blocked-with-tracked-issue`, or `not-applicable`.
+- `GOV-02-GIT-018` Bootstrap must choose one canonical board target and follow explicit phase order: adopt or create, then normalize.
+- `GOV-02-GIT-019` If duplicate empty boards were created during retries, bootstrap should keep one canonical board, clean the accidental duplicates, and report that cleanup.
+- `GOV-02-GIT-020` Bootstrap must ensure repository linkage to the canonical board before claiming completion.
+- `GOV-02-GIT-021` GitHub built-in `Status` should be normalized in place when needed; bootstrap should not assume replacement via create/delete flows.
+- `GOV-02-GIT-022` If the repository has no issues, board setup may still be complete, but bootstrap must report the board as intentionally empty.
+- `GOV-02-GIT-023` Bootstrap must emit durable local status artifacts (for example `BOOTSTRAP_STATUS.md` and `BOOTSTRAP_FEEDBACK.md`) even when commit mode forbids committing.
+- `GOV-02-GIT-024` Bootstrap is incomplete until generated docs/artifacts are reconciled against final live git/GitHub state after any auth refresh, board mutation, or cleanup action.
 
 This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.
 

--- a/.governance/specs/bootstrap-contract-hardening-and-output-artifacts.md
+++ b/.governance/specs/bootstrap-contract-hardening-and-output-artifacts.md
@@ -1,0 +1,69 @@
+# Bootstrap Contract Hardening and Output Artifacts
+
+## Intent
+Harden the VibeGov bootstrap contract so GitHub-hosted repositories get a consistent, reviewable, stateful bootstrap package instead of a thin file scaffold. The bootstrap flow should use one aligned pass gate across machine-readable and human-readable sources, support empty or underdefined repos without forcing invented product direction, classify pre-existing repo state before changing files, and leave behind durable local output artifacts even when commits are intentionally withheld.
+
+## Scope
+In scope:
+- align the machine-readable bootstrap sources (`agent.txt`, `bootstrap.json`) with the public bootstrap docs
+- define explicit GitHub preflight/capability outcomes before board mutation
+- define a stronger expected bootstrap package for GitHub-hosted repos
+- define empty-repo fallback behavior that allows a bootstrap-focused first spec instead of forcing a product feature spec
+- define bootstrap commit-policy semantics and dirty-tree handling
+- require durable bootstrap status/feedback artifacts for reviewable no-commit runs
+- update bootstrap, bootstrap-update, feedback, quickstart, GitHub board, and FAQ docs accordingly
+- update canonical rules/public rule pages where the bootstrap contract is governed there
+
+Out of scope:
+- implementing repository ruleset automation against GitHub itself
+- changing non-bootstrap product delivery semantics outside the affected bootstrap contract
+- adding automated PII detection beyond documenting the feedback flow
+
+## Acceptance Criteria
+- `BOOT-HARDEN-001` `static/agent.txt`, `static/bootstrap.json`, and `docs/bootstrap.md` describe the same bootstrap completion bar.
+- `BOOT-HARDEN-002` Canonical machine-readable bootstrap URLs are `https://vibegov.io/agent.txt` and `https://vibegov.io/bootstrap.json`.
+- `BOOT-HARDEN-003` Empty or underdefined repos may use a bootstrap/governance setup spec as `SPEC-001` instead of forcing inferred product scope.
+- `BOOT-HARDEN-004` Bootstrap defines explicit GitHub capability checks and named outcomes before project-board mutation.
+- `BOOT-HARDEN-005` GitHub-hosted bootstrap completion requires the stronger operational package unless explicitly blocked: workflow artifacts, board status/reporting artifacts, documented issue-pickup flow, and final live-state reconciliation.
+- `BOOT-HARDEN-006` Bootstrap defines explicit commit-policy modes and required dirty-tree handling.
+- `BOOT-HARDEN-007` Bootstrap requires durable local output artifacts such as bootstrap status and feedback files even when commits are forbidden.
+- `BOOT-HARDEN-008` Bootstrap feedback guidance tells the agent to write scrubbed feedback to a local file before or alongside public issue filing.
+- `BOOT-HARDEN-009` Public bootstrap/update/quickstart/GitHub-project docs and published governance pages reflect the same contract.
+- `BOOT-HARDEN-010` `npm run build` succeeds after the documentation/rule/spec updates.
+
+## Tests and Evidence
+- inspect `static/agent.txt`
+- inspect `static/bootstrap.json`
+- inspect `docs/bootstrap.md`
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/bootstrap-feedback-prompt.md`
+- inspect `docs/github-project-bootstrap.md`
+- inspect `docs/quickstart.md`
+- inspect relevant FAQ pages
+- inspect `.governance/rules/gov-01-instructions.mdc`
+- inspect `.governance/rules/gov-02-workflow.mdc`
+- inspect published docs for GOV-01 and GOV-02
+- run `npm run build`
+
+## Documentation Impact
+- update `static/agent.txt`
+- update `static/bootstrap.json`
+- update `docs/bootstrap.md`
+- update `docs/bootstrap-update.md`
+- update `docs/bootstrap-feedback-prompt.md`
+- update `docs/github-project-bootstrap.md`
+- update `docs/quickstart.md`
+- update `docs/contribute.md` if needed for the new feedback-file flow
+- update FAQ pages related to bootstrap init/update/feedback
+- update `.governance/rules/gov-01-instructions.mdc`
+- update `.governance/rules/gov-02-workflow.mdc`
+- update `docs/published/gov-01-instructions.md`
+- update `docs/published/gov-02-workflow.md`
+
+## Verification
+Verification is documentation-driven. Success requires the machine-readable bootstrap sources, public bootstrap docs, update/remediation docs, GitHub board docs, feedback docs, FAQs, and published governance pages to describe the same stronger bootstrap contract, plus a successful site build.
+
+## Change Notes
+- Prefer a bootstrap-spec fallback over inferring product direction from the repository name.
+- Treat scaffold-only bootstrap output as incomplete for GitHub-hosted repos unless the missing operational pieces are explicitly blocked and reported.
+- Make reviewable local output artifacts part of the bootstrap contract so no-commit runs still leave durable evidence.

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -4,16 +4,13 @@ sidebar_position: 5
 
 # Bootstrap Feedback Prompt
 
-Use this after a fresh bootstrap or bootstrap-update run when you want an agent to tell you what VibeGov still underspecified.
+Use this after a bootstrap or bootstrap-update run when you want durable, scrubbed feedback.
 
-After you get the result, raise a GitHub issue with the feedback so it becomes durable, reviewable, and actionable.
-
-Before sharing anything publicly, remove or obfuscate:
+Before public sharing, remove or obfuscate:
 - PII
 - secrets/tokens/keys
-- emails, usernames, IDs, chat handles, and personal URLs
-- internal hostnames, private repo URLs, tenant IDs, or environment-specific sensitive details
-- any customer/user/project data that should not be public
+- emails, usernames, IDs, chat handles, personal URLs
+- internal hostnames, private repo URLs, tenant IDs, environment-specific sensitive details
 
 ```text
 Please review the bootstrap/setup process you just executed for this repo and tell me what VibeGov could do better.
@@ -28,20 +25,25 @@ Focus on:
 - what should be mandatory next time
 - what exact wording or rules would have made bootstrap smoother
 
-Before returning the feedback:
-- remove or obfuscate any PII, secrets, tokens, keys, emails, usernames, IDs, URLs, and environment-specific sensitive details
-- keep the feedback useful, but make it safe to share in a public GitHub issue
+Before finalizing:
+- scrub sensitive details (PII/secrets/tokens/IDs/URLs/environment-specific details)
+- keep the feedback useful for a public issue
 
-Return:
-1. a short summary of the biggest problems
-2. a bullet list of concrete improvements VibeGov should make
-3. any exact prompt/rule wording you recommend
-4. a short suggested GitHub issue title the user can use when filing the feedback
+Then produce BOTH:
+1) a local feedback artifact at `.governance/project/BOOTSTRAP_FEEDBACK.md`
+2) a GitHub issue-ready payload:
+   - title
+   - body
+   - suggested issue type/labels
+
+If issue filing is explicitly requested:
+- file to `governance-foundation/vibegov.io`
+- return the created issue URL
 ```
 
 ## What to do next
 
 1. Run the prompt.
-2. Review the result for anything sensitive the agent missed.
-3. Open a GitHub issue and paste the scrubbed feedback there.
-4. Link the affected page, prompt, or rule if you know it.
+2. Review the generated local feedback artifact.
+3. Open/file the GitHub issue using the scrubbed title/body.
+4. Link affected page/rule/prompt sections.

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -4,25 +4,31 @@ sidebar_position: 3
 
 # Bootstrap Update
 
-Copy this as message 1 in any coding agent when the repo already has some VibeGov bootstrap state and you want the agent to repair, tighten, or normalize it.
+Copy this as message 1 in any coding agent when the repo already has some VibeGov bootstrap state and you want repair/normalization instead of a fresh start.
 
 ```text
 Update this repo's VibeGov bootstrap state.
 Read and follow:
-- https://governance-foundation.github.io/vibegov.io/agent.txt
-- https://governance-foundation.github.io/vibegov.io/bootstrap.json
+- https://vibegov.io/agent.txt
+- https://vibegov.io/bootstrap.json
 
 This is an update/remediation pass, not a fresh bootstrap.
-Do not restart from scratch if useful governance artifacts already exist.
+Do not restart from scratch when valid artifacts already exist.
 
 Before writing any product code:
-1. Inspect the existing `.governance/`, `AGENTS.md`, project intent, specs, and backlog state.
-2. Repair or normalize missing or weak bootstrap artifacts while preserving valid existing work.
-3. Keep `.governance/` canonical and report the active governance sources in use.
-4. If project intent or the first spec is weak, tighten it honestly instead of inventing fake product direction.
-5. Normalize backlog/spec traceability so the repo is ready for governed next-step work.
-6. If a provider-native rules directory already exists, keep it aligned with `.governance/rules/*.mdc` and report the exact target path(s).
-7. Report exactly what was repaired, what was preserved, and what still needs follow-up.
+1. Inspect existing `.governance/`, `AGENTS.md`, project intent, specs, backlog, `.github/` workflow artifacts, and current Git/GitHub state.
+2. Classify start state (branch, clean/dirty tree, untracked/uncommitted changes) and declare commit policy mode (`required`, `allowed`, `forbidden`).
+3. Preserve valid artifacts; repair only stale, missing, contradictory, or weak artifacts.
+4. Keep `.governance/` canonical and report active governance sources.
+5. If product intent is vague, allow `SPEC-001` to be a bootstrap/governance setup spec instead of inventing product scope.
+6. For GitHub repos, run capability preflight before board mutation and report each dependency as `configured`, `blocked-with-tracked-issue`, or `not-applicable`.
+7. Choose exactly one canonical board target (adopt/create/normalize), normalize fields, ensure repo linkage, handle duplicate empty board cleanup if needed, and report final board state.
+8. If no issues exist, still create/normalize/report board and mark intentionally empty.
+9. Write durable output artifacts:
+   - `.governance/project/BOOTSTRAP_STATUS.md`
+   - `.governance/project/BOOTSTRAP_FEEDBACK.md`
+   - optional `.governance/project/BOOTSTRAP_BLOCKERS.md`
+10. Reconcile all generated docs against final live git/GitHub state before claiming completion.
 
 Then stop before product-code implementation.
 ```

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -9,87 +9,70 @@ Copy this as message 1 in any coding agent.
 ```text
 Bootstrap this repo with VibeGov.
 Read and follow:
-- https://governance-foundation.github.io/vibegov.io/agent.txt
-- https://governance-foundation.github.io/vibegov.io/bootstrap.json
+- https://vibegov.io/agent.txt
+- https://vibegov.io/bootstrap.json
 
 Before writing any product code:
 1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/`.
 2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
-3. Create `.governance/project/PROJECT_INTENT.md` from `PROJECT_TEMPLATE.md`.
-4. Create the first feature/change spec as `.governance/specs/SPEC-001-<feature>.md` from `SPEC_TEMPLATE.md`.
-5. Create or normalize a backlog mapped to the spec sections.
-6. Install the strict Git workflow for agents:
-   - `main` is promotion/release only
-   - `develop` is the pull-request integration branch
-   - issue-scoped `feature/`, `fix/`, `docs/`, and `chore/` branches start from `develop`
-   - normal issue branches must not be created from another working branch
-   - non-`main` / non-`develop` branches are work units, not reusable parent branches
-   - agents never commit directly to `main` or `develop`
-   - normal work enters `develop` through pull request
-   - `develop` promotes to `main` through an explicit pull request
-   - hotfixes branch from `main` and must be reconciled back into `develop`
-   - stacked-branch exceptions require explicit human approval and a reconciliation plan
-   - add a repo-local pull-request template and branch-protection checklist
-7. If the repo is GitHub-hosted, check whether `git` and `gh` are installed and whether GitHub auth/project access is available.
-8. If GitHub automation is available, create, adopt, or normalize a GitHub project board with canonical fields:
-   - `Status`: `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Blocked`
-   - `Priority`: `P0`, `P1`, `P2`
-   - `Size`: `XS`, `S`, `M`, `L`, `XL`
-   - import or attach existing open issues
-9. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the exact target path(s). If none exists, keep `.governance/` canonical and do not invent a mirror path.
-10. Report the active governance sources you are using, the Git workflow artifacts you installed, and the GitHub board status (URL or missing prerequisite).
-11. State the expected default issue-pickup flow for normal work: choose from `Backlog`/`Ready`, clarify + spec-bind, branch from `develop`, move to `In progress`, verify, open PR into `develop`, move to `In review`, then `Done` or `Blocked`.
+3. Detect existing provider-native rules directories and mirror `.governance/rules/*.mdc` only when they already exist.
+4. Create or normalize `.governance/project/PROJECT_INTENT.md`.
+5. Create `SPEC-001` as either:
+   - `.governance/specs/SPEC-001-<feature>.md`, or
+   - a bootstrap/governance-setup spec when product intent is still too vague.
+6. Create or normalize a backlog mapped to the spec sections.
+7. Install strict Git workflow artifacts before implementation:
+   - `AGENTS.md`
+   - `.github/pull_request_template.md`
+   - `.github/branch-protection-checklist.md`
+   - documented default issue-pickup flow
+8. Classify starting repo state before edits:
+   - current branch
+   - clean/dirty working tree
+   - untracked files
+   - uncommitted changes
+9. Run with explicit commit policy: `required`, `allowed`, or `forbidden`.
+10. If repo is dirty, do exactly one: resolve first, stop blocked, or continue in explicit review mode.
+11. If GitHub-hosted, run preflight before board mutation:
+   - `git` available
+   - `gh` available
+   - GitHub auth
+   - repo access
+   - project read access
+   - project write access
+12. If GitHub automation is available, create/adopt/normalize one canonical board target:
+   - normalize `Status`: `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Blocked`
+   - normalize `Priority`: `P0`, `P1`, `P2`
+   - normalize `Size`: `XS`, `S`, `M`, `L`, `XL`
+   - link the repo
+   - import/attach existing issues
+   - if no issues exist, report board as intentionally empty
+   - clean accidental duplicate empty boards and report cleanup
+13. If GitHub automation is unavailable, report exact missing capability and leave a tracked blocker artifact.
+14. Write durable local output artifacts:
+   - `.governance/project/BOOTSTRAP_STATUS.md`
+   - `.governance/project/BOOTSTRAP_FEEDBACK.md`
+   - optional `.governance/project/BOOTSTRAP_BLOCKERS.md`
+15. Reconcile generated docs against final live git/GitHub state before claiming completion.
 
 Then stop before product-code implementation.
-
-Quality expectation:
-- Use AI to help raise delivery completeness, not just implementation speed.
-- Treat tests, specs, documentation, validation evidence, traceability, and delivery clarity as first-class delivery artifacts.
-- Do not use AI only to accelerate code changes while skipping the quality scaffolding around those changes.
-- If completeness cannot be fully achieved in-scope, convert the missing part into tracked follow-up work instead of leaving it invisible.
 ```
-
-Need a repeatable way to prove bootstrap works? See [Bootstrap Validation](/docs/bootstrap-validation) and the [Bootstrap Validator Harness](/docs/bootstrap-validator-harness).
-
-Strict Git workflow reference: [Branch Protection Checklist](/docs/branch-protection-checklist).
-
-## Governance Rules Navigation
-
-- [GOV-01: Instructions](/docs/published/gov-01-instructions)
-- [GOV-02: Workflow](/docs/published/gov-02-workflow)
-- [GOV-03: Communication](/docs/published/gov-03-communication)
-- [GOV-04: Quality](/docs/published/gov-04-quality)
-- [GOV-05: Testing](/docs/published/gov-05-testing)
-- [GOV-06: Issues](/docs/published/gov-06-issues)
-- [GOV-07: Tasks](/docs/published/gov-07-tasks)
-- [GOV-08: Exploratory Review](/docs/published/gov-08-exploratory-review)
-
-## Quality expectation after bootstrap
-
-Bootstrap is not only about installing governance files. It is also about installing a higher standard for done.
-
-VibeGov already pushes this through:
-- **GOV-04 Quality** — evidence, maintainability, docs/spec updates, and residual-risk honesty
-- **GOV-05 Testing** — tests as proof of claims, traceable to requirements or acceptance criteria
-- **GOV-06 Issues** — implementation-grade issue quality, verification expectations, and traceable closure
-
-The AI-enabled implication is straightforward: as tests, specs, documentation, traceability, and delivery clarity become cheaper to maintain, they become less optional to skip. AI should help teams deliver to the highest standards they expect, not just help them ship faster.
 
 ## Pass Gate #1
 
 Continue only if all are true:
 
-- `.governance/rules/` exists
-- active governance set includes `GOV-01` through `GOV-08`
+- `.governance/rules/` exists with `GOV-01` through `GOV-08`
 - `.governance/project/PROJECT_INTENT.md` exists
-- `.governance/specs/` contains a first feature/change spec matching `SPEC-001-<feature>.md`
+- `.governance/specs/` has `SPEC-001` (feature spec or bootstrap-setup spec for vague repos)
 - backlog maps to spec scope
-- strict `main`/`develop` roles and pull-request flow are documented before implementation begins
-- if the repo uses GitHub, prerequisite checks for `git`/`gh`/auth were completed and reported
-- if GitHub automation is available, a project board exists with canonical workflow/planning fields and imported open issues
-- if the repo uses GitHub, a pull-request template exists and branch protection expectations are documented
-- active governance sources, Git workflow artifacts, and GitHub board status were reported
-- the default issue-pickup flow for normal work was reported
-- no product code has been written yet
+- `AGENTS.md` exists and points to canonical governance sources
+- strict Git workflow artifacts exist
+- starting repo state and commit-policy mode are reported
+- for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`)
+- for GitHub repos with automation, canonical board target is adopted/created/normalized and repo-link status is reported
+- bootstrap status + feedback artifacts are written
+- final docs are reconciled with final live git/GitHub state
+- no product code was written
 
-If any fail, rerun the same prompt.
+If any fail, rerun bootstrap/update with remediation mode.

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -35,7 +35,11 @@ Use the [Branch Protection Checklist](/docs/branch-protection-checklist) when se
 
 ## Bootstrap adoption feedback
 
-If you have just run a fresh bootstrap or an update/remediation pass, use the [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt) and raise a GitHub issue with the scrubbed result.
+If you have just run a fresh bootstrap or an update/remediation pass, use the [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt).
+
+Expected feedback flow:
+1. write scrubbed feedback to `.governance/project/BOOTSTRAP_FEEDBACK.md`
+2. then raise a GitHub issue with the scrubbed result (or auto-file when requested)
 
 Before posting, remove or obfuscate PII, secrets, tokens, emails, usernames, IDs, URLs, and environment-specific sensitive details.
 

--- a/docs/faq/when-do-i-use-bootstrap-init.md
+++ b/docs/faq/when-do-i-use-bootstrap-init.md
@@ -8,7 +8,8 @@ question: When do I use bootstrap init?
 
 Use **bootstrap init** when a repo does not have VibeGov installed yet.
 
-This is the first-pass setup flow. It should create the initial governance structure, install the active rules, create project intent + first spec scaffolding, and then stop before product-code implementation.
+Init should produce both:
+- the governance scaffold (`.governance/` + `SPEC-001` + backlog)
+- the operational bootstrap package (workflow artifacts, GitHub preflight/board outcome, and bootstrap status artifacts)
 
-Use the homepage quick path or the canonical doc:
-- [Bootstrap](/docs/bootstrap)
+If product intent is too vague, `SPEC-001` can be a bootstrap/governance setup spec instead of a guessed product feature spec.

--- a/docs/faq/when-do-i-use-bootstrap-update.md
+++ b/docs/faq/when-do-i-use-bootstrap-update.md
@@ -6,9 +6,6 @@ question: When do I use bootstrap update?
 
 # When do I use bootstrap update?
 
-Use **bootstrap update** when a repo already has some VibeGov/bootstrap state and you want the agent to repair, normalize, or tighten it instead of starting over.
+Use **bootstrap update** when a repo already has partial VibeGov state and needs repair/normalization.
 
-This is the right recovery/remediation path for partially bootstrapped repos.
-
-Use the homepage quick path or the canonical doc:
-- [Bootstrap Update](/docs/bootstrap-update)
+Update mode should preserve valid artifacts and repair stale/missing/contradictory state, then revalidate docs against final live git/GitHub state before claiming completion.

--- a/docs/faq/when-do-i-use-the-feedback-prompt.md
+++ b/docs/faq/when-do-i-use-the-feedback-prompt.md
@@ -6,11 +6,10 @@ question: When do I use the feedback prompt?
 
 # When do I use the feedback prompt?
 
-Use the **bootstrap feedback prompt** after a bootstrap init or bootstrap update run when you want the agent to tell you what VibeGov still underspecified.
+Use the **bootstrap feedback prompt** after bootstrap init/update when you want durable, scrubbed feedback.
 
-Then raise a **GitHub issue** with the scrubbed result so the feedback becomes durable, reviewable, and actionable.
+Expected output:
+1. local file: `.governance/project/BOOTSTRAP_FEEDBACK.md`
+2. issue-ready title/body for `governance-foundation/vibegov.io`
 
-Before posting, remove or obfuscate PII, secrets, tokens, emails, usernames, IDs, URLs, and environment-specific sensitive details.
-
-Use the canonical doc:
-- [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt)
+If asked to file automatically, file and return the created issue URL.

--- a/docs/github-project-bootstrap.md
+++ b/docs/github-project-bootstrap.md
@@ -4,156 +4,64 @@ sidebar_position: 9
 
 # GitHub Project Bootstrap
 
-Use this when adopting VibeGov in a GitHub-hosted repository and you want the backlog/project board to become part of the governed delivery system from day one.
+Use this when adopting VibeGov in a GitHub-hosted repository.
 
-## Why this exists
+## Mandatory preflight before any board mutation
 
-A governed repo should not stop at markdown issues and specs. On GitHub, the project board is part of the operational control surface.
+Check and classify each dependency as one of:
+- `configured`
+- `blocked-with-tracked-issue`
+- `not-applicable`
 
-Bootstrap should therefore:
-- detect whether GitHub project automation is possible
-- create, adopt, or normalize a project board
-- import existing open issues
-- keep issue state synchronized with actual delivery progress
-
-## Prerequisites
-
-Check these first:
-
-```bash
-git --version
-gh --version
-gh auth status
-```
-
-Expected GitHub capabilities:
+Required checks:
+- `git` availability
+- `gh` availability
+- GitHub auth (`gh auth status`)
 - repo access
-- project access
-- org read access where relevant
+- project read access
+- project write access
 
-If `git` or `gh` is missing, or if `gh auth status` fails, bootstrap should:
-- still install `.governance/`
-- still install branch/PR workflow guidance
-- report the exact missing capability
-- avoid falsely claiming GitHub project-board setup succeeded
+If any required capability is missing, report exact missing capability and stop board mutation.
 
-## Canonical VibeGov board shape
+## Canonical board decision flow
 
-### Required workflow field
-- **Status**
-  - Backlog
-  - Ready
-  - In progress
-  - In review
-  - Done
-  - Blocked
+Bootstrap must choose exactly one canonical board target:
+1. **adopt** an existing suitable board, or
+2. **create** a new dedicated board when none is suitable,
+3. then **normalize** canonical fields/options in place.
 
-### Required planning fields
-- **Priority**
-  - P0
-  - P1
-  - P2
-- **Size**
-  - XS
-  - S
-  - M
-  - L
-  - XL
+Do not leave multiple competing board targets unresolved.
 
-### Useful built-in fields
-These may also be present and are useful when available:
-- Assignees
-- Labels
-- Linked pull requests
-- Reviewers
-- Milestone
-- Parent issue
-- Sub-issues progress
-- Estimate
-- Start date
-- Target date
+If retries produced duplicate empty boards:
+- keep one canonical board
+- clean up accidental duplicates
+- report cleanup explicitly
 
-## Bootstrap behavior
+## Canonical board shape
 
-For GitHub-hosted repos, bootstrap should:
+Required workflow field:
+- `Status`: `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Blocked`
 
-1. detect whether the repo is using GitHub
-2. verify `git` is installed
-3. verify `gh` is installed
-4. verify `gh auth status` succeeds
-5. detect whether a suitable project board already exists
-6. if one exists, adopt or normalize it toward the canonical field set
-7. if one does not exist, create it
-8. import or attach all existing open issues
-9. report the board URL and the canonical statuses/fields present
+Required planning fields:
+- `Priority`: `P0`, `P1`, `P2`
+- `Size`: `XS`, `S`, `M`, `L`, `XL`
 
-## Branch source invariant
+Normalization rule:
+- update GitHub built-in `Status` in place when needed; do not assume create/delete replacement flows are available.
 
-The board workflow only stays trustworthy if branch sources are disciplined too.
+Repo linkage rule:
+- repository must be linked to the canonical board before bootstrap is complete.
 
-Required invariant:
-- normal `feature/`, `fix/`, `docs/`, and `chore/` branches must start from `develop`
-- hotfix branches must start from `main`
-- agents must not create a new normal work branch from another working branch
-- non-`main` / non-`develop` branches are governed work units, not reusable parent branches
-- any stacked-branch exception requires explicit human approval and a reconciliation plan
+No-issues fallback:
+- if repo has no issues, board can still be complete and should be reported as intentionally empty.
 
-## Issue movement contract
+## Completion evidence
 
-The board is not static metadata. It should move with the work.
-
-Expected state movement:
-- new/untriaged/imported work -> **Backlog**
-- clarified and spec-bound work -> **Ready**
-- active implementation or execution -> **In progress**
-- PR open / review underway -> **In review**
-- merged and verified complete -> **Done**
-- proven blocker with evidence -> **Blocked**
-
-## Typical issue pickup flow
-
-For normal backlog-driven work, agents should follow this sequence:
-1. pick the next issue from `Backlog` or `Ready`
-2. clarify it until it is implementation-grade
-3. bind it to spec/requirement IDs
-4. move it to `Ready` if clarification/spec binding was needed
-5. branch from `develop`
-6. move it to `In progress` when work starts
-7. verify with evidence
-8. open PR into `develop`
-9. move it to `In review`
-10. after merge and verification, move it to `Done`
-11. if blocked, move it to `Blocked` with evidence instead of leaving status stale
-
-## Existing project adoption
-
-For an existing repo with open issues, bootstrap should not require a clean slate.
-
-Instead it should:
-- inspect existing issues
-- create or adopt a board
-- import/attach the existing issues
-- normalize the workflow fields
-- start moving issues through the workflow as work begins
-
-## CLI implementation pattern
-
-Use `gh` as the primary automation surface for GitHub-hosted repos.
-
-Examples:
-
-```bash
-gh auth status
-gh issue list --repo owner/repo --state open
-gh project view <number> --owner <owner>
-gh project field-list <number> --owner <owner>
-```
-
-If a project board must be created or normalized, automation should do that explicitly and then report the final board URL back in the bootstrap completion message.
-
-## Related docs
-
-- [Bootstrap](/docs/bootstrap)
-- [Quick Start](/docs/quickstart)
-- [Branch Protection Checklist](/docs/branch-protection-checklist)
-- [Published GOV-02 Workflow](/docs/published/gov-02-workflow)
+For GitHub-hosted bootstrap, report:
+- canonical board URL
+- board action path used (`adopt/create/normalize`)
+- repo-link status
+- field/status normalization result
+- issue import/attach result (or intentionally empty)
+- any blockers/missing capabilities
+- final live-state reconciliation result

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -36,6 +36,7 @@ Follow this loop for meaningful changes:
 - Spec-first: bind work to requirement IDs before implementation starts.
 - If requirement coverage is missing, create/update spec requirements first.
 - If intake item is under-defined, expand it to implementation-grade issue quality before execution.
+- If the item came from backlog, confirm the issue is in the correct board state before work starts (`Backlog` or `Ready`) and move it to `Ready` once the issue is clear enough to execute.
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
@@ -71,11 +72,30 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-002` `develop` is the integration branch for normal work. Agent-authored feature, fix, docs, and chore changes must land in `develop` through pull request.
 - `GOV-02-GIT-003` Normal work must start from an issue-scoped branch created from `develop` using a typed prefix such as `feature/`, `fix/`, `docs/`, or `chore/`, plus the governing issue ID and short slug.
 - `GOV-02-GIT-004` Agents must not commit or push directly to `main` or `develop`.
+- `GOV-02-GIT-004A` Normal issue branches must be created from `develop` only. Agents must not create a new `feature/`, `fix/`, `docs/`, or `chore/` branch from another working branch.
+- `GOV-02-GIT-004B` A non-`main` / non-`develop` branch is a governed work unit, not a reusable parent branch.
+- `GOV-02-GIT-004C` Hotfix branches must be created from `main` only.
+- `GOV-02-GIT-004D` Any stacked-branch exception requires explicit human approval, a bounded reason, and an explicit reconciliation plan.
 - `GOV-02-GIT-005` Every agent-authored non-hotfix change must use a pull request into `develop` that links the governing issue/spec and records verification evidence.
 - `GOV-02-GIT-006` Promotion from `develop` to `main` must be explicit and reviewable. Release or promotion pull requests should state what is being promoted and what release-readiness evidence supports the move.
 - `GOV-02-GIT-007` Hotfix work must branch from `main`, merge back to `main` through an explicit hotfix pull request, and then be back-merged or otherwise reconciled into `develop` immediately so the branches do not drift.
 - `GOV-02-GIT-008` Repositories adopting VibeGov should document branch protection expectations for `main` and `develop`, including required pull requests, review gates, status checks, and restricted direct pushes.
 - `GOV-02-GIT-009` Bootstrap and adoption guidance should install the branch/pull-request workflow, review template, and protection checklist before product-code implementation begins.
+- `GOV-02-GIT-010` For GitHub-hosted repositories, bootstrap should also check whether `git` and `gh` are available and whether GitHub authentication/project access is available before attempting board automation.
+- `GOV-02-GIT-011` When GitHub project automation is available, bootstrap should create, adopt, or normalize a canonical project board and report the board URL plus any fallback limitations.
+- `GOV-02-GIT-012` Canonical GitHub board workflow should include `Status` values `Backlog`, `Ready`, `In progress`, `In review`, `Done`, and `Blocked`.
+- `GOV-02-GIT-013` Canonical GitHub board planning fields should include `Priority` (`P0`, `P1`, `P2`) and `Size` (`XS`, `S`, `M`, `L`, `XL`).
+- `GOV-02-GIT-014` Existing open issues should be imported or attached to the GitHub board during adoption/bootstrap when project automation is available.
+- `GOV-02-GIT-015` Issue state on the GitHub board must move with actual delivery state rather than remaining static: `Backlog` -> `Ready` -> `In progress` -> `In review` -> `Done`, with `Blocked` used for proven blockers.
+- `GOV-02-GIT-016` If GitHub prerequisites or auth are missing, bootstrap should report the exact missing capability and degrade gracefully instead of pretending project-board setup succeeded.
+- `GOV-02-GIT-017` For GitHub-hosted repos, bootstrap must classify each board preflight dependency using explicit outcome states: `configured`, `blocked-with-tracked-issue`, or `not-applicable`.
+- `GOV-02-GIT-018` Bootstrap must choose one canonical board target and follow explicit phase order: adopt or create, then normalize.
+- `GOV-02-GIT-019` If duplicate empty boards were created during retries, bootstrap should keep one canonical board, clean the accidental duplicates, and report that cleanup.
+- `GOV-02-GIT-020` Bootstrap must ensure repository linkage to the canonical board before claiming completion.
+- `GOV-02-GIT-021` GitHub built-in `Status` should be normalized in place when needed; bootstrap should not assume replacement via create/delete flows.
+- `GOV-02-GIT-022` If the repository has no issues, board setup may still be complete, but bootstrap must report the board as intentionally empty.
+- `GOV-02-GIT-023` Bootstrap must emit durable local status artifacts (for example `BOOTSTRAP_STATUS.md` and `BOOTSTRAP_FEEDBACK.md`) even when commit mode forbids committing.
+- `GOV-02-GIT-024` Bootstrap is incomplete until generated docs/artifacts are reconciled against final live git/GitHub state after any auth refresh, board mutation, or cleanup action.
 
 This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.
 
@@ -98,7 +118,7 @@ Governed agent execution should use explicit orchestration and bounded work unit
 
 This section governs work structure, not implementation details. It does not prescribe specific runtimes, queue settings, model choices, shell commands, or machine-local paths. It defines the accountability shape of delegation, while project/runbook docs may specify concrete supervision timings.
 
-> Commentary: Defines the default shape of governed multi-agent execution so coordination stays visible, auditable, recoverable, and visibly supervised after delegation.
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
 ## Execution Modes
 
@@ -216,6 +236,27 @@ A blocker pauses the current item. It does not pause delivery unless it removes 
 - If scope grows, document the reason and request explicit approval.
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
+## Typical Issue Pickup Flow
+
+For normal backlog-driven work, the default governed pickup flow is:
+1. choose the next highest-priority unblocked issue from backlog or `Ready`
+2. clarify the issue until it reaches implementation-grade quality
+3. bind the issue to the governing spec/requirement IDs before implementation
+4. move the issue to `Ready` if clarification/spec binding was required
+5. create a new issue-scoped branch from `develop`
+6. move the issue to `In progress` when active work starts
+7. implement the smallest coherent scoped change
+8. verify with mode-appropriate evidence
+9. update docs/specs/traceability as needed
+10. open a pull request into `develop`
+11. move the issue to `In review` while the PR is active
+12. merge, verify post-merge/release-readiness as needed, then move the issue to `Done`
+13. if a proven blocker stops progress, move the issue to `Blocked` with evidence instead of leaving it stale
+
+This flow defines the default governed lifecycle for normal work. Hotfix flow remains the exception path from `main`.
+
+> Commentary: Provides traceability and scope control so changes remain auditable.
 
 ## Completion Standard
 

--- a/docs/published/gov-04-quality.md
+++ b/docs/published/gov-04-quality.md
@@ -24,6 +24,24 @@ Every meaningful change should satisfy:
 
 > Commentary: Defines quality gates to reduce regressions and maintenance risk.
 
+## Quality Scaffolding Principle
+
+Quality scaffolding is the supporting artifact layer that makes work trustworthy, reviewable, maintainable, and releasable.
+
+Typical quality scaffolding includes:
+- issue clarity
+- spec/requirement binding
+- tests and validation evidence
+- documentation updates
+- traceability links
+- PR and handoff clarity
+- release-readiness or operational evidence
+- explicit residual risk and follow-up debt
+
+AI should help teams maintain this scaffolding, not just accelerate implementation.
+
+> Commentary: Defines quality gates to reduce regressions and maintenance risk.
+
 ## Minimum Quality Checklist
 
 - Scope is explicit and respected
@@ -32,6 +50,7 @@ Every meaningful change should satisfy:
 - Documentation/spec updates reflect behavior changes
 - OpenSpec requirements are updated before claiming behavior changes complete
 - Known trade-offs are recorded
+- Missing completeness is captured as explicit follow-up work rather than left invisible
 
 > Commentary: Defines quality gates to reduce regressions and maintenance risk.
 
@@ -46,10 +65,32 @@ Every meaningful change should satisfy:
 
 ## Verification Expectations
 
-Run verification appropriate to risk:
-- low-risk doc changes: lint/structure checks
+Run verification appropriate to work type and risk:
+- low-risk doc/content changes: lint/structure/link/build checks
 - behavior changes: targeted + regression checks
 - contract/API changes: contract verification + compatibility review
+- release-critical or operationally risky changes: strongest operational evidence available
+
+Verification should be proportional, but never replaced by presentation quality or activity volume.
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
+## Anti-Fake-Completion Principle
+
+Do not confuse these with trustworthy completion:
+- passing build == verified behavior
+- merged PR == done
+- long summary == evidence
+- generated tests == meaningful coverage
+- closed issue == complete work
+
+AI makes it easier to generate the appearance of completeness. Governance must distinguish appearance-of-completion from trustworthy completion.
+
+Verification review should also make explicit:
+- which scenario classes were exercised
+- what proof is direct vs surrogate-only
+- what remains unverified, blocked, or deferred
+- what follow-up artifact was created for missing completeness
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
@@ -60,5 +101,6 @@ Done means:
 - verification evidence captured
 - docs/traceability updated
 - residual risks documented
+- missing completeness converted into tracked follow-up work where relevant
 
 > Commentary: Defines quality gates to reduce regressions and maintenance risk.

--- a/docs/published/gov-05-testing.md
+++ b/docs/published/gov-05-testing.md
@@ -57,7 +57,7 @@ Unit tests are not sufficient by themselves when the governed claim depends on:
 
 When unit tests are the right layer, they should be preferred over slower broad tests for proving isolated logic. When the claim extends beyond isolated logic, pair unit coverage with the higher-layer evidence the claim actually needs.
 
-> Commentary: Clarifies when unit tests are expected, and prevents them from being overclaimed as full proof for broader behavioral changes.
+> Commentary: Ensures implementation is validated by evidence, not assumptions.
 
 ## Test-to-Intent Traceability
 
@@ -81,7 +81,7 @@ For each meaningful test run, explicitly consider:
 - whether the evidence directly proves the claim or only a proxy
 - what remains unverified and what follow-up artifact was created
 
-> Commentary: Makes the execution record show what was actually proved, what was skipped, and where evidence is weak or incomplete.
+> Commentary: Ensures implementation is validated by evidence, not assumptions.
 
 ## Scenario Coverage Expectations
 
@@ -99,7 +99,7 @@ Consider these scenario classes where relevant:
 
 Not every change needs every scenario class, but the execution record should make coverage boundaries visible.
 
-> Commentary: Prevents vague "tested it" reporting by making the scenario envelope explicit.
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
 ## Result Classification
 
@@ -112,7 +112,7 @@ Meaningful test outcomes should be classifiable as:
 
 This helps prevent weak “green enough” reporting.
 
-> Commentary: Forces honest status labels instead of collapsing everything into pass/fail hand-waving.
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
 ## Proof Strength
 
@@ -123,7 +123,7 @@ Evidence should be judged honestly:
 
 Passing build output, a success toast, or a 200 response is not always direct proof of the intended behavior.
 
-> Commentary: Stops proxy evidence from being reported as if it fully proved the governed claim.
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
 ## Persistence and Post-Action Proof
 
@@ -136,7 +136,7 @@ When work changes persisted, synced, deleted, or otherwise durable state, verifi
 
 UI-only success must not be treated as sufficient proof for mutation-heavy work.
 
-> Commentary: Reinforces that durable state changes need durable proof, not just a transient success signal.
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
 ## Execution Expectations
 
@@ -150,7 +150,7 @@ UI-only success must not be treated as sufficient proof for mutation-heavy work.
 - passing tests are evidence only when the asserted behavior matches the governed claim
 - if meaningful coverage is missing, create follow-up work instead of silently treating the gap as acceptable
 
-> Commentary: Clarifies that unit tests are expected for isolated logic changes, but are not a free pass for broader behavior claims.
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
 ## Test Quality Anti-Patterns
 

--- a/docs/published/gov-06-issues.md
+++ b/docs/published/gov-06-issues.md
@@ -82,6 +82,7 @@ Before closing, ensure:
 - verification evidence exists
 - OpenSpec/traceability references are updated or explicitly marked `SPEC_GAP` follow-up
 - follow-up items are captured (if any)
+- missing completeness is converted into explicit follow-up work rather than silently carried forward
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,158 +4,48 @@ sidebar_position: 3
 
 # Quick Start
 
-Use this to install VibeGov into any project in under 5 minutes.
-
-URL-first users should start here first: [Bootstrap](/docs/bootstrap).
+Use this to install VibeGov quickly with the hardened bootstrap contract.
 
 ## Copy-paste bootstrap prompt
-
-Paste this into your agent:
 
 ```text
 Bootstrap this repo with VibeGov.
 Read and follow:
-- https://governance-foundation.github.io/vibegov.io/agent.txt
-- https://governance-foundation.github.io/vibegov.io/bootstrap.json
+- https://vibegov.io/agent.txt
+- https://vibegov.io/bootstrap.json
 
 Initialization contract:
-1) If `.governance/` does not exist, create:
-   - `.governance/rules/`
-   - `.governance/project/`
-   - `.governance/specs/`
-2) Copy/adopt VibeGov canonical rules into `.governance/rules/*.mdc`.
-3) Detect any provider-native rules directory that already exists in the repo. If found, sync active `.governance/rules/*.mdc` into it and report the exact target(s).
-4) If no provider-native rules directory exists, do not invent placeholder paths; use `.governance/rules/*.mdc` as canonical.
-5) Do not place governance files outside `.governance/` unless explicitly requested.
-6) Read `gov-01` through `gov-08` and extract the active workflow, communication, quality, testing, issue, task, and exploratory rules.
-7) Create `.governance/project/PROJECT_INTENT.md` from `PROJECT_TEMPLATE.md`.
-8) Create the first feature/change spec as `.governance/specs/SPEC-001-<feature>.md` from `SPEC_TEMPLATE.md`.
-9) Install a strict Git workflow before implementation:
-   - treat `main` as promotion/release only
-   - treat `develop` as the pull-request integration branch
-   - create issue-scoped `feature/`, `fix/`, `docs/`, and `chore/` branches from `develop`
-   - forbid direct agent commits to `main` or `develop`
-   - require pull requests into `develop` for normal work
-   - require explicit promotion from `develop` to `main`
-   - require hotfix branches from `main` with reconciliation back into `develop`
-   - add a repo-local pull-request template and branch protection checklist
-10) If the repo is GitHub-hosted, verify `git` and `gh` are installed and `gh auth status` succeeds with project-capable access.
-11) If GitHub automation is available, create, adopt, or normalize a project board with:
-   - `Status`: `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Blocked`
-   - `Priority`: `P0`, `P1`, `P2`
-   - `Size`: `XS`, `S`, `M`, `L`, `XL`
-   - add/import existing open issues
-12) Confirm governance activation by listing active rule files, active governance sources, installed Git workflow artifacts, and GitHub board status (URL or missing prerequisite).
+1) Create/normalize `.governance/rules/`, `.governance/project/`, `.governance/specs/`.
+2) Install `GOV-01` through `GOV-08` in `.governance/rules/`.
+3) Detect existing provider-native rules dirs; mirror only if present.
+4) Create/normalize `PROJECT_INTENT.md`.
+5) Create `SPEC-001` (feature spec, or bootstrap-setup spec when product intent is still vague).
+6) Map backlog to spec sections.
+7) Install workflow artifacts: `AGENTS.md`, PR template, branch-protection checklist, default issue-pickup flow.
+8) Classify repo start state (branch, clean/dirty, untracked, uncommitted) and declare commit policy (`required|allowed|forbidden`).
+9) For GitHub repos, preflight `git`, `gh`, auth, repo access, project read/write.
+10) If preflight is configured, adopt/create/normalize one canonical board target and link repo.
+11) Normalize board fields:
+   - `Status`: Backlog, Ready, In progress, In review, Done, Blocked
+   - `Priority`: P0, P1, P2
+   - `Size`: XS, S, M, L, XL
+12) Import/attach existing issues; if none exist, report intentionally empty board.
+13) Write durable output artifacts:
+   - `.governance/project/BOOTSTRAP_STATUS.md`
+   - `.governance/project/BOOTSTRAP_FEEDBACK.md`
+   - optional `.governance/project/BOOTSTRAP_BLOCKERS.md`
+14) Reconcile docs against final live git/GitHub state.
 
-Execution gate:
-- Do not start product-code implementation until steps 1-12 are completed and reported.
-- Do not use AI only to accelerate implementation while skipping tests, specs, docs, traceability, validation evidence, or delivery clarity.
-
-During delivery:
-- Keep project intent in `.governance/project/PROJECT_INTENT.md`.
-- Keep app feature/change specs in `.governance/specs/`.
-- Choose the correct execution mode before acting.
-- Use AI to increase completeness, not just speed.
-- Treat tests, specs, docs, validation evidence, traceability, and delivery clarity as first-class delivery artifacts.
-- Apply rules proportionally, but do not skip mandatory governance requirements.
-
-Completion report:
-- summarize which governance rules were applied
-- provide mode-appropriate evidence
-- list ambiguity, conflicts, or deviations and why
+Then stop before product-code implementation.
 ```
 
-Machine-readable references:
+## Canonical URLs
 
-- `https://governance-foundation.github.io/vibegov.io/agent.txt`
-- `https://governance-foundation.github.io/vibegov.io/bootstrap.json`
+- https://vibegov.io/agent.txt
+- https://vibegov.io/bootstrap.json
 
-## 1. Copy the governance folder
+## Notes
 
-Copy these files into the target repo:
-
-```text
-.governance/
-  rules/gov-*.mdc
-  project/PROJECT_TEMPLATE.md
-  specs/SPEC_TEMPLATE.md
-```
-
-## 2. Activate rules for your agent
-
-For any agent/IDE rule loader: detect any existing provider-native rules directory and mirror active `.governance/rules/*.mdc` files into it.
-
-For agents that read `AGENTS.md`:
-- Add a root `AGENTS.md`.
-- Declare `.governance/rules/*.mdc` and any detected provider-native mirror as active rule sources.
-
-Canonical-source model:
-- Keep `.governance/` as the source of truth.
-- Let each agent/provider link to that source using its own structure.
-
-## 3. Install the strict Git workflow
-
-- Use `main` as the promotion/release branch.
-- Use `develop` as the integration branch for normal work.
-- Create issue-scoped `feature/<issue>-<slug>`, `fix/<issue>-<slug>`, `docs/<issue>-<slug>`, or `chore/<issue>-<slug>` branches from `develop`.
-- Do not let agents commit directly to `main` or `develop`.
-- Require pull requests into `develop` for normal work.
-- Promote `develop` to `main` through an explicit promotion pull request.
-- Run hotfixes from `main`, then back-merge or otherwise reconcile them into `develop`.
-- For GitHub repos, add `.github/pull_request_template.md` and follow the [Branch Protection Checklist](/docs/branch-protection-checklist).
-- For GitHub repos, create or adopt a project board with canonical `Status`, `Priority`, and `Size` fields, then import existing open issues.
-- Keep issue status synchronized with actual work state (`Backlog` -> `Ready` -> `In progress` -> `In review` -> `Done`, or `Blocked` when a blocker is proven).
-
-## 4. Fill project intent before coding
-
-- Create/update project intent from `.governance/project/PROJECT_TEMPLATE.md` as `.governance/project/PROJECT_INTENT.md`.
-- Create feature/change specs from `.governance/specs/SPEC_TEMPLATE.md` as `.governance/specs/SPEC-001-<feature>.md` and later numbered spec files when needed.
-
-## 5. Start with the governance set
-
-Read in this order:
-1. `gov-01-instructions.mdc`
-2. `gov-02-workflow.mdc`
-3. `gov-03` to `gov-07`
-4. `gov-08-exploratory-review.mdc`
-
-## 6. Understand the execution modes
-
-VibeGov works through two operating modes:
-- **Development** — change behavior with proof, release-readiness checks, and shipping discipline
-- **Exploration** — discover behavior and hydrate backlog
-
-Release verification is part of Development, not a third peer mode.
-
-Useful supporting docs:
-- [Execution Modes](/docs/execution-modes)
-- [Exploratory Review Mode](/docs/exploratory-review-mode)
-- [Checkpoint Reporting](/docs/checkpoint-reporting)
-- [Blocker Escalation](/docs/blocker-escalation)
-- [Workflow Quality Rubric](/docs/workflow-quality-rubric)
-- [Bootstrap Validation](/docs/bootstrap-validation)
-
-## 7. Quality and completeness expectation
-
-Bootstrap should not only create governance files. It should also raise the expected standard of done.
-
-That expectation is already reinforced by:
-- [Published GOV-04 Quality](/docs/published/gov-04-quality)
-- [Published GOV-05 Testing](/docs/published/gov-05-testing)
-- [Published GOV-06 Issues](/docs/published/gov-06-issues)
-
-The practical implication is that AI should help teams maintain the quality scaffolding around a change — tests, specs, docs, traceability, and delivery clarity — rather than simply producing code faster.
-
-## 8. Validate installation
-
-Confirm the agent can read active rule files and that prompts/outputs reflect:
-- spec-first behavior
-- evidence-driven validation
-- issue/task traceability
-- strict `main`/`develop` roles plus issue-scoped branch naming
-- pull-request-only integration through `develop`, with explicit promotion and hotfix flow
-- pull-request template and branch-protection expectations when using GitHub
-- exploratory artifact creation for non-validated findings
-- blocker visibility instead of silent stalls
-
-If these do not appear, rule activation is incomplete.
+- Scaffold-only output is incomplete for GitHub-hosted repos unless missing operational pieces are explicitly blocked and reported.
+- If product intent is unclear, do not invent domain direction from repo name.
+- Prefer bootstrap/update remediation that preserves valid artifacts and only repairs weak/missing/contradictory state.

--- a/static/agent.txt
+++ b/static/agent.txt
@@ -11,12 +11,48 @@ scope rules:
 - detect any provider-native rules directory that already exists in the repo and mirror .governance/rules/*.mdc into it
 - if none exist, do not invent placeholder paths; use .governance/rules/*.mdc only
 
-hard gate:
-- before writing any product code, create:
+bootstrap contract:
+- use https://vibegov.io/agent.txt and https://vibegov.io/bootstrap.json as the canonical bootstrap sources
+- do not rely on redirected or stale bootstrap sources
+- bootstrap is not complete for a GitHub-hosted repo when only the .governance scaffold exists
+
+hard gate before product code:
+- create or normalize:
   - .governance/project/PROJECT_INTENT.md
-  - .governance/specs/SPEC-001-<feature>.md
+  - .governance/specs/SPEC-001-<feature>.md or a bootstrap/governance setup spec when product intent is still too vague
   - backlog mapped to spec sections
+- install or report the Git workflow artifacts required before implementation:
+  - AGENTS.md
+  - pull request template
+  - branch-protection checklist
+  - documented default issue-pickup flow
+- if the repo is GitHub-hosted, run GitHub preflight before project-board mutation:
+  - git available
+  - gh available
+  - GitHub auth available
+  - project read access
+  - project write access
+  - repo access
+- if GitHub automation is available, create, adopt, or normalize one canonical board target, link the repo, normalize the canonical fields, and report the final live board state
+- if GitHub automation is unavailable, report the exact missing capability and leave a tracked blocker or equivalent durable blocker note instead of silently treating bootstrap as complete
 - then stop
+
+empty-repo fallback:
+- if the repository does not contain a validated product brief, do not infer product scope from the repository name or placeholder README
+- in that case, SPEC-001 may be the bootstrap/governance setup spec itself and project intent must be marked provisional
+
+repo-state discipline:
+- before modifying files, classify the starting repo state: branch, clean/dirty tree, untracked files, and uncommitted changes
+- bootstrap must run with an explicit commit policy: required, allowed, or forbidden
+- if the repo is dirty, bootstrap must resolve the existing work first, stop and report blocked, or continue only in explicit review mode
+
+durable output artifacts:
+- every bootstrap run must leave durable local output artifacts even when commits are forbidden
+- expected review artifacts include:
+  - .governance/project/BOOTSTRAP_STATUS.md
+  - .governance/project/BOOTSTRAP_FEEDBACK.md
+  - optional: .governance/project/BOOTSTRAP_BLOCKERS.md
+- bootstrap feedback should be written to a local file before or alongside any public GitHub issue filing
 
 delivery loop:
 - Observe -> Plan -> Implement -> Verify -> Document
@@ -26,5 +62,4 @@ active rules:
 
 completion rule:
 - each completed task must include verification evidence and traceability update
-
-
+- bootstrap completion must reflect the final live git/GitHub state, not a stale intermediate state

--- a/static/bootstrap.json
+++ b/static/bootstrap.json
@@ -1,7 +1,11 @@
 {
   "name": "vibegov",
-  "version": "1.0",
-  "source": "https://governance-foundation.github.io/vibegov.io",
+  "version": "1.1",
+  "source": "https://vibegov.io",
+  "canonicalBootstrapSources": {
+    "agent": "https://vibegov.io/agent.txt",
+    "bootstrap": "https://vibegov.io/bootstrap.json"
+  },
   "folders": [
     ".governance/rules",
     ".governance/project",
@@ -15,7 +19,8 @@
   "spec_policy": {
     "scope": "feature_and_change_spec_only",
     "path_glob": ".governance/specs/*",
-    "is_single_source_of_truth_for_features": true
+    "is_single_source_of_truth_for_features": true,
+    "allowBootstrapSetupSpecAsFirstSpecWhenProductIntentIsVague": true
   },
   "compatibility": {
     "mirror_to_provider_rules_if_present": true,
@@ -46,14 +51,99 @@
   "hard_gate_before_product_code": true,
   "pre_coding_required_outputs": [
     ".governance/project/PROJECT_INTENT.md",
-    ".governance/specs/SPEC-001-<feature>.md",
-    "backlog_mapped_to_spec_sections"
+    ".governance/specs/SPEC-001-<feature>.md_or_bootstrap_setup_spec",
+    "backlog_mapped_to_spec_sections",
+    "AGENTS.md",
+    "git_workflow_artifacts",
+    "documented_default_issue_pickup_flow"
   ],
+  "github_hosted_bootstrap": {
+    "preflightChecks": [
+      "git_available",
+      "gh_available",
+      "github_auth_available",
+      "repo_access",
+      "project_read_access",
+      "project_write_access"
+    ],
+    "preflightOutcomeStates": [
+      "configured",
+      "blocked-with-tracked-issue",
+      "not-applicable"
+    ],
+    "requiredWorkflowArtifacts": [
+      "AGENTS.md",
+      ".github/pull_request_template.md",
+      ".github/branch-protection-checklist.md"
+    ],
+    "requiredStatusArtifacts": [
+      ".governance/project/BOOTSTRAP_STATUS.md",
+      ".governance/project/BOOTSTRAP_FEEDBACK.md"
+    ],
+    "optionalStatusArtifacts": [
+      ".governance/project/BOOTSTRAP_BLOCKERS.md",
+      ".governance/project/GIT_WORKFLOW.md",
+      ".governance/project/GITHUB_PROJECT_STATUS.md",
+      ".governance/project/BOOTSTRAP_REPORT.md"
+    ],
+    "board": {
+      "mustChooseSingleCanonicalTarget": true,
+      "allowedActions": [
+        "adopt",
+        "create",
+        "normalize"
+      ],
+      "requiredFields": {
+        "Status": [
+          "Backlog",
+          "Ready",
+          "In progress",
+          "In review",
+          "Done",
+          "Blocked"
+        ],
+        "Priority": [
+          "P0",
+          "P1",
+          "P2"
+        ],
+        "Size": [
+          "XS",
+          "S",
+          "M",
+          "L",
+          "XL"
+        ]
+      },
+      "normalizeBuiltInStatusFieldInPlace": true,
+      "mustLinkRepo": true,
+      "allowIntentionallyEmptyBoardWhenNoIssuesExist": true,
+      "cleanupDuplicateEmptyBoards": true,
+      "finalLiveStateReconciliationRequired": true
+    }
+  },
+  "bootstrap_commit_policy": {
+    "requiredModes": [
+      "required",
+      "allowed",
+      "forbidden"
+    ],
+    "mustClassifyStartingRepoState": true,
+    "dirtyRepoAllowedResolutions": [
+      "resolve-existing-work-first",
+      "stop-and-report-blocked",
+      "explicit-review-mode"
+    ]
+  },
+  "feedback_flow": {
+    "mustWriteLocalFeedbackFile": true,
+    "writeBeforeOrAlongsidePublicIssueFiling": true,
+    "mustScrubSensitiveData": true
+  },
   "stop_after_pre_coding_outputs": true,
   "task_completion_requirements": [
     "verification_evidence",
-    "traceability_update"
+    "traceability_update",
+    "final_state_reconciliation"
   ]
 }
-
-


### PR DESCRIPTION
## Summary\n- align machine-readable bootstrap sources (static/agent.txt, static/bootstrap.json) with stronger bootstrap contract requirements\n- add explicit repo-state + commit-policy semantics and durable local output artifact expectations\n- harden bootstrap/update/quickstart/feedback/GitHub-board docs for stateful GitHub setup\n- allow bootstrap-spec fallback for empty/underdefined repos instead of forcing guessed product feature scope\n- extend GOV-02 Git bootstrap requirements and regenerate published rule docs\n\n## OpenSpec\n- .governance/specs/bootstrap-contract-hardening-and-output-artifacts.md\n- BOOT-HARDEN-001 through BOOT-HARDEN-010\n\n## Validation\n- 
pm run build\n\nCloses #57\nCloses #58\nCloses #59