### PR TITLE
#63 store bootstrap artifacts as timestamped run history

### DIFF
--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -69,7 +69,7 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-020` Bootstrap must ensure repository linkage to the canonical board before claiming completion.
 - `GOV-02-GIT-021` GitHub built-in `Status` should be normalized in place when needed; bootstrap should not assume replacement via create/delete flows.
 - `GOV-02-GIT-022` If the repository has no issues, board setup may still be complete, but bootstrap must report the board as intentionally empty.
-- `GOV-02-GIT-023` Bootstrap must emit durable local status artifacts (for example `BOOTSTRAP_STATUS.md` and `BOOTSTRAP_FEEDBACK.md`) even when commit mode forbids committing.
+- `GOV-02-GIT-023` Bootstrap must emit durable local run-history artifacts under a timestamped path such as `.governance/project/bootstrap-runs/<timestamp>-status.md` and `.governance/project/bootstrap-runs/<timestamp>-feedback.md` even when commit mode forbids committing.
 - `GOV-02-GIT-024` Bootstrap is incomplete until generated docs/artifacts are reconciled against final live git/GitHub state after any auth refresh, board mutation, or cleanup action.
 
 This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.

--- a/.governance/specs/bootstrap-run-history-artifacts.md
+++ b/.governance/specs/bootstrap-run-history-artifacts.md
@@ -1,0 +1,57 @@
+# Bootstrap Run History Artifacts
+
+## Intent
+Preserve bootstrap evidence across repeated init, update, and review runs by writing bootstrap output artifacts into a timestamped run-history folder instead of relying only on singleton filenames. This matters because bootstrap is often iterative and stateful, and overwriting the prior status/feedback artifacts weakens reviewability, diffability, and audit history.
+
+## Scope
+In scope:
+- define timestamped bootstrap run-history artifact paths
+- define the expected status, feedback, and optional blockers files per run
+- allow stable top-level summary files only as convenience pointers/summaries to the latest run
+- update bootstrap, bootstrap-update, quickstart, feedback, contribute, FAQ, machine-readable bootstrap sources, and governed workflow wording accordingly
+
+Out of scope:
+- non-bootstrap run histories
+- binary artifact storage or compression
+- automatic pruning/retention policy for historical run artifacts
+
+## Acceptance Criteria
+- `BOOT-RUN-001` Bootstrap docs describe timestamped run-history artifacts under `.governance/project/bootstrap-runs/`.
+- `BOOT-RUN-002` Machine-readable bootstrap sources (`agent.txt`, `bootstrap.json`) describe the timestamped run-history structure.
+- `BOOT-RUN-003` The expected per-run artifacts include status and feedback files, with optional blockers files.
+- `BOOT-RUN-004` Stable top-level files may remain only as latest-run summaries/pointers and are not the sole historical artifact source.
+- `BOOT-RUN-005` Feedback guidance tells the agent to write the local feedback artifact into the timestamped run-history folder.
+- `BOOT-RUN-006` Governed workflow wording reflects durable timestamped bootstrap artifacts.
+- `BOOT-RUN-007` `npm run build` succeeds after the doc/rule/spec updates.
+
+## Tests and Evidence
+- inspect `static/agent.txt`
+- inspect `static/bootstrap.json`
+- inspect `docs/bootstrap.md`
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/bootstrap-feedback-prompt.md`
+- inspect `docs/quickstart.md`
+- inspect `docs/contribute.md`
+- inspect FAQ pages
+- inspect `.governance/rules/gov-02-workflow.mdc`
+- inspect `docs/published/gov-02-workflow.md`
+- run `npm run build`
+
+## Documentation Impact
+- update `static/agent.txt`
+- update `static/bootstrap.json`
+- update `docs/bootstrap.md`
+- update `docs/bootstrap-update.md`
+- update `docs/bootstrap-feedback-prompt.md`
+- update `docs/quickstart.md`
+- update `docs/contribute.md`
+- update `docs/faq/when-do-i-use-the-feedback-prompt.md`
+- update `.governance/rules/gov-02-workflow.mdc`
+- update `docs/published/gov-02-workflow.md`
+
+## Verification
+Verification is documentation-driven. Success requires the public bootstrap docs, machine-readable bootstrap sources, and governed workflow wording to consistently describe timestamped bootstrap run-history artifacts, plus a successful site build.
+
+## Change Notes
+- Prefer `.governance/project/bootstrap-runs/<timestamp>-*.md` over singleton bootstrap artifact files.
+- Allow top-level summary files only as convenience pointers/summaries to the latest run.

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -30,7 +30,8 @@ Before finalizing:
 - keep the feedback useful for a public issue
 
 Then produce BOTH:
-1) a local feedback artifact at `.governance/project/BOOTSTRAP_FEEDBACK.md`
+1) a local feedback artifact at `.governance/project/bootstrap-runs/<timestamp>-feedback.md`
+   - optional stable top-level summary/pointer: `.governance/project/BOOTSTRAP_FEEDBACK.md`
 2) a GitHub issue-ready payload:
    - title
    - body
@@ -44,6 +45,6 @@ If issue filing is explicitly requested:
 ## What to do next
 
 1. Run the prompt.
-2. Review the generated local feedback artifact.
+2. Review the generated timestamped local feedback artifact.
 3. Open/file the GitHub issue using the scrubbed title/body.
 4. Link affected page/rule/prompt sections.

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -24,10 +24,11 @@ Before writing any product code:
 6. For GitHub repos, run capability preflight before board mutation and report each dependency as `configured`, `blocked-with-tracked-issue`, or `not-applicable`.
 7. Choose exactly one canonical board target (adopt/create/normalize), normalize fields, ensure repo linkage, handle duplicate empty board cleanup if needed, and report final board state.
 8. If no issues exist, still create/normalize/report board and mark intentionally empty.
-9. Write durable output artifacts:
-   - `.governance/project/BOOTSTRAP_STATUS.md`
-   - `.governance/project/BOOTSTRAP_FEEDBACK.md`
-   - optional `.governance/project/BOOTSTRAP_BLOCKERS.md`
+9. Write durable output artifacts into `.governance/project/bootstrap-runs/`:
+   - `<timestamp>-status.md`
+   - `<timestamp>-feedback.md`
+   - optional `<timestamp>-blockers.md`
+   - stable top-level files may exist only as latest-run summaries/pointers
 10. Reconcile all generated docs against final live git/GitHub state before claiming completion.
 
 Then stop before product-code implementation.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -49,10 +49,11 @@ Before writing any product code:
    - if no issues exist, report board as intentionally empty
    - clean accidental duplicate empty boards and report cleanup
 13. If GitHub automation is unavailable, report exact missing capability and leave a tracked blocker artifact.
-14. Write durable local output artifacts:
-   - `.governance/project/BOOTSTRAP_STATUS.md`
-   - `.governance/project/BOOTSTRAP_FEEDBACK.md`
-   - optional `.governance/project/BOOTSTRAP_BLOCKERS.md`
+14. Write durable local output artifacts into `.governance/project/bootstrap-runs/`:
+   - `<timestamp>-status.md`
+   - `<timestamp>-feedback.md`
+   - optional `<timestamp>-blockers.md`
+   - stable top-level files may exist only as latest-run summaries/pointers
 15. Reconcile generated docs against final live git/GitHub state before claiming completion.
 
 Then stop before product-code implementation.
@@ -71,7 +72,7 @@ Continue only if all are true:
 - starting repo state and commit-policy mode are reported
 - for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`)
 - for GitHub repos with automation, canonical board target is adopted/created/normalized and repo-link status is reported
-- bootstrap status + feedback artifacts are written
+- timestamped bootstrap status + feedback artifacts are written under `.governance/project/bootstrap-runs/`
 - final docs are reconciled with final live git/GitHub state
 - no product code was written
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -38,8 +38,9 @@ Use the [Branch Protection Checklist](/docs/branch-protection-checklist) when se
 If you have just run a fresh bootstrap or an update/remediation pass, use the [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt).
 
 Expected feedback flow:
-1. write scrubbed feedback to `.governance/project/BOOTSTRAP_FEEDBACK.md`
-2. then raise a GitHub issue with the scrubbed result (or auto-file when requested)
+1. write scrubbed feedback to `.governance/project/bootstrap-runs/<timestamp>-feedback.md`
+2. optionally update `.governance/project/BOOTSTRAP_FEEDBACK.md` as the latest summary/pointer
+3. then raise a GitHub issue with the scrubbed result (or auto-file when requested)
 
 Before posting, remove or obfuscate PII, secrets, tokens, emails, usernames, IDs, URLs, and environment-specific sensitive details.
 

--- a/docs/faq/when-do-i-use-the-feedback-prompt.md
+++ b/docs/faq/when-do-i-use-the-feedback-prompt.md
@@ -9,7 +9,8 @@ question: When do I use the feedback prompt?
 Use the **bootstrap feedback prompt** after bootstrap init/update when you want durable, scrubbed feedback.
 
 Expected output:
-1. local file: `.governance/project/BOOTSTRAP_FEEDBACK.md`
-2. issue-ready title/body for `governance-foundation/vibegov.io`
+1. local file: `.governance/project/bootstrap-runs/<timestamp>-feedback.md`
+2. optional latest summary/pointer: `.governance/project/BOOTSTRAP_FEEDBACK.md`
+3. issue-ready title/body for `governance-foundation/vibegov.io`
 
 If asked to file automatically, file and return the created issue URL.

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -94,7 +94,7 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-020` Bootstrap must ensure repository linkage to the canonical board before claiming completion.
 - `GOV-02-GIT-021` GitHub built-in `Status` should be normalized in place when needed; bootstrap should not assume replacement via create/delete flows.
 - `GOV-02-GIT-022` If the repository has no issues, board setup may still be complete, but bootstrap must report the board as intentionally empty.
-- `GOV-02-GIT-023` Bootstrap must emit durable local status artifacts (for example `BOOTSTRAP_STATUS.md` and `BOOTSTRAP_FEEDBACK.md`) even when commit mode forbids committing.
+- `GOV-02-GIT-023` Bootstrap must emit durable local run-history artifacts under a timestamped path such as `.governance/project/bootstrap-runs/<timestamp>-status.md` and `.governance/project/bootstrap-runs/<timestamp>-feedback.md` even when commit mode forbids committing.
 - `GOV-02-GIT-024` Bootstrap is incomplete until generated docs/artifacts are reconciled against final live git/GitHub state after any auth refresh, board mutation, or cleanup action.
 
 This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,10 +30,11 @@ Initialization contract:
    - `Priority`: P0, P1, P2
    - `Size`: XS, S, M, L, XL
 12) Import/attach existing issues; if none exist, report intentionally empty board.
-13) Write durable output artifacts:
-   - `.governance/project/BOOTSTRAP_STATUS.md`
-   - `.governance/project/BOOTSTRAP_FEEDBACK.md`
-   - optional `.governance/project/BOOTSTRAP_BLOCKERS.md`
+13) Write durable output artifacts into `.governance/project/bootstrap-runs/`:
+   - `<timestamp>-status.md`
+   - `<timestamp>-feedback.md`
+   - optional `<timestamp>-blockers.md`
+   - stable top-level files may exist only as latest-run summaries/pointers
 14) Reconcile docs against final live git/GitHub state.
 
 Then stop before product-code implementation.

--- a/static/agent.txt
+++ b/static/agent.txt
@@ -48,11 +48,12 @@ repo-state discipline:
 
 durable output artifacts:
 - every bootstrap run must leave durable local output artifacts even when commits are forbidden
-- expected review artifacts include:
-  - .governance/project/BOOTSTRAP_STATUS.md
-  - .governance/project/BOOTSTRAP_FEEDBACK.md
-  - optional: .governance/project/BOOTSTRAP_BLOCKERS.md
-- bootstrap feedback should be written to a local file before or alongside any public GitHub issue filing
+- write per-run artifacts into:
+  - .governance/project/bootstrap-runs/<timestamp>-status.md
+  - .governance/project/bootstrap-runs/<timestamp>-feedback.md
+  - optional: .governance/project/bootstrap-runs/<timestamp>-blockers.md
+- stable top-level files such as BOOTSTRAP_STATUS.md / BOOTSTRAP_FEEDBACK.md may exist only as latest-run summaries or pointers
+- bootstrap feedback should be written to the timestamped local run-history file before or alongside any public GitHub issue filing
 
 delivery loop:
 - Observe -> Plan -> Implement -> Verify -> Document

--- a/static/bootstrap.json
+++ b/static/bootstrap.json
@@ -77,10 +77,13 @@
       ".github/branch-protection-checklist.md"
     ],
     "requiredStatusArtifacts": [
-      ".governance/project/BOOTSTRAP_STATUS.md",
-      ".governance/project/BOOTSTRAP_FEEDBACK.md"
+      ".governance/project/bootstrap-runs/<timestamp>-status.md",
+      ".governance/project/bootstrap-runs/<timestamp>-feedback.md"
     ],
     "optionalStatusArtifacts": [
+      ".governance/project/bootstrap-runs/<timestamp>-blockers.md",
+      ".governance/project/BOOTSTRAP_STATUS.md",
+      ".governance/project/BOOTSTRAP_FEEDBACK.md",
       ".governance/project/BOOTSTRAP_BLOCKERS.md",
       ".governance/project/GIT_WORKFLOW.md",
       ".governance/project/GITHUB_PROJECT_STATUS.md",
@@ -137,6 +140,7 @@
   },
   "feedback_flow": {
     "mustWriteLocalFeedbackFile": true,
+    "localFeedbackRunHistoryPath": ".governance/project/bootstrap-runs/<timestamp>-feedback.md",
     "writeBeforeOrAlongsidePublicIssueFiling": true,
     "mustScrubSensitiveData": true
   },


### PR DESCRIPTION
## Summary
- switch bootstrap status/feedback/blocker guidance to timestamped run-history artifacts under .governance/project/bootstrap-runs/
- keep top-level bootstrap files only as optional latest-run summaries/pointers
- update machine-readable bootstrap sources, bootstrap docs, feedback docs, quickstart, contribute guidance, and governed workflow wording

## OpenSpec
- .governance/specs/bootstrap-run-history-artifacts.md
- BOOT-RUN-001 through BOOT-RUN-007

## Validation
- 
ode scripts/generate-published-rules.js
- 
pm run build

Closes #63