### PR TITLE
#61 unify bootstrap init, update, and review under one contract

### DIFF
--- a/.governance/specs/bootstrap-mode-selection-and-canonical-contract.md
+++ b/.governance/specs/bootstrap-mode-selection-and-canonical-contract.md
@@ -1,0 +1,55 @@
+# Bootstrap Mode Selection and Canonical Contract
+
+## Intent
+Prevent contract drift between bootstrap init, bootstrap update, and bootstrap review by defining one canonical bootstrap contract with explicit mode selection. All bootstrap modes should share the same completion bar, artifact expectations, GitHub preflight behavior, board normalization rules, output artifact rules, and final live-state reconciliation rules. Modes should differ only in how they act on the repo state.
+
+## Scope
+In scope:
+- define explicit bootstrap modes: `init`, `update`, `review`
+- establish one canonical bootstrap contract shared by all modes
+- update machine-readable bootstrap sources to expose mode selection
+- update public bootstrap docs so `bootstrap.md` becomes the canonical contract surface
+- reduce `bootstrap-update.md` to mode-specific guidance pointing back to the canonical contract
+- add a review/audit mode doc or equivalent mode guidance without forking the contract
+- update FAQs and related adoption docs to reflect mode selection
+
+Out of scope:
+- changing non-bootstrap product delivery semantics
+- adding a separate alternate review checklist that forks the bootstrap contract
+- implementing repo automation beyond documented bootstrap behavior
+
+## Acceptance Criteria
+- `BOOT-MODE-001` VibeGov defines explicit bootstrap modes `init`, `update`, and `review`.
+- `BOOT-MODE-002` `docs/bootstrap.md` is the canonical bootstrap contract surface for all modes.
+- `BOOT-MODE-003` `docs/bootstrap-update.md` refers back to the canonical bootstrap contract instead of defining a divergent completion bar.
+- `BOOT-MODE-004` Review/audit guidance uses the same contract and differs only in audit behavior, not in pass gate requirements.
+- `BOOT-MODE-005` `static/agent.txt` and `static/bootstrap.json` expose the same mode model.
+- `BOOT-MODE-006` Public docs make clear that mode differences are behavioral only:
+  - `init` creates missing bootstrap state
+  - `update` repairs/normalizes existing bootstrap state
+  - `review` audits/reports gaps without claiming missing work was completed
+- `BOOT-MODE-007` `npm run build` succeeds after the docs/spec/source updates.
+
+## Tests and Evidence
+- inspect `static/agent.txt`
+- inspect `static/bootstrap.json`
+- inspect `docs/bootstrap.md`
+- inspect `docs/bootstrap-update.md`
+- inspect the review-mode doc/guidance
+- inspect bootstrap-related FAQ pages
+- run `npm run build`
+
+## Documentation Impact
+- update `static/agent.txt`
+- update `static/bootstrap.json`
+- update `docs/bootstrap.md`
+- update `docs/bootstrap-update.md`
+- add or update review-mode bootstrap guidance
+- update relevant FAQ pages
+
+## Verification
+Verification is documentation-driven. Success requires machine-readable and public docs to describe one canonical bootstrap contract with explicit mode selection and no divergent completion bar between init, update, and review, plus a successful site build.
+
+## Change Notes
+- Prefer one contract + mode selection over multiple bootstrap prompts with similar but drifting requirements.
+- Do not create a standalone review checklist that becomes a second contract surface.

--- a/docs/bootstrap-review.md
+++ b/docs/bootstrap-review.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 4
+---
+
+# Bootstrap Review
+
+Use this when a repo already has some bootstrap state and you want to **audit it against the same canonical bootstrap contract** without pretending missing work was completed.
+
+This is **not** a separate bootstrap contract.
+It is the same contract from [Bootstrap](/docs/bootstrap), run in **`review` mode**.
+
+## Mode behavior
+
+- `init` — create missing bootstrap state
+- `update` — repair/normalize existing bootstrap state
+- `review` — audit against the same contract, write findings, and do not claim missing work was completed
+
+## Review prompt
+
+```text
+Run VibeGov bootstrap in `review` mode.
+Read and follow:
+- https://vibegov.io/agent.txt
+- https://vibegov.io/bootstrap.json
+- https://vibegov.io/docs/bootstrap/
+
+Use the same canonical bootstrap contract and pass gate as bootstrap init/update.
+Do not fork the contract.
+Do not claim missing work was completed.
+
+Review the repo against the canonical bootstrap contract.
+Write timestamped run-history artifacts under `.governance/project/bootstrap-runs/`.
+Report:
+- what already satisfies the contract
+- what is missing or weak
+- what is blocked
+- what exact next fixes are required
+```
+
+## Rule
+
+If a repo fails bootstrap review, the next remediation pass should use **bootstrap update** against the same canonical contract.

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -4,32 +4,28 @@ sidebar_position: 3
 
 # Bootstrap Update
 
-Copy this as message 1 in any coding agent when the repo already has some VibeGov bootstrap state and you want repair/normalization instead of a fresh start.
+`bootstrap update` is **bootstrap run in `update` mode**.
+
+It does **not** use a weaker or different contract.
+Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
+
+## Update behavior
+
+- preserve valid existing artifacts
+- repair stale, missing, contradictory, or weak artifacts
+- keep the same pass gate as `init`
+- if the repo still fails the contract, report exact blockers/gaps instead of claiming partial completion
+
+## Update prompt
 
 ```text
-Update this repo's VibeGov bootstrap state.
+Run VibeGov bootstrap in mode: update.
 Read and follow:
 - https://vibegov.io/agent.txt
 - https://vibegov.io/bootstrap.json
+- https://vibegov.io/docs/bootstrap/
 
-This is an update/remediation pass, not a fresh bootstrap.
+Use the canonical bootstrap contract.
 Do not restart from scratch when valid artifacts already exist.
-
-Before writing any product code:
-1. Inspect existing `.governance/`, `AGENTS.md`, project intent, specs, backlog, `.github/` workflow artifacts, and current Git/GitHub state.
-2. Classify start state (branch, clean/dirty tree, untracked/uncommitted changes) and declare commit policy mode (`required`, `allowed`, `forbidden`).
-3. Preserve valid artifacts; repair only stale, missing, contradictory, or weak artifacts.
-4. Keep `.governance/` canonical and report active governance sources.
-5. If product intent is vague, allow `SPEC-001` to be a bootstrap/governance setup spec instead of inventing product scope.
-6. For GitHub repos, run capability preflight before board mutation and report each dependency as `configured`, `blocked-with-tracked-issue`, or `not-applicable`.
-7. Choose exactly one canonical board target (adopt/create/normalize), normalize fields, ensure repo linkage, handle duplicate empty board cleanup if needed, and report final board state.
-8. If no issues exist, still create/normalize/report board and mark intentionally empty.
-9. Write durable output artifacts into `.governance/project/bootstrap-runs/`:
-   - `<timestamp>-status.md`
-   - `<timestamp>-feedback.md`
-   - optional `<timestamp>-blockers.md`
-   - stable top-level files may exist only as latest-run summaries/pointers
-10. Reconcile all generated docs against final live git/GitHub state before claiming completion.
-
-Then stop before product-code implementation.
+Repair or normalize the repo until the same bootstrap contract is satisfied, or report exact blockers.
 ```

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -4,29 +4,45 @@ sidebar_position: 2
 
 # Bootstrap
 
-Copy this as message 1 in any coding agent.
+This is the **canonical bootstrap contract** for VibeGov.
+
+Use the same contract in one of three explicit modes:
+- `init`
+- `update`
+- `review`
+
+Mode differences are behavioral only:
+- `init` creates missing bootstrap state
+- `update` repairs/normalizes existing bootstrap state
+- `review` audits against the same contract without claiming missing work was completed
+
+## Canonical bootstrap prompt
 
 ```text
-Bootstrap this repo with VibeGov.
+Run VibeGov bootstrap in mode: <init|update|review>.
 Read and follow:
 - https://vibegov.io/agent.txt
 - https://vibegov.io/bootstrap.json
+- https://vibegov.io/docs/bootstrap/
 
-Before writing any product code:
-1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/`.
-2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+Use the same canonical bootstrap contract for all modes.
+Do not fork or weaken the pass gate by mode.
+
+Before writing any product code (or before claiming bootstrap review is complete):
+1. Create/normalize `.governance/rules/`, `.governance/project/`, and `.governance/specs/` as needed for the selected mode.
+2. Ensure the active VibeGov rule set (`GOV-01` through `GOV-08`) is installed in `.governance/rules/`.
 3. Detect existing provider-native rules directories and mirror `.governance/rules/*.mdc` only when they already exist.
 4. Create or normalize `.governance/project/PROJECT_INTENT.md`.
 5. Create `SPEC-001` as either:
    - `.governance/specs/SPEC-001-<feature>.md`, or
    - a bootstrap/governance-setup spec when product intent is still too vague.
 6. Create or normalize a backlog mapped to the spec sections.
-7. Install strict Git workflow artifacts before implementation:
+7. Install or verify strict Git workflow artifacts before implementation:
    - `AGENTS.md`
    - `.github/pull_request_template.md`
    - `.github/branch-protection-checklist.md`
    - documented default issue-pickup flow
-8. Classify starting repo state before edits:
+8. Classify starting repo state before edits or review conclusions:
    - current branch
    - clean/dirty working tree
    - untracked files
@@ -56,6 +72,11 @@ Before writing any product code:
    - stable top-level files may exist only as latest-run summaries/pointers
 15. Reconcile generated docs against final live git/GitHub state before claiming completion.
 
+Mode-specific behavior:
+- `init`: create the missing bootstrap state required by the contract
+- `update`: preserve valid existing artifacts and repair stale/missing/contradictory ones until the same contract is satisfied
+- `review`: audit the repo against the same contract, write findings and blockers, and do not claim missing work was completed
+
 Then stop before product-code implementation.
 ```
 
@@ -76,4 +97,6 @@ Continue only if all are true:
 - final docs are reconciled with final live git/GitHub state
 - no product code was written
 
-If any fail, rerun bootstrap/update with remediation mode.
+If any fail:
+- `init` and `update` are incomplete
+- `review` must report the exact gaps and blockers without pretending the repo is bootstrapped

--- a/docs/faq/when-do-i-use-bootstrap-init.md
+++ b/docs/faq/when-do-i-use-bootstrap-init.md
@@ -8,8 +8,8 @@ question: When do I use bootstrap init?
 
 Use **bootstrap init** when a repo does not have VibeGov installed yet.
 
-Init should produce both:
-- the governance scaffold (`.governance/` + `SPEC-001` + backlog)
-- the operational bootstrap package (workflow artifacts, GitHub preflight/board outcome, and bootstrap status artifacts)
+This is the canonical bootstrap contract run in **`init` mode**.
+It creates missing bootstrap state using the same pass gate used by `update` and `review`.
 
-If product intent is too vague, `SPEC-001` can be a bootstrap/governance setup spec instead of a guessed product feature spec.
+Canonical doc:
+- [Bootstrap](/docs/bootstrap)

--- a/docs/faq/when-do-i-use-bootstrap-review.md
+++ b/docs/faq/when-do-i-use-bootstrap-review.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 5
+homepage: true
+question: When do I use bootstrap review?
+---
+
+# When do I use bootstrap review?
+
+Use **bootstrap review** when you want to audit a repo against the canonical bootstrap contract without claiming missing work was completed.
+
+This is the canonical bootstrap contract run in **`review` mode**.
+If review finds gaps, the next remediation pass should use `bootstrap update` against the same contract.
+
+Canonical docs:
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Review](/docs/bootstrap-review)

--- a/docs/faq/when-do-i-use-bootstrap-update.md
+++ b/docs/faq/when-do-i-use-bootstrap-update.md
@@ -6,6 +6,11 @@ question: When do I use bootstrap update?
 
 # When do I use bootstrap update?
 
-Use **bootstrap update** when a repo already has partial VibeGov state and needs repair/normalization.
+Use **bootstrap update** when a repo already has partial bootstrap state and needs repair/normalization.
 
-Update mode should preserve valid artifacts and repair stale/missing/contradictory state, then revalidate docs against final live git/GitHub state before claiming completion.
+This is the canonical bootstrap contract run in **`update` mode**.
+It uses the same completion bar as `init`; it just preserves valid artifacts and repairs missing or weak ones.
+
+Canonical docs:
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Update](/docs/bootstrap-update)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,10 +6,17 @@ sidebar_position: 3
 
 Use this to install VibeGov quickly with the hardened bootstrap contract.
 
+Bootstrap now uses one canonical contract with explicit modes:
+- `init`
+- `update`
+- `review`
+
+Use [Bootstrap](/docs/bootstrap) as the canonical contract surface.
+
 ## Copy-paste bootstrap prompt
 
 ```text
-Bootstrap this repo with VibeGov.
+Run VibeGov bootstrap in mode: <init|update|review>.
 Read and follow:
 - https://vibegov.io/agent.txt
 - https://vibegov.io/bootstrap.json

--- a/static/agent.txt
+++ b/static/agent.txt
@@ -14,7 +14,13 @@ scope rules:
 bootstrap contract:
 - use https://vibegov.io/agent.txt and https://vibegov.io/bootstrap.json as the canonical bootstrap sources
 - do not rely on redirected or stale bootstrap sources
+- bootstrap must use one canonical contract with explicit mode selection: init, update, or review
 - bootstrap is not complete for a GitHub-hosted repo when only the .governance scaffold exists
+
+mode behavior:
+- init: create missing bootstrap state using the canonical contract
+- update: repair or normalize existing bootstrap state using the same canonical contract
+- review: audit the repo against the same canonical contract, write findings and blockers, and do not claim missing work was completed
 
 hard gate before product code:
 - create or normalize:

--- a/static/bootstrap.json
+++ b/static/bootstrap.json
@@ -6,6 +6,19 @@
     "agent": "https://vibegov.io/agent.txt",
     "bootstrap": "https://vibegov.io/bootstrap.json"
   },
+  "modes": {
+    "canonicalContractDoc": "/docs/bootstrap",
+    "supported": [
+      "init",
+      "update",
+      "review"
+    ],
+    "behavior": {
+      "init": "create_missing_bootstrap_state",
+      "update": "repair_or_normalize_existing_bootstrap_state",
+      "review": "audit_against_same_contract_without_claiming_missing_work_completed"
+    }
+  },
   "folders": [
     ".governance/rules",
     ".governance/project",


### PR DESCRIPTION
## Summary
- define explicit bootstrap modes: `init`, `update`, and `review`
- make `docs/bootstrap.md` the canonical bootstrap contract surface for all modes
- add `bootstrap-review` guidance without creating a second contract
- expose the same mode model in `agent.txt` and `bootstrap.json`
- tighten update/FAQ/quickstart wording so mode differences are behavioral only

## OpenSpec
- `.governance/specs/bootstrap-mode-selection-and-canonical-contract.md`
- `BOOT-MODE-001` through `BOOT-MODE-007`

## Validation
- `npm run build`

Closes #61
