### PR TITLE
#62 tighten GitHub bootstrap setup and state reconciliation

### DIFF
--- a/.governance/specs/github-project-setup-and-state-reconciliation.md
+++ b/.governance/specs/github-project-setup-and-state-reconciliation.md
@@ -1,0 +1,45 @@
+# GitHub Project Setup and State Reconciliation
+
+## Intent
+Make GitHub project setup during bootstrap explicit enough that real bootstrap/update runs can complete without ambiguous board selection, duplicate-board drift, stale reporting, or half-configured GitHub state. This matters because GitHub-hosted bootstrap is stateful and mutation-heavy, and weak sequencing or weak reporting causes retries, confusion, and false completion claims.
+
+## Scope
+In scope:
+- explicit GitHub preflight before any board action
+- explicit board phases and ordering: adopt/create then normalize
+- canonical board selection when multiple matching boards exist
+- duplicate empty-board cleanup behavior
+- repo-to-board linking as a completion requirement
+- built-in `Status` normalization guidance
+- early `AGENTS.md` creation during bootstrap
+- explicit `develop` branch expectation guidance
+- final live-state reconciliation after GitHub mutations
+- distinguishing historical evidence from current state in bootstrap reports/docs
+
+Out of scope:
+- automating GitHub rulesets or protections directly
+- non-GitHub board providers
+- changing the non-bootstrap delivery workflow
+
+## Acceptance Criteria
+- `GH-SETUP-001` Bootstrap docs require GitHub auth, repo access, project read access, and project write access before any board mutation.
+- `GH-SETUP-002` Bootstrap docs define board phases in order: adopt/create, then normalize.
+- `GH-SETUP-003` Bootstrap docs define how to choose one canonical board when multiple matching boards exist.
+- `GH-SETUP-004` Bootstrap docs define duplicate empty-board cleanup behavior explicitly.
+- `GH-SETUP-005` Bootstrap docs require repo-to-board linking before bootstrap is complete.
+- `GH-SETUP-006` Bootstrap docs define built-in `Status` normalization in place.
+- `GH-SETUP-007` Bootstrap docs require `AGENTS.md` early as part of initial bootstrap, not only as remediation.
+- `GH-SETUP-008` Bootstrap docs state whether `develop` must be created locally during bootstrap and whether remote/protection expectations should be reported separately.
+- `GH-SETUP-009` Bootstrap docs require a final live-state reconciliation pass and distinguish current state from historical evidence.
+- `GH-SETUP-010` `npm run build` succeeds after the updates.
+
+## Tests and Evidence
+- inspect `docs/github-project-bootstrap.md`
+- inspect `docs/bootstrap.md`
+- inspect `static/agent.txt`
+- inspect `static/bootstrap.json`
+- inspect relevant FAQ/bootstrap docs
+- run `npm run build`
+
+## Verification
+Verification is documentation-driven. Success requires GitHub bootstrap behavior to be explicit enough that a bootstrap run can determine one canonical board target, normalize it, link the repo, report current state accurately, and distinguish repaired history from final live state.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -38,7 +38,7 @@ Before writing any product code (or before claiming bootstrap review is complete
    - a bootstrap/governance-setup spec when product intent is still too vague.
 6. Create or normalize a backlog mapped to the spec sections.
 7. Install or verify strict Git workflow artifacts before implementation:
-   - `AGENTS.md`
+   - `AGENTS.md` (create this early so future agents have a repo-local entrypoint)
    - `.github/pull_request_template.md`
    - `.github/branch-protection-checklist.md`
    - documented default issue-pickup flow
@@ -57,6 +57,7 @@ Before writing any product code (or before claiming bootstrap review is complete
    - project read access
    - project write access
 12. If GitHub automation is available, create/adopt/normalize one canonical board target:
+   - if multiple matching boards exist, choose one canonical target explicitly and report why it was chosen
    - normalize `Status`: `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Blocked`
    - normalize `Priority`: `P0`, `P1`, `P2`
    - normalize `Size`: `XS`, `S`, `M`, `L`, `XL`
@@ -71,6 +72,7 @@ Before writing any product code (or before claiming bootstrap review is complete
    - optional `<timestamp>-blockers.md`
    - stable top-level files may exist only as latest-run summaries/pointers
 15. Reconcile generated docs against final live git/GitHub state before claiming completion.
+16. Distinguish final current state from historical evidence gathered earlier in the run.
 
 Mode-specific behavior:
 - `init`: create the missing bootstrap state required by the contract
@@ -92,7 +94,7 @@ Continue only if all are true:
 - strict Git workflow artifacts exist
 - starting repo state and commit-policy mode are reported
 - for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`)
-- for GitHub repos with automation, canonical board target is adopted/created/normalized and repo-link status is reported
+- for GitHub repos with automation, canonical board target is adopted/created/normalized, repo-link status is reported, and multiple-match selection is explained when relevant
 - timestamped bootstrap status + feedback artifacts are written under `.governance/project/bootstrap-runs/`
 - final docs are reconciled with final live git/GitHub state
 - no product code was written

--- a/docs/github-project-bootstrap.md
+++ b/docs/github-project-bootstrap.md
@@ -21,16 +21,20 @@ Required checks:
 - project read access
 - project write access
 
-If any required capability is missing, report exact missing capability and stop board mutation.
+If any required capability is missing, report the exact missing capability and stop board mutation.
 
 ## Canonical board decision flow
 
-Bootstrap must choose exactly one canonical board target:
-1. **adopt** an existing suitable board, or
-2. **create** a new dedicated board when none is suitable,
+Bootstrap must choose exactly one canonical board target and follow this order:
+1. **adopt** an existing suitable board if one clean match exists,
+2. otherwise **create** a new dedicated board,
 3. then **normalize** canonical fields/options in place.
 
-Do not leave multiple competing board targets unresolved.
+If multiple matching boards exist:
+- choose one canonical board explicitly
+- prefer the board already linked to the repo when present
+- otherwise prefer the cleanest dedicated board with the expected canonical fields
+- do not leave multiple competing board targets unresolved
 
 If retries produced duplicate empty boards:
 - keep one canonical board
@@ -55,13 +59,29 @@ Repo linkage rule:
 No-issues fallback:
 - if repo has no issues, board can still be complete and should be reported as intentionally empty.
 
+## Branch/bootstrap expectations
+
+- `AGENTS.md` should be created early during bootstrap so future agents have a repo-local entrypoint into the canonical `.governance/` sources and current board state.
+- Bootstrap should create `develop` locally when the strict Git workflow is being installed, unless explicitly blocked.
+- Remote push/protection state for `develop` should be reported separately instead of being silently assumed.
+
+## Current state vs historical evidence
+
+Bootstrap reports should distinguish:
+- **current state** — the final live git/GitHub state after the run finishes
+- **historical evidence** — what was observed or repaired earlier in the run
+
+Do not leave stale intermediate state described as if it were still current after auth refreshes, board mutations, or cleanup actions.
+
 ## Completion evidence
 
 For GitHub-hosted bootstrap, report:
 - canonical board URL
 - board action path used (`adopt/create/normalize`)
+- why that board was selected when multiple matches existed
 - repo-link status
 - field/status normalization result
 - issue import/attach result (or intentionally empty)
 - any blockers/missing capabilities
+- `develop` branch local/remote/protection status
 - final live-state reconciliation result

--- a/static/agent.txt
+++ b/static/agent.txt
@@ -28,7 +28,7 @@ hard gate before product code:
   - .governance/specs/SPEC-001-<feature>.md or a bootstrap/governance setup spec when product intent is still too vague
   - backlog mapped to spec sections
 - install or report the Git workflow artifacts required before implementation:
-  - AGENTS.md
+  - AGENTS.md (create this early)
   - pull request template
   - branch-protection checklist
   - documented default issue-pickup flow
@@ -39,7 +39,7 @@ hard gate before product code:
   - project read access
   - project write access
   - repo access
-- if GitHub automation is available, create, adopt, or normalize one canonical board target, link the repo, normalize the canonical fields, and report the final live board state
+- if GitHub automation is available, create, adopt, or normalize one canonical board target, explain canonical-board selection when multiple matches exist, link the repo, normalize the canonical fields, and report the final live board state
 - if GitHub automation is unavailable, report the exact missing capability and leave a tracked blocker or equivalent durable blocker note instead of silently treating bootstrap as complete
 - then stop
 
@@ -70,3 +70,4 @@ active rules:
 completion rule:
 - each completed task must include verification evidence and traceability update
 - bootstrap completion must reflect the final live git/GitHub state, not a stale intermediate state
+- reports must distinguish historical evidence from current final state when the run repaired or mutated GitHub state mid-flight

--- a/static/bootstrap.json
+++ b/static/bootstrap.json
@@ -85,7 +85,7 @@
       "not-applicable"
     ],
     "requiredWorkflowArtifacts": [
-      "AGENTS.md",
+      "AGENTS.md_early_repo_entrypoint",
       ".github/pull_request_template.md",
       ".github/branch-protection-checklist.md"
     ],
@@ -104,6 +104,7 @@
     ],
     "board": {
       "mustChooseSingleCanonicalTarget": true,
+      "mustExplainCanonicalSelectionWhenMultipleMatchesExist": true,
       "allowedActions": [
         "adopt",
         "create",
@@ -135,7 +136,8 @@
       "mustLinkRepo": true,
       "allowIntentionallyEmptyBoardWhenNoIssuesExist": true,
       "cleanupDuplicateEmptyBoards": true,
-      "finalLiveStateReconciliationRequired": true
+      "finalLiveStateReconciliationRequired": true,
+      "mustDistinguishHistoricalEvidenceFromCurrentState": true
     }
   },
   "bootstrap_commit_policy": {


### PR DESCRIPTION
## Summary
- make GitHub board preflight and board-selection behavior more explicit in bootstrap docs
- require canonical-board selection explanation when multiple matches exist
- clarify AGENTS.md early creation, develop reporting, and current-vs-historical state reporting
- expose the same GitHub bootstrap expectations in machine-readable sources

## OpenSpec
- .governance/specs/github-project-setup-and-state-reconciliation.md
- GH-SETUP-001 through GH-SETUP-010

## Validation
- 
pm run build

Closes #62