### PR TITLE
#27 write AI completeness not speed post

### DIFF
--- a/blog/2026-03-29-ai-should-raise-the-standard-for-done.md
+++ b/blog/2026-03-29-ai-should-raise-the-standard-for-done.md
@@ -272,7 +272,7 @@ That is the version of AI leverage worth building toward.
 ## Series navigation
 
 - **1. AI Should Raise the Standard for Done** ← you are here
-- 2. AI Should Increase Completeness, Not Just Speed *(planned)*
+- 2. [AI Should Increase Completeness, Not Just Speed](/blog/ai-should-increase-completeness-not-just-speed)
 - 3. AI Makes Quality More Affordable, So Expectations Should Rise *(planned)*
 - 4. Tests, Specs, and Docs Are No Longer Cheap Excuses to Skip *(planned)*
 - 5. AI-Native Contribution Should Be Measured in Completeness *(planned)*

--- a/blog/2026-04-05-ai-should-increase-completeness-not-just-speed.md
+++ b/blog/2026-04-05-ai-should-increase-completeness-not-just-speed.md
@@ -1,0 +1,307 @@
+---
+slug: ai-should-increase-completeness-not-just-speed
+title: "AI Should Increase Completeness, Not Just Speed"
+authors: [VibeGov_team]
+tags: [governance, ai, quality, delivery]
+---
+
+This is the second piece in the VibeGov series about AI, quality, and completeness.
+
+The first post made one claim clear:
+
+> if AI increases delivery capacity, the standard for done should rise.
+
+This follow-up sharpens the point.
+
+The real gain from AI should not show up only as faster implementation.
+It should show up as more complete delivery.
+
+That means AI should help teams produce more of the things that make work trustworthy:
+- stronger tests
+- clearer specs
+- current documentation
+- better traceability
+- more explicit validation evidence
+- cleaner handoff and release clarity
+
+Not just more code.
+
+## Speed is visible, completeness is valuable
+
+A lot of AI adoption still gets judged through the easiest metric to notice:
+- how fast a draft appeared
+- how quickly a feature branch moved
+- how many tickets got touched
+- how much code was produced in a day
+
+That is understandable.
+Speed is visible.
+Completeness often is not.
+
+But software delivery does not really fail because code appeared too slowly in isolation.
+It fails because the surrounding proof and clarity were too weak.
+
+Teams get hurt by things like:
+- thin regression coverage
+- vague issue bodies
+- missing or stale specs
+- documentation that no longer matches reality
+- pull requests that are hard to review
+- release status that sounds confident but proves very little
+- changes that technically landed but remain hard to trust or extend
+
+AI should help reduce those gaps.
+If it only helps a team type faster, then it is amplifying the easiest part of the job while leaving the expensive uncertainty untouched.
+
+## Incompleteness is what creates drag later
+
+There is a reason VibeGov keeps pushing on tests, specs, docs, evidence, and traceability.
+Those things are not ornamental process furniture.
+They are what reduce future drag.
+
+Incomplete delivery creates compound costs:
+- the next contributor has to rediscover intent
+- reviewers have to guess whether something is actually safe
+- regressions slip because the real behavior was never pinned down
+- support and operations inherit ambiguity instead of clarity
+- follow-up work becomes slower because context was not preserved
+
+That is why the AI conversation should move past a shallow productivity question.
+
+The better question is not:
+
+> how much implementation speed did AI add?
+
+It is:
+
+> how much incompleteness did AI remove?
+
+That is a better measure of whether the extra capacity is being spent well.
+
+## Completeness is not perfectionism
+
+This argument is easy to misunderstand if people hear "completeness" as "do everything forever."
+That is not the point.
+
+Completeness is not perfectionism.
+It is not infinite polish.
+It is not a demand that every tiny change carry enterprise ceremony.
+
+Completeness means the change is accompanied by the level of supporting clarity and evidence it reasonably needs.
+
+For a governed delivery system, that often includes:
+- issue clarity that explains the actual problem
+- spec or requirement binding that explains intended behavior
+- tests or checks that prove the relevant claim
+- docs updated where behavior or setup changed
+- traceability that links intent, change, and evidence
+- PR/release notes that make the result understandable to someone else
+- explicit residual risk when something still matters
+
+That is not bureaucracy.
+That is what makes a change legible.
+
+## AI lowers the cost of the surrounding work
+
+This is where the economics really matter.
+
+Historically, the supporting artifacts around a change often got cut first because they were expensive:
+- writing tests carefully
+- keeping docs current
+- tightening issue quality
+- maintaining spec coverage
+- producing clear PR descriptions
+- recording blockers and residual risk honestly
+- leaving a handoff that someone else can actually use
+
+AI does not make those things automatic.
+But it does make many of them cheaper to draft, refine, compare, summarize, and keep current.
+
+That means teams have less excuse for skipping them by default.
+
+If AI can help generate:
+- stronger first-pass tests from acceptance criteria
+- spec deltas while implementation context is still warm
+- clearer docs and setup notes
+- better issue summaries and PR descriptions
+- faster traceability linking between requirement and evidence
+- more explicit blocker reports and release-readiness summaries
+
+then the standard should shift.
+
+The gain should not be consumed entirely by more implementation throughput.
+Some of it should be spent on making delivery more complete.
+
+## The right question is what AI improves around the code
+
+Too many AI success stories still reduce contribution quality to the code body itself.
+
+But code is only one part of delivery.
+A stronger way to judge AI-enabled work is to ask:
+
+### Did AI improve the tests?
+- Was useful coverage added?
+- Were important regressions made less likely?
+- Did the checks actually prove the intended behavior?
+
+### Did AI improve the spec quality?
+- Was the intended behavior made clearer?
+- Did requirement IDs or acceptance criteria become easier to trace?
+- Was ambiguity removed instead of passed downstream?
+
+### Did AI improve the documentation?
+- Does the repo explain reality more clearly than before?
+- Can another contributor bootstrap or review the work without chat archaeology?
+- Are setup and operational expectations more explicit?
+
+### Did AI improve delivery clarity?
+- Is the issue sharper?
+- Is the PR easier to review?
+- Are blockers and residual risks explicit?
+- Is release readiness easier to evaluate?
+
+### Did AI improve handoff quality?
+- Could another person continue the work without guessing the intent?
+- Are the next actions, limitations, and follow-ups preserved?
+
+Those are all completeness questions.
+And they matter more than raw typing speed.
+
+## Faster implementation with weak completeness is not a win
+
+It is possible to ship faster and still get worse outcomes.
+
+If AI causes teams to produce:
+- more half-specified work
+- more weakly tested changes
+- more docs drift
+- more ambiguous PRs
+- more shallow release claims
+- more cleanup debt pushed onto future contributors
+
+then the team may look more productive while actually becoming less trustworthy.
+
+That is not a real gain.
+That is just faster incompleteness.
+
+The dangerous part is that faster incompleteness can look impressive in short reporting windows.
+You see more movement.
+More drafts.
+More merges.
+More visible activity.
+
+But the unpriced cost shows up later in:
+- churn
+- rework
+- support burden
+- brittle knowledge transfer
+- fake confidence in delivery status
+- slower future change because the surrounding clarity never got built
+
+## AI should widen what contribution quality means
+
+This is one of the most important mindset shifts.
+
+When AI enters the system, teams should not just ask how to produce more implementation.
+They should ask what counts as a high-quality contribution now.
+
+The answer should become broader, not narrower.
+
+A strong AI-enabled contribution is not just:
+- code landed
+- ticket touched
+- summary written
+
+It is increasingly:
+- code plus proof
+- intent plus traceability
+- delivery plus documentation
+- velocity plus clarity
+- output plus evidence
+
+That is a healthier definition of value.
+And it aligns better with how real delivery quality is experienced by everyone after the original author moves on.
+
+## This is why VibeGov keeps treating support artifacts as first-class
+
+VibeGov does not separate tests, specs, docs, blockers, traceability, and release clarity into a bucket called "nice to have later."
+
+The governance model treats them as part of the delivery artifact itself.
+
+That is visible in:
+- `GOV-04 Quality`
+- `GOV-05 Testing`
+- `GOV-06 Issues`
+- the bootstrap contract
+- the stronger definitions of review, validation, and completion
+
+That is not accidental.
+It reflects a delivery thesis:
+
+> the quality of a contribution includes the supporting artifacts that make the change understandable, verifiable, and maintainable.
+
+AI makes that thesis more practical, not less.
+
+## Organizations should spend AI gains on trustworthiness
+
+If AI creates extra delivery capacity, leadership still has to decide where that capacity goes.
+
+It can go into:
+- more raw ticket throughput
+- more visible coding activity
+- more drafts and more motion
+
+Or it can go into:
+- stronger tests
+- tighter issue/spec clarity
+- better docs
+- cleaner handoff
+- more honest validation
+- lower ambiguity in the system
+
+The second path is what turns AI from a volume multiplier into a trust multiplier.
+
+That is the version worth aiming for.
+Because over time, the teams that benefit most from AI will not just be the ones who moved fastest.
+They will be the ones who used the extra capacity to make their delivery system more legible, more reviewable, and more dependable.
+
+## The better ambition
+
+The right ambition is not:
+
+> AI lets us produce more output.
+
+It is:
+
+> AI lets us deliver more completely.
+
+That means fewer missing tests.
+Fewer undocumented changes.
+Fewer vague issues.
+Fewer handoff gaps.
+Fewer fake-green delivery claims.
+Fewer places where future contributors have to guess.
+
+That is a better use of leverage.
+It also creates a better long-term compounding effect.
+
+Because the teams that preserve clarity, proof, and traceability do not just ship this week’s work better.
+They make next month’s work cheaper too.
+
+That is the kind of improvement AI should be buying.
+
+## Series navigation
+
+- 1. [AI Should Raise the Standard for Done](/blog/ai-should-raise-the-standard-for-done)
+- **2. AI Should Increase Completeness, Not Just Speed** ← you are here
+- 3. AI Makes Quality More Affordable, So Expectations Should Rise *(planned)*
+- 4. Tests, Specs, and Docs Are No Longer Cheap Excuses to Skip *(planned)*
+- 5. AI-Native Contribution Should Be Measured in Completeness *(planned)*
+
+## Related docs
+
+- [Published GOV-04 Quality](/docs/published/gov-04-quality)
+- [Published GOV-05 Testing](/docs/published/gov-05-testing)
+- [Published GOV-06 Issues](/docs/published/gov-06-issues)
+- [Workflow Quality Rubric](/docs/workflow-quality-rubric)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)


### PR DESCRIPTION
## Summary
- add the second post in the AI quality/completeness series: "AI Should Increase Completeness, Not Just Speed"
- sharpen the argument that AI gains should appear in tests, specs, docs, traceability, validation, and handoff clarity rather than only raw implementation velocity
- update the anchor post series navigation to link to the new post

## OpenSpec
- `.governance/specs/ai-quality-completeness-series.md`
- `CONTENT-AI-QUALITY-002`
- `CONTENT-AI-QUALITY-004`

## Validation
- `npm run build`

Closes #27
