### PR TITLE
#69 force BU prompt to fresh-read canonical sources

### DIFF
--- a/.governance/specs/bootstrap-update-fresh-read-of-canonical-sources.md
+++ b/.governance/specs/bootstrap-update-fresh-read-of-canonical-sources.md
@@ -1,0 +1,27 @@
+# Bootstrap Update Fresh Read of Canonical Sources
+
+## Intent
+Make `bootstrap update` explicitly require a fresh read of the latest canonical VibeGov bootstrap sources before acting. This matters because agents can otherwise reuse stale prompt text, cached instructions, or earlier chat summaries and end up applying an outdated bootstrap contract.
+
+## Scope
+In scope:
+- update the homepage Bootstrap Update prompt wording
+- update `docs/bootstrap-update.md`
+- make clear that the live canonical sources are authoritative for the run
+- explicitly reject stale cached/copied bootstrap text when it conflicts
+
+Out of scope:
+- changing non-update bootstrap mode semantics
+- adding new bootstrap sources
+
+## Acceptance Criteria
+- `BU-FRESH-001` Homepage Bootstrap Update prompt explicitly tells the agent to fresh-read the latest canonical bootstrap sources.
+- `BU-FRESH-002` `docs/bootstrap-update.md` says the same.
+- `BU-FRESH-003` The wording points to `https://vibegov.io/agent.txt`, `https://vibegov.io/bootstrap.json`, and `https://vibegov.io/docs/bootstrap/` as the live authoritative sources.
+- `BU-FRESH-004` The wording makes clear that stale cached/bootstrap text is not authoritative if it conflicts.
+- `BU-FRESH-005` `npm run build` succeeds after the updates.
+
+## Tests and Evidence
+- inspect homepage prompt text in `src/pages/index.tsx`
+- inspect `docs/bootstrap-update.md`
+- run `npm run build`

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -21,10 +21,14 @@ Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
 
 ```text
 Run VibeGov bootstrap in mode: update.
-Read and follow:
+
+Before doing anything else, fresh-read the latest live canonical bootstrap sources:
 - https://vibegov.io/agent.txt
 - https://vibegov.io/bootstrap.json
 - https://vibegov.io/docs/bootstrap/
+
+Treat those live sources as authoritative for this run.
+Do not rely on previously cached bootstrap text, earlier chat summaries, or older copied instructions if they differ.
 
 Use the canonical bootstrap contract.
 Do not restart from scratch when valid artifacts already exist.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -48,7 +48,7 @@ const promptCards: PromptCard[] = [
   {
     title: 'Bootstrap Update Prompt',
     description: 'Use this when a repo already has some bootstrap state.',
-    prompt: `Run VibeGov bootstrap in mode: update.\nRead and follow:\n- https://vibegov.io/docs/bootstrap\n\nThen stop before product-code implementation.`,
+    prompt: `Run VibeGov bootstrap in mode: update.\n\nBefore doing anything else, fresh-read the latest live canonical bootstrap sources:\n- https://vibegov.io/agent.txt\n- https://vibegov.io/bootstrap.json\n- https://vibegov.io/docs/bootstrap/\n\nTreat those live sources as authoritative for this run. Do not rely on stale cached or earlier copied bootstrap text if it differs.\n\nThen stop before product-code implementation.`,
     href: '/docs/bootstrap-update',
   },
   {


### PR DESCRIPTION
## Summary
- make the homepage Bootstrap Update quick-path prompt explicitly fresh-read the latest live canonical bootstrap sources
- update `docs/bootstrap-update.md` to treat `agent.txt`, `bootstrap.json`, and `docs/bootstrap/` as the live authoritative sources for each update run
- make clear that stale cached/bootstrap text is not authoritative when it conflicts

## OpenSpec
- `.governance/specs/bootstrap-update-fresh-read-of-canonical-sources.md`
- `BU-FRESH-001` through `BU-FRESH-005`

## Validation
- `npm run build`

Closes #69
