### PR TITLE
#71 force feedback prompt to fresh-read canonical sources

### DIFF
--- a/.governance/specs/bootstrap-feedback-fresh-read-of-canonical-sources.md
+++ b/.governance/specs/bootstrap-feedback-fresh-read-of-canonical-sources.md
@@ -1,0 +1,27 @@
+# Bootstrap Feedback Fresh Read of Canonical Sources
+
+## Intent
+Make the bootstrap feedback flow explicitly require a fresh read of the latest live canonical VibeGov bootstrap sources before generating feedback. This matters because feedback against stale cached/copied contract text can create duplicate or already-fixed complaints and weakens the usefulness of adoption feedback.
+
+## Scope
+In scope:
+- update homepage Bootstrap Feedback prompt wording
+- update `docs/bootstrap-feedback-prompt.md`
+- make the latest live canonical sources authoritative for the feedback run
+- explicitly reject stale cached/copied bootstrap text when it conflicts
+
+Out of scope:
+- changing the rest of the bootstrap contract
+- adding new bootstrap sources
+
+## Acceptance Criteria
+- `BF-FRESH-001` Homepage Bootstrap Feedback prompt explicitly tells the agent to fresh-read the latest canonical bootstrap sources.
+- `BF-FRESH-002` `docs/bootstrap-feedback-prompt.md` says the same.
+- `BF-FRESH-003` The wording points to `https://vibegov.io/agent.txt`, `https://vibegov.io/bootstrap.json`, and `https://vibegov.io/docs/bootstrap/` as the live authoritative sources for review context.
+- `BF-FRESH-004` The wording makes clear that stale cached/bootstrap text is not authoritative if it conflicts.
+- `BF-FRESH-005` `npm run build` succeeds after the updates.
+
+## Tests and Evidence
+- inspect homepage prompt text in `src/pages/index.tsx`
+- inspect `docs/bootstrap-feedback-prompt.md`
+- run `npm run build`

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -13,6 +13,14 @@ Before public sharing, remove or obfuscate:
 - internal hostnames, private repo URLs, tenant IDs, environment-specific sensitive details
 
 ```text
+Before reviewing bootstrap feedback, fresh-read the latest live canonical bootstrap sources:
+- https://vibegov.io/agent.txt
+- https://vibegov.io/bootstrap.json
+- https://vibegov.io/docs/bootstrap/
+
+Treat those live sources as authoritative for this feedback run.
+Do not rely on previously cached bootstrap text, earlier chat summaries, or older copied instructions if they differ.
+
 Please review the bootstrap/setup process you just executed for this repo and tell me what VibeGov could do better.
 
 Focus on:

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -55,7 +55,7 @@ const promptCards: PromptCard[] = [
     title: 'Bootstrap Feedback Prompt',
     description:
       'Use this after bootstrap/init or bootstrap/update, then raise a scrubbed GitHub issue with the feedback.',
-    prompt: `Review the bootstrap/setup process you just executed for this repo.\nRead and follow:\n- https://vibegov.io/docs/bootstrap-feedback-prompt`,
+    prompt: `Before reviewing bootstrap feedback, fresh-read the latest live canonical bootstrap sources:\n- https://vibegov.io/agent.txt\n- https://vibegov.io/bootstrap.json\n- https://vibegov.io/docs/bootstrap/\n\nTreat those live sources as authoritative for this feedback run. Do not rely on stale cached or earlier copied bootstrap text if it differs.\n\nThen read and follow:\n- https://vibegov.io/docs/bootstrap-feedback-prompt`,
     href: '/docs/bootstrap-feedback-prompt',
   },
 ];


### PR DESCRIPTION
## Summary
- make the homepage Bootstrap Feedback quick-path prompt explicitly fresh-read the latest live canonical bootstrap sources
- update `docs/bootstrap-feedback-prompt.md` to treat `agent.txt`, `bootstrap.json`, and `docs/bootstrap/` as the live authoritative sources for each feedback run
- make clear that stale cached/bootstrap text is not authoritative when it conflicts

## OpenSpec
- `.governance/specs/bootstrap-feedback-fresh-read-of-canonical-sources.md`
- `BF-FRESH-001` through `BF-FRESH-005`

## Validation
- `npm run build`

Closes #71
