### PR TITLE
#73 make BU repair to operational completion

### DIFF
--- a/.governance/specs/bootstrap-update-operational-completion-and-settled-end-state.md
+++ b/.governance/specs/bootstrap-update-operational-completion-and-settled-end-state.md
@@ -1,0 +1,27 @@
+# Bootstrap Update Operational Completion and Settled End State
+
+## Intent
+Make `bootstrap update` explicitly responsible for repairing a partially bootstrapped repo all the way to an operationally complete state, or leaving explicit blockers plus a settled end state. This matters because a repo can look improved without actually being bootstrap-complete, especially when workflow artifacts, GitHub state, or durable status artifacts are still missing.
+
+## Scope
+In scope:
+- tighten `bootstrap update` wording to repair missing operational bootstrap artifacts, not just scaffold gaps
+- require explicit settled end-state classification for local repo state
+- require status/blocker artifact emission when update cannot complete all gaps
+- make clear that GitHub/project setup gaps must be fixed or left as explicit blockers with exact next actions
+
+Out of scope:
+- changing the canonical bootstrap pass gate itself
+- automating git push/PR behavior beyond documenting the required end-state classification
+
+## Acceptance Criteria
+- `BU-OPER-001` `bootstrap update` docs explicitly say update must repair missing operational bootstrap artifacts until the canonical contract is satisfied.
+- `BU-OPER-002` `bootstrap update` docs define a settled end state for local repo changes such as committed/pushed, pending-review, or blocked.
+- `BU-OPER-003` `bootstrap update` docs explicitly require status/blocker artifacts when update cannot complete all gaps.
+- `BU-OPER-004` Canonical bootstrap docs reflect the same stronger update semantics.
+- `BU-OPER-005` `npm run build` succeeds after the updates.
+
+## Tests and Evidence
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/bootstrap.md`
+- run `npm run build`

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -13,9 +13,12 @@ Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
 
 - preserve valid existing artifacts
 - repair stale, missing, contradictory, or weak artifacts
+- repair missing **operational** bootstrap artifacts too, not just scaffold gaps
 - keep the same pass gate as `init`
 - create/update `INIT-TODO.md` early and record any missing prerequisite with exact remediation
 - if the repo still fails the contract, report exact blockers/gaps instead of claiming partial completion
+- do not leave the repo in ambiguous drift: classify the end state as committed/pushed, pending-review, or blocked
+- when update cannot complete all gaps, emit explicit status/blocker artifacts instead of only chat output
 
 ## Update prompt
 
@@ -32,5 +35,7 @@ Do not rely on previously cached bootstrap text, earlier chat summaries, or olde
 
 Use the canonical bootstrap contract.
 Do not restart from scratch when valid artifacts already exist.
-Repair or normalize the repo until the same bootstrap contract is satisfied, or report exact blockers.
+Repair or normalize the repo until the same bootstrap contract is satisfied, including missing operational bootstrap artifacts, or report exact blockers.
+Do not stop in an ambiguous local end state; classify the result as committed/pushed, pending-review, or blocked.
+If update cannot complete all gaps, write explicit status/blocker artifacts describing what remains and the exact next actions.
 ```

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -79,7 +79,7 @@ Before writing any product code (or before claiming bootstrap review is complete
 
 Mode-specific behavior:
 - `init`: create the missing bootstrap state required by the contract
-- `update`: preserve valid existing artifacts and repair stale/missing/contradictory ones until the same contract is satisfied
+- `update`: preserve valid existing artifacts and repair stale/missing/contradictory ones, including missing operational bootstrap artifacts, until the same contract is satisfied; if that cannot be done, leave explicit status/blocker artifacts plus a settled end-state classification (`committed/pushed`, `pending-review`, or `blocked`)
 - `review`: audit the repo against the same contract, write findings and blockers, and do not claim missing work was completed
 
 Then stop before product-code implementation.
@@ -100,6 +100,7 @@ Continue only if all are true:
 - for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`)
 - for GitHub repos with automation, canonical board target is adopted/created/normalized, repo-link status is reported, and multiple-match selection is explained when relevant
 - timestamped bootstrap status + feedback artifacts are written under `.governance/project/bootstrap-runs/`
+- if update cannot complete all gaps, timestamped blocker/status artifacts make the incomplete state explicit with exact next actions
 - final docs are reconciled with final live git/GitHub state
 - no product code was written
 


### PR DESCRIPTION
## Summary
- make `bootstrap update` explicitly repair missing operational bootstrap artifacts, not just scaffold gaps
- require a settled end-state classification for local repo state (`committed/pushed`, `pending-review`, or `blocked`)
- require explicit status/blocker artifacts when update cannot complete all remaining gaps

## OpenSpec
- `.governance/specs/bootstrap-update-operational-completion-and-settled-end-state.md`
- `BU-OPER-001` through `BU-OPER-005`

## Validation
- `npm run build`

Closes #73
