### PR TITLE
#75 treat private repo protection limits as warnings

### DIFF
--- a/.governance/specs/private-repo-branch-protection-warning.md
+++ b/.governance/specs/private-repo-branch-protection-warning.md
@@ -1,0 +1,27 @@
+# Private Repo Branch Protection Warning
+
+## Intent
+Treat private-repository branch-protection verification limits as a documented warning/degraded verification note rather than a hard bootstrap blocker when the repo has otherwise been normalized correctly. This matters because some GitHub-hosted feature restrictions can prevent live branch-protection verification even when auth, board setup, repo linkage, and the rest of the bootstrap contract all succeed.
+
+## Scope
+In scope:
+- update bootstrap docs
+- update bootstrap-update docs
+- update GitHub bootstrap docs
+- clarify reporting expectations for hosted-feature verification limits on private repos
+
+Out of scope:
+- changing GitHub platform behavior
+- removing the need to report exact evidence and next actions
+
+## Acceptance Criteria
+- `PRIV-PROT-001` Bootstrap docs distinguish hosted-feature verification limits from hard blockers.
+- `PRIV-PROT-002` GitHub bootstrap docs say private-repo branch-protection verification limits can be recorded as warnings/degraded verification when the rest of normalization succeeds.
+- `PRIV-PROT-003` Reporting guidance requires exact evidence and next action for the warning.
+- `PRIV-PROT-004` `npm run build` succeeds after the updates.
+
+## Tests and Evidence
+- inspect `docs/bootstrap.md`
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/github-project-bootstrap.md`
+- run `npm run build`

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -19,6 +19,7 @@ Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
 - if the repo still fails the contract, report exact blockers/gaps instead of claiming partial completion
 - do not leave the repo in ambiguous drift: classify the end state as committed/pushed, pending-review, or blocked
 - when update cannot complete all gaps, emit explicit status/blocker artifacts instead of only chat output
+- if a private-repo hosted-feature limit prevents live branch-protection verification but the rest of bootstrap normalization succeeds, report it as degraded verification/warning with exact evidence and next action rather than treating the whole run as a hard blocker
 
 ## Update prompt
 
@@ -38,4 +39,5 @@ Do not restart from scratch when valid artifacts already exist.
 Repair or normalize the repo until the same bootstrap contract is satisfied, including missing operational bootstrap artifacts, or report exact blockers.
 Do not stop in an ambiguous local end state; classify the result as committed/pushed, pending-review, or blocked.
 If update cannot complete all gaps, write explicit status/blocker artifacts describing what remains and the exact next actions.
+If a known private-repo hosted-feature limit blocks branch-protection verification, record that as a warning/degraded verification note with exact evidence and next action.
 ```

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -59,6 +59,7 @@ Before writing any product code (or before claiming bootstrap review is complete
    - project write access
    - branch-protection/admin capability when relevant
    - if any required capability is missing, record it in `INIT-TODO.md` with the exact remediation command or next action before proceeding
+   - if branch-protection verification is unavailable only because of a known hosted-feature/private-repo limitation, record it as degraded verification with exact evidence and next action rather than pretending the repo normalization failed
 12. If GitHub automation is available, create/adopt/normalize one canonical board target:
    - if multiple matching boards exist, choose one canonical target explicitly and report why it was chosen
    - normalize `Status`: `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Blocked`
@@ -97,7 +98,7 @@ Continue only if all are true:
 - `INIT-TODO.md` exists for bootstrap/adoption/remediation work and records any missing prerequisite with exact remediation when relevant
 - strict Git workflow artifacts exist
 - starting repo state and commit-policy mode are reported
-- for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`)
+- for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`), and known hosted-feature verification limits are distinguished from core bootstrap failure
 - for GitHub repos with automation, canonical board target is adopted/created/normalized, repo-link status is reported, and multiple-match selection is explained when relevant
 - timestamped bootstrap status + feedback artifacts are written under `.governance/project/bootstrap-runs/`
 - if update cannot complete all gaps, timestamped blocker/status artifacts make the incomplete state explicit with exact next actions

--- a/docs/github-project-bootstrap.md
+++ b/docs/github-project-bootstrap.md
@@ -65,6 +65,7 @@ No-issues fallback:
 - `INIT-TODO.md` should be created/updated early during bootstrap so prerequisite failures and exact GitHub remediation steps are durable.
 - Bootstrap should create `develop` locally when the strict Git workflow is being installed, unless explicitly blocked.
 - Remote push/protection state for `develop` should be reported separately instead of being silently assumed.
+- If live branch-protection verification is unavailable only because of a known hosted-feature/private-repo limitation, report that as degraded verification/warning with exact evidence and next action instead of treating the whole bootstrap run as a failed normalization.
 
 ## Current state vs historical evidence
 
@@ -84,5 +85,6 @@ For GitHub-hosted bootstrap, report:
 - field/status normalization result
 - issue import/attach result (or intentionally empty)
 - any blockers/missing capabilities
+- any degraded-verification warnings caused by hosted-feature limits, with exact evidence and next action
 - `develop` branch local/remote/protection status
 - final live-state reconciliation result


### PR DESCRIPTION
## Summary
- distinguish private-repo hosted-feature branch-protection limits from hard bootstrap blockers
- require those limits to be reported as degraded verification/warnings with exact evidence and next action
- keep the rest of the bootstrap normalization result truthful instead of collapsing the whole run into a blocker

## OpenSpec
- `.governance/specs/private-repo-branch-protection-warning.md`
- `PRIV-PROT-001` through `PRIV-PROT-004`

## Validation
- `npm run build`

Closes #75
