### PR TITLE
#77 make BI and BU emit status, analysis, and feedback

### DIFF
--- a/.governance/specs/bootstrap-status-analysis-feedback-artifact-bundle.md
+++ b/.governance/specs/bootstrap-status-analysis-feedback-artifact-bundle.md
@@ -1,0 +1,31 @@
+# Bootstrap Status Analysis Feedback Artifact Bundle
+
+## Intent
+Make bootstrap init and bootstrap update emit a fuller default artifact bundle so each run leaves not only status, but also a durable analysis of current repo/bootstrap state and durable feedback on what VibeGov should improve. This matters because bootstrap rounds are easier to evaluate and compare when the output separates what happened, what state exists now, and what the framework should improve.
+
+## Scope
+In scope:
+- update canonical bootstrap docs so BI and BU emit timestamped status, analysis, and feedback artifacts by default
+- document blockers as optional but required when completion is blocked or degraded
+- add stable latest-run summary/pointer guidance for analysis artifacts
+- update bootstrap-update and bootstrap-feedback docs to fit the fuller artifact model
+- update machine-readable guidance if needed
+
+Out of scope:
+- changing the underlying bootstrap pass gate
+- removing the standalone feedback prompt
+
+## Acceptance Criteria
+- `BOOT-BUNDLE-001` Canonical bootstrap docs say BI and BU emit timestamped `status`, `analysis`, and `feedback` artifacts by default.
+- `BOOT-BUNDLE-002` Blocker artifacts remain optional but are required when completion is blocked or degraded.
+- `BOOT-BUNDLE-003` Stable latest-run summary/pointer files are documented for analysis as well.
+- `BOOT-BUNDLE-004` Bootstrap feedback docs distinguish standalone feedback from the embedded feedback artifact emitted by BI/BU.
+- `BOOT-BUNDLE-005` `npm run build` succeeds after the updates.
+
+## Tests and Evidence
+- inspect `docs/bootstrap.md`
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/bootstrap-feedback-prompt.md`
+- inspect `static/agent.txt`
+- inspect `static/bootstrap.json`
+- run `npm run build`

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -4,7 +4,9 @@ sidebar_position: 5
 
 # Bootstrap Feedback Prompt
 
-Use this after a bootstrap or bootstrap-update run when you want durable, scrubbed feedback.
+Use this after a bootstrap or bootstrap-update run when you want deeper, standalone durable feedback.
+
+Note: bootstrap init and bootstrap update should already emit default feedback artifacts as part of their normal run bundle. This prompt is for an extra dedicated feedback pass when you want more reflection or a cleaner issue-ready writeup.
 
 Before public sharing, remove or obfuscate:
 - PII
@@ -40,7 +42,9 @@ Before finalizing:
 Then produce BOTH:
 1) a local feedback artifact at `.governance/project/bootstrap-runs/<timestamp>-feedback.md`
    - optional stable top-level summary/pointer: `.governance/project/BOOTSTRAP_FEEDBACK.md`
-2) a GitHub issue-ready payload:
+2) a companion local analysis artifact at `.governance/project/bootstrap-runs/<timestamp>-analysis.md`
+   - optional stable top-level summary/pointer: `.governance/project/BOOTSTRAP_ANALYSIS.md`
+3) a GitHub issue-ready payload:
    - title
    - body
    - suggested issue type/labels

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -18,7 +18,8 @@ Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
 - create/update `INIT-TODO.md` early and record any missing prerequisite with exact remediation
 - if the repo still fails the contract, report exact blockers/gaps instead of claiming partial completion
 - do not leave the repo in ambiguous drift: classify the end state as committed/pushed, pending-review, or blocked
-- when update cannot complete all gaps, emit explicit status/blocker artifacts instead of only chat output
+- emit explicit status, analysis, and feedback artifacts instead of relying only on chat output
+- when update cannot complete all gaps, emit explicit blocker artifacts too
 - if a private-repo hosted-feature limit prevents live branch-protection verification but the rest of bootstrap normalization succeeds, report it as degraded verification/warning with exact evidence and next action rather than treating the whole run as a hard blocker
 
 ## Update prompt
@@ -38,6 +39,7 @@ Use the canonical bootstrap contract.
 Do not restart from scratch when valid artifacts already exist.
 Repair or normalize the repo until the same bootstrap contract is satisfied, including missing operational bootstrap artifacts, or report exact blockers.
 Do not stop in an ambiguous local end state; classify the result as committed/pushed, pending-review, or blocked.
-If update cannot complete all gaps, write explicit status/blocker artifacts describing what remains and the exact next actions.
+Write explicit status, analysis, and feedback artifacts for the run.
+If update cannot complete all gaps, write explicit blocker artifacts describing what remains and the exact next actions.
 If a known private-repo hosted-feature limit blocks branch-protection verification, record that as a warning/degraded verification note with exact evidence and next action.
 ```

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -72,9 +72,10 @@ Before writing any product code (or before claiming bootstrap review is complete
 13. If GitHub automation is unavailable, report exact missing capability and leave a tracked blocker artifact.
 14. Write durable local output artifacts into `.governance/project/bootstrap-runs/`:
    - `<timestamp>-status.md`
+   - `<timestamp>-analysis.md`
    - `<timestamp>-feedback.md`
    - optional `<timestamp>-blockers.md`
-   - stable top-level files may exist only as latest-run summaries/pointers
+   - stable top-level files may exist only as latest-run summaries/pointers (`BOOTSTRAP_STATUS.md`, `BOOTSTRAP_ANALYSIS.md`, `BOOTSTRAP_FEEDBACK.md`, `BOOTSTRAP_BLOCKERS.md`)
 15. Reconcile generated docs against final live git/GitHub state before claiming completion.
 16. Distinguish final current state from historical evidence gathered earlier in the run.
 
@@ -100,8 +101,8 @@ Continue only if all are true:
 - starting repo state and commit-policy mode are reported
 - for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`), and known hosted-feature verification limits are distinguished from core bootstrap failure
 - for GitHub repos with automation, canonical board target is adopted/created/normalized, repo-link status is reported, and multiple-match selection is explained when relevant
-- timestamped bootstrap status + feedback artifacts are written under `.governance/project/bootstrap-runs/`
-- if update cannot complete all gaps, timestamped blocker/status artifacts make the incomplete state explicit with exact next actions
+- timestamped bootstrap status + analysis + feedback artifacts are written under `.governance/project/bootstrap-runs/`
+- if update cannot complete all gaps or only reaches degraded verification, timestamped blocker artifacts make the incomplete state explicit with exact next actions
 - final docs are reconciled with final live git/GitHub state
 - no product code was written
 

--- a/static/agent.txt
+++ b/static/agent.txt
@@ -59,10 +59,11 @@ durable output artifacts:
 - every bootstrap run must leave durable local output artifacts even when commits are forbidden
 - write per-run artifacts into:
   - .governance/project/bootstrap-runs/<timestamp>-status.md
+  - .governance/project/bootstrap-runs/<timestamp>-analysis.md
   - .governance/project/bootstrap-runs/<timestamp>-feedback.md
   - optional: .governance/project/bootstrap-runs/<timestamp>-blockers.md
-- stable top-level files such as BOOTSTRAP_STATUS.md / BOOTSTRAP_FEEDBACK.md may exist only as latest-run summaries or pointers
-- bootstrap feedback should be written to the timestamped local run-history file before or alongside any public GitHub issue filing
+- stable top-level files such as BOOTSTRAP_STATUS.md / BOOTSTRAP_ANALYSIS.md / BOOTSTRAP_FEEDBACK.md may exist only as latest-run summaries or pointers
+- bootstrap feedback and analysis should be written to the timestamped local run-history files before or alongside any public GitHub issue filing
 
 delivery loop:
 - Observe -> Plan -> Implement -> Verify -> Document

--- a/static/bootstrap.json
+++ b/static/bootstrap.json
@@ -93,11 +93,13 @@
     ],
     "requiredStatusArtifacts": [
       ".governance/project/bootstrap-runs/<timestamp>-status.md",
+      ".governance/project/bootstrap-runs/<timestamp>-analysis.md",
       ".governance/project/bootstrap-runs/<timestamp>-feedback.md"
     ],
     "optionalStatusArtifacts": [
       ".governance/project/bootstrap-runs/<timestamp>-blockers.md",
       ".governance/project/BOOTSTRAP_STATUS.md",
+      ".governance/project/BOOTSTRAP_ANALYSIS.md",
       ".governance/project/BOOTSTRAP_FEEDBACK.md",
       ".governance/project/BOOTSTRAP_BLOCKERS.md",
       ".governance/project/GIT_WORKFLOW.md",
@@ -157,6 +159,7 @@
   },
   "feedback_flow": {
     "mustWriteLocalFeedbackFile": true,
+    "localAnalysisRunHistoryPath": ".governance/project/bootstrap-runs/<timestamp>-analysis.md",
     "localFeedbackRunHistoryPath": ".governance/project/bootstrap-runs/<timestamp>-feedback.md",
     "writeBeforeOrAlongsidePublicIssueFiling": true,
     "mustScrubSensitiveData": true


### PR DESCRIPTION
## Summary
- make bootstrap init and bootstrap update emit timestamped status, analysis, and feedback artifacts by default
- keep blockers optional but required when completion is blocked or degraded
- add stable analysis pointer guidance alongside status/feedback pointers
- clarify that the standalone feedback prompt is for a deeper extra reflection pass, not the only way to get feedback output

## OpenSpec
- `.governance/specs/bootstrap-status-analysis-feedback-artifact-bundle.md`
- `BOOT-BUNDLE-001` through `BOOT-BUNDLE-005`

## Validation
- `npm run build`

Closes #77
