### PR TITLE
#79 document BI, BU, and BF shorthand

### DIFF
--- a/.governance/specs/bootstrap-shorthand-references.md
+++ b/.governance/specs/bootstrap-shorthand-references.md
@@ -1,0 +1,30 @@
+# Bootstrap Shorthand References
+
+## Intent
+Define the shorthand references used in conversation and docs for the three bootstrap entrypoints so they are unambiguous and documented in the canonical VibeGov docs.
+
+## Scope
+In scope:
+- define `BI` as bootstrap init
+- define `BU` as bootstrap update
+- define `BF` as bootstrap feedback
+- update the relevant docs and homepage quick-path wording
+- record the shorthand in daily memory
+
+Out of scope:
+- changing bootstrap behavior
+- adding new bootstrap modes
+
+## Acceptance Criteria
+- `BOOT-REF-001` `docs/bootstrap.md` defines `BI`, `BU`, and `BF`.
+- `BOOT-REF-002` `docs/bootstrap-update.md` defines `BU` explicitly.
+- `BOOT-REF-003` `docs/bootstrap-feedback-prompt.md` defines `BF` explicitly.
+- `BOOT-REF-004` homepage quick-path wording reflects the shorthand where useful.
+- `BOOT-REF-005` `npm run build` succeeds.
+
+## Tests and Evidence
+- inspect `docs/bootstrap.md`
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/bootstrap-feedback-prompt.md`
+- inspect `src/pages/index.tsx`
+- run `npm run build`

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -6,6 +6,9 @@ sidebar_position: 5
 
 Use this after a bootstrap or bootstrap-update run when you want deeper, standalone durable feedback.
 
+Shorthand ref:
+- `BF` = bootstrap feedback
+
 Note: bootstrap init and bootstrap update should already emit default feedback artifacts as part of their normal run bundle. This prompt is for an extra dedicated feedback pass when you want more reflection or a cleaner issue-ready writeup.
 
 Before public sharing, remove or obfuscate:

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -6,6 +6,9 @@ sidebar_position: 3
 
 `bootstrap update` is **bootstrap run in `update` mode**.
 
+Shorthand ref:
+- `BU` = bootstrap update
+
 It does **not** use a weaker or different contract.
 Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -6,6 +6,11 @@ sidebar_position: 2
 
 This is the **canonical bootstrap contract** for VibeGov.
 
+Shorthand refs used in docs and chat:
+- `BI` = bootstrap init
+- `BU` = bootstrap update
+- `BF` = bootstrap feedback
+
 Use the same contract in one of three explicit modes:
 - `init`
 - `update`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,19 +40,19 @@ type FaqItem = {
 
 const promptCards: PromptCard[] = [
   {
-    title: 'Bootstrap Init Prompt',
+    title: 'Bootstrap Init Prompt (BI)',
     description: 'Use this when a repo does not have VibeGov installed yet.',
     prompt: `Run VibeGov bootstrap in mode: init.\nRead and follow:\n- https://vibegov.io/docs/bootstrap\n\nThen stop before product-code implementation.`,
     href: '/docs/bootstrap',
   },
   {
-    title: 'Bootstrap Update Prompt',
+    title: 'Bootstrap Update Prompt (BU)',
     description: 'Use this when a repo already has some bootstrap state.',
     prompt: `Run VibeGov bootstrap in mode: update.\n\nBefore doing anything else, fresh-read the latest live canonical bootstrap sources:\n- https://vibegov.io/agent.txt\n- https://vibegov.io/bootstrap.json\n- https://vibegov.io/docs/bootstrap/\n\nTreat those live sources as authoritative for this run. Do not rely on stale cached or earlier copied bootstrap text if it differs.\n\nThen stop before product-code implementation.`,
     href: '/docs/bootstrap-update',
   },
   {
-    title: 'Bootstrap Feedback Prompt',
+    title: 'Bootstrap Feedback Prompt (BF)',
     description:
       'Use this after bootstrap/init or bootstrap/update, then raise a scrubbed GitHub issue with the feedback.',
     prompt: `Before reviewing bootstrap feedback, fresh-read the latest live canonical bootstrap sources:\n- https://vibegov.io/agent.txt\n- https://vibegov.io/bootstrap.json\n- https://vibegov.io/docs/bootstrap/\n\nTreat those live sources as authoritative for this feedback run. Do not rely on stale cached or earlier copied bootstrap text if it differs.\n\nThen read and follow:\n- https://vibegov.io/docs/bootstrap-feedback-prompt`,


### PR DESCRIPTION
## Summary
- define the shorthand refs used in docs/chat for the three bootstrap entrypoints: `BI`, `BU`, and `BF`
- update the core bootstrap docs so the shorthand is explicit and discoverable
- label the homepage quick-path cards with the shorthand names

## OpenSpec
- `.governance/specs/bootstrap-shorthand-references.md`
- `BOOT-REF-001` through `BOOT-REF-005`

## Validation
- `npm run build`

Closes #79
