### PR TITLE
docs: add GOV-09 agent continuity bootstrap

### DIFF
--- a/.governance/rules/gov-01-instructions.mdc
+++ b/.governance/rules/gov-01-instructions.mdc
@@ -18,6 +18,7 @@ Apply these files in order:
 5. `gov-06-issues.mdc` (issue lifecycle)
 6. `gov-07-tasks.mdc` (task hygiene)
 7. `gov-08-exploratory-review.mdc` (continuous exploratory discovery + backlog hydration)
+8. `gov-09-agent-continuity-bootstrap.mdc` (continuity layers, checkpoint triggers, and bootstrap memory discipline)
 
 ## Source-of-Truth Layout
 

--- a/.governance/rules/gov-06-issues.mdc
+++ b/.governance/rules/gov-06-issues.mdc
@@ -57,6 +57,29 @@ Only after review/confirmation can the issue enter active implementation.
 3. review outcomes and risks
 4. close with traceable resolution
 
+## Active Work Visibility (mandatory)
+
+While an issue is actively being worked, the issue comments must show the work as it happens.
+
+Leave a visible issue comment at every meaningful state change, not just at the end.
+Minimum states to comment:
+- start/resume
+- meaningful plan change
+- blocker/risk
+- validation result
+- final outcome, including commit/PR links when present
+
+Do not spam micro-steps with no durable state change, for example:
+- opening files
+- reading code
+- rerunning the same command without a new result
+
+Preferred behavior:
+- update the current working comment for small same-phase follow-ups when practical
+- create a new comment when the issue changes phase
+
+Goal: someone reading only the issue should be able to see what was planned, what happened, what evidence exists, and what remains.
+
 ## Closure Standard
 
 Before closing, ensure:

--- a/.governance/rules/gov-09-agent-continuity-bootstrap.mdc
+++ b/.governance/rules/gov-09-agent-continuity-bootstrap.mdc
@@ -1,0 +1,43 @@
+---
+description: bootstrap and continuity rules for durable agent memory and checkpointing
+globs:
+alwaysApply: true
+---
+# Governance: Agent Continuity Bootstrap
+
+Continuity is part of execution, not cleanup after execution.
+
+Governed projects should bootstrap agents with durable continuity structure and explicit checkpoint behavior early, before long-running work depends on live chat context.
+
+## Continuity Layers
+
+- `GOV-09-CONT-001` Governed projects should define four continuity layers: session/thread continuity, recent/daily continuity, project continuity, and durable global/operator continuity when that scope exists.
+- `GOV-09-CONT-002` The continuity model should define what belongs in each layer, where it lives, and how information is promoted between layers.
+- `GOV-09-CONT-003` Projects should prefer concise factual continuity artifacts over transcript dumps or undocumented chat memory.
+
+## Checkpoint Triggers
+
+- `GOV-09-CONT-004` Agents must checkpoint important state during work, not only at the end.
+- `GOV-09-CONT-005` Required checkpoint triggers should include new instructions or corrections, decisions made, blockers or open loops discovered, task phase changes, prolonged multi-step execution, and likely compaction or handoff risk.
+- `GOV-09-CONT-006` When several meaningful turns occur without a checkpoint, the agent should write a compact continuity update before proceeding.
+
+## Session Diaries and Promotion
+
+- `GOV-09-CONT-007` Recurring chats, threads, or operating contexts should maintain concise session diaries that capture important discussion points, decisions, open loops, follow-ups, and thread-specific norms.
+- `GOV-09-CONT-008` Session diaries should not be treated as raw transcript archives; they should preserve substance needed for future resumption.
+- `GOV-09-CONT-009` Continuity information should flow upward deliberately: session or recent notes into project continuity when they become durable project context, and into global/operator continuity only when they are truly cross-project and safe for that scope.
+
+## Bootstrap Expectations
+
+- `GOV-09-CONT-010` Bootstrap should install both continuity structure and operating rules, not merely mention memory as a future concern.
+- `GOV-09-CONT-011` Bootstrap/adoption guidance should create or normalize repo-local continuity scaffolding, recommended continuity paths, and agent operating instructions for checkpointing and promotion.
+- `GOV-09-CONT-012` Bootstrap completion should not be claimed when continuity artifacts or continuity operating rules expected by the project contract are still missing.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- treating live chat context as the only continuity system
+- waiting until the end of a long run to write memory
+- storing all continuity in one undifferentiated global file
+- relying on transcript archaeology instead of structured continuity artifacts
+- importing person-specific wording into generic bootstrap semantics when the rule is meant to be reusable

--- a/.governance/specs/agent-continuity-bootstrap.md
+++ b/.governance/specs/agent-continuity-bootstrap.md
@@ -1,0 +1,45 @@
+# Agent Continuity Bootstrap
+
+## Intent
+Extend VibeGov bootstrap so new projects install a durable agent continuity model by default. The outcome is a reusable governance rule that treats memory checkpointing, compaction resilience, and session/project continuity as part of normal execution rather than optional aftercare.
+
+## Scope
+In scope:
+- add a new governance rule for agent continuity bootstrap
+- define continuity layers, checkpoint triggers, session diary expectations, and promotion rules
+- update bootstrap docs/contracts/templates so continuity scaffolding and continuity instructions are installed early
+- add public-facing pages that explain the new rule and how bootstrap should apply it
+
+Out of scope:
+- runtime-enforced compaction hooks
+- provider-specific transcript-sync implementations
+- private/local workspace-only memory preferences
+
+## Acceptance Criteria
+- VibeGov includes a canonical governance rule covering continuity layers, checkpoint triggers, session diaries, and bootstrap expectations.
+- The bootstrap contract explicitly includes continuity structure and continuity operating guidance as required pre-product-code outputs.
+- Public docs explain the rule in generic reusable language and keep local/personal semantics out of the published contract.
+- The AGENTS template includes continuity guidance that downstream projects can adopt.
+- Site docs build successfully after the new rule/pages are added.
+
+## Tests and Evidence
+- inspect `.governance/rules/gov-09-agent-continuity-bootstrap.mdc`
+- inspect `.governance/specs/agent-continuity-bootstrap.md`
+- inspect `docs/agent-continuity-bootstrap.md`
+- inspect `docs/published/gov-09-agent-continuity-bootstrap.md`
+- inspect `docs/bootstrap.md`, `docs/quickstart.md`, `docs/agents-template.md`, `static/agent.txt`, and `static/bootstrap.json`
+- run `npm run build`
+
+## Documentation Impact
+- add `.governance/rules/gov-09-agent-continuity-bootstrap.mdc`
+- add `docs/agent-continuity-bootstrap.md`
+- add `docs/published/gov-09-agent-continuity-bootstrap.md`
+- update bootstrap/quickstart/template/index/readme/sidebar/generator references for GOV-09 and continuity bootstrap requirements
+
+## Verification
+Verification is documentation-driven. Success requires the canonical rule, published mirror, bootstrap contract surfaces, and AGENTS template to align on the same continuity model, plus a successful Docusaurus build.
+
+## Change Notes
+- Keep the rule generic and reusable for future projects.
+- Make continuity part of bootstrap, not a local afterthought.
+- Prefer concrete trigger conditions over vague advice to “remember things.”

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -214,6 +214,7 @@ The goal is professional delivery behavior that survives speed.
 - `.governance/rules/gov-01-instructions.mdc`
 - `.governance/rules/gov-02-workflow.mdc`
 - `.governance/rules/gov-08-exploratory-review.mdc`
+- `.governance/rules/gov-09-agent-continuity-bootstrap.mdc`
 - `docs/execution-modes.md`
 - `docs/checkpoint-reporting.md`
 - `docs/workflow-quality-rubric.md`

--- a/INDEX.md
+++ b/INDEX.md
@@ -26,6 +26,7 @@ If no provider-native rules directory exists, do not invent one.
 - `.governance/rules/gov-06-issues.mdc`: issue management workflow and templates
 - `.governance/rules/gov-07-tasks.mdc`: task list usage and status management
 - `.governance/rules/gov-08-exploratory-review.mdc`: structured exploratory review, scenario classification, artifact completeness, backlog hydration
+- `.governance/rules/gov-09-agent-continuity-bootstrap.mdc`: continuity layers, checkpoint triggers, session diaries, and bootstrap memory discipline
 
 ## Public operational guides (`docs/`)
 - `docs/intro.md`: public overview of VibeGov
@@ -38,7 +39,8 @@ If no provider-native rules directory exists, do not invent one.
 - `docs/checkpoint-reporting.md`: checkpoint structure, cadence, and examples
 - `docs/blocker-escalation.md`: blocker handling and routing model
 - `docs/workflow-quality-rubric.md`: how to judge whether a workflow is actually strong
-- `docs/published/gov-01-instructions.md` ... `docs/published/gov-08-exploratory-review.md`: published commentary versions of the canonical rules
+- `docs/agent-continuity-bootstrap.md`: continuity model, checkpoint triggers, and bootstrap expectations
+- `docs/published/gov-01-instructions.md` ... `docs/published/gov-09-agent-continuity-bootstrap.md`: published commentary versions of the canonical rules
 
 ## Key supporting repo docs
 - `OPENSPEC_RULES.md`: OpenSpec-first execution rules
@@ -68,6 +70,7 @@ If no provider-native rules directory exists, do not invent one.
 4. `.governance/rules/gov-01-instructions.mdc`
 5. `.governance/rules/gov-02-workflow.mdc`
 6. `.governance/rules/gov-08-exploratory-review.mdc`
+7. `.governance/rules/gov-09-agent-continuity-bootstrap.mdc`
 
 ### I want to understand the operating model
 1. `GUIDE.md`
@@ -77,4 +80,4 @@ If no provider-native rules directory exists, do not invent one.
 5. `docs/workflow-quality-rubric.md`
 
 ### I want the full public rule set
-- `docs/published/gov-01-instructions.md` through `docs/published/gov-08-exploratory-review.md`
+- `docs/published/gov-01-instructions.md` through `docs/published/gov-09-agent-continuity-bootstrap.md`

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -31,6 +31,7 @@ Start by reading:
 2. `gov-02-workflow.mdc`
 3. `gov-03` through `gov-07`
 4. `gov-08-exploratory-review.mdc`
+5. `gov-09-agent-continuity-bootstrap.mdc`
 
 ## 4) Define project intent
 Create or update project intent from:
@@ -72,6 +73,14 @@ Store and report:
 - decisions and confidence limits
 - blockers and next actions
 - exploratory completeness labels where applicable
+
+Also install a continuity model early:
+- session/thread continuity
+- recent/daily continuity
+- project continuity
+- durable global/operator continuity when that scope exists
+
+Agents should checkpoint decisions, blockers, and compaction-sensitive state during work, not only at the end.
 
 You are now in governed delivery mode.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ If you are new to VibeGov, use this order:
 3. `.governance/rules/gov-01-instructions.mdc`
 4. `.governance/rules/gov-02-workflow.mdc`
 5. `.governance/rules/gov-08-exploratory-review.mdc`
+6. `.governance/rules/gov-09-agent-continuity-bootstrap.mdc`
 
 Then review the operational docs on the site:
 - `docs/vibegov-sdlc.md`
@@ -116,6 +117,7 @@ The proof model changes with the mode.
 - blockers become routed work, not hidden stalls
 - issues, specs, tests, and delivery updates stay connected
 - future changes become safer because context survives
+- continuity becomes a governed artifact instead of depending on chat memory
 
 ---
 

--- a/blog/2026-04-13-agent-continuity-is-part-of-delivery.md
+++ b/blog/2026-04-13-agent-continuity-is-part-of-delivery.md
@@ -1,0 +1,148 @@
+---
+slug: agent-continuity-is-part-of-delivery
+title: "Agent Continuity Is Part of Delivery"
+authors: [VibeGov_team]
+tags: [agents, continuity, governance, delivery]
+---
+
+A lot of teams still treat agent continuity as an implementation detail.
+If the agent forgets context, they assume the answer is a better model, a longer context window, or a bigger transcript.
+
+That misses the real problem.
+
+Continuity is not just a model capability question.
+It is an operating-system question.
+
+If important state lives only in live chat context, then the project will keep paying for the same failure modes:
+- repeated decisions
+- reopened settled questions
+- incomplete handoffs
+- hidden blockers
+- work that looked active but cannot be resumed cleanly
+
+That is why VibeGov added **agent continuity bootstrap** as an explicit governance concern.
+
+## Bootstrap should install continuity, not just mention it
+
+One of the easiest mistakes in agent-enabled projects is to say memory matters, but leave no durable continuity structure behind.
+
+That usually means:
+- no clear continuity layers
+- no guidance on what belongs where
+- no checkpoint triggers
+- no session diary pattern for recurring threads
+- no promotion path from local notes to durable project context
+
+In practice, that turns "continuity" into wishful thinking.
+
+A governed bootstrap flow should leave the repo with both:
+- continuity structure
+- continuity operating rules
+
+Without that, teams get governance text but not governance behavior.
+
+## Live context is not a durable operating system
+
+Large context windows are useful.
+They are not the same thing as durable project continuity.
+
+The failure mode is familiar:
+- the agent learns a constraint
+- a decision gets made
+- a blocker is discovered
+- a thread develops its own norms and assumptions
+- then the conversation moves on, compacts, or restarts
+
+If those things were never checkpointed into durable artifacts, future work has to reconstruct them from fragments.
+That is slower, less reliable, and more expensive than writing them down at the right time.
+
+So the core principle is simple:
+
+> continuity is part of execution, not cleanup after execution
+
+## Four continuity layers are better than one giant memory file
+
+VibeGov’s continuity model is deliberately layered:
+
+1. session/thread continuity
+2. recent/daily continuity
+3. project continuity
+4. durable global/operator continuity when that scope exists
+
+The point is not that every repo must use the exact same filenames.
+The point is that the project should make the layers explicit.
+
+That gives agents and humans a better answer to questions like:
+- what belongs only to this thread?
+- what should be visible in today’s run history?
+- what has become durable project context?
+- what is truly cross-project operator knowledge?
+
+Without that structure, teams often dump everything into one place and make continuity harder to maintain, not easier.
+
+## Checkpointing should be event-driven
+
+Another important shift is treating checkpointing as a normal execution behavior, not an end-of-task ritual.
+
+Agents should checkpoint when:
+- a new instruction or correction appears
+- a decision is made
+- a blocker or open loop is found
+- a task changes phase
+- the work becomes long or compaction-sensitive
+- several meaningful turns have happened without a checkpoint
+
+That is a better model because it ties continuity writes to the moments when important state is actually created.
+
+Waiting until the end is how state gets lost.
+
+## Session diaries matter for recurring operating contexts
+
+Recurring chats and threads should not rely on transcript archaeology.
+They should keep concise session diaries.
+
+Not transcript dumps.
+Not every filler message.
+Just the things future work would need:
+- important discussion points
+- decisions
+- open loops
+- follow-ups
+- thread-specific norms
+
+That turns a recurring operating context into something resumable.
+
+## Why this matters beyond memory hygiene
+
+It is tempting to frame this as just a tidiness improvement.
+It is bigger than that.
+
+Continuity quality affects:
+- delivery speed later
+- whether blockers get rediscovered or resolved
+- whether handoff works
+- whether agents can continue work without asking the same questions again
+- whether a project accumulates operational clarity or operational fog
+
+That is why continuity belongs inside bootstrap governance.
+If it only appears as informal advice after the repo is already active, it is too easy to skip.
+
+## The broader point
+
+Agent-enabled delivery systems should not rely on a shrinking live context as their primary memory model.
+They should bootstrap durable continuity intentionally.
+
+That means:
+- explicit continuity layers
+- explicit checkpoint triggers
+- session diary guidance for recurring contexts
+- promotion rules between continuity layers
+- bootstrap completion that refuses to pretend continuity is installed when it is still missing
+
+If continuity matters to execution, it belongs in bootstrap.
+
+## Related reading
+
+- [Agent Continuity Bootstrap](/docs/agent-continuity-bootstrap)
+- [Published GOV 09](/docs/published/gov-09-agent-continuity-bootstrap)
+- [Bootstrap](/docs/bootstrap)

--- a/blog/2026-04-13-bootstrap-should-leave-a-settled-state.md
+++ b/blog/2026-04-13-bootstrap-should-leave-a-settled-state.md
@@ -1,0 +1,127 @@
+---
+slug: bootstrap-should-leave-a-settled-state
+title: "Bootstrap Should Leave a Repo in a Settled State"
+authors: [VibeGov_team]
+tags: [bootstrap, governance, delivery, operations]
+---
+
+Bootstrap is often treated like setup theater.
+A repo gets some folders, a few templates, maybe a checklist, and everyone moves on as if the system is now ready.
+
+That is not a strong operating model.
+
+If a bootstrap run leaves the repo in an ambiguous half-configured state, the work did not really finish.
+It just moved uncertainty forward.
+
+Recent VibeGov bootstrap updates push against that pattern in a few concrete ways:
+
+- `bootstrap update` is not a weaker mode, it uses the same canonical contract as bootstrap init
+- update should repair the repo to **operational completion**, not stop at superficial normalization
+- runs should emit explicit **status**, **analysis**, and **feedback** artifacts instead of relying only on chat output
+- the end state should be classified clearly, for example `committed/pushed`, `pending-review`, or `blocked`
+- shorthand references like `BI`, `BU`, and `BF` should stay consistent with the canonical bootstrap contract rather than drift into informal aliases
+
+## The real problem is ambiguous completion
+
+A lot of bootstrap and remediation work fails in a very specific way.
+The repo looks more organized than before, but nobody can answer the simple operational question:
+
+> is this actually done, reviewable, or still blocked?
+
+That ambiguity is expensive.
+
+It causes teams to:
+- assume gaps were fixed when they were only documented
+- reopen the same setup questions later
+- confuse historical findings with current repo state
+- trust chat summaries more than durable artifacts
+- carry quiet operational risk into the next implementation phase
+
+A governed bootstrap flow should remove that ambiguity, not normalize it.
+
+## Update mode should repair, not shrug
+
+`bootstrap update` matters because most real repos are not greenfield.
+They already contain some mix of:
+- valid artifacts
+- stale artifacts
+- contradictory docs
+- missing operational files
+- partially adopted governance
+
+That means update mode cannot just say "close enough" after preserving a few files.
+It has to preserve what is already valid **and** repair what is weak, stale, or contradictory until the same bootstrap contract is satisfied, or explicitly report why that could not be completed.
+
+That is a much stronger expectation than cosmetic setup maintenance.
+It treats bootstrap as operational work.
+
+## Artifact-emitting runs are easier to trust
+
+Another key change is forcing bootstrap runs to leave durable output artifacts.
+
+That matters because bootstrap work often spans:
+- local repo inspection
+- GitHub capability checks
+- board/project normalization
+- rule/spec/doc reconciliation
+- blockers that may not be solvable in one pass
+
+Without artifacts, the only narrative of the run lives in chat or memory.
+That is fragile.
+
+Explicit status, analysis, and feedback artifacts make the run legible afterward:
+- **status** says what state the repo ended in
+- **analysis** explains what was found and why the result is what it is
+- **feedback** captures what the bootstrap system itself should improve next
+- **blockers** make remaining gaps explicit when completion was not possible
+
+That is much more useful than a vague "bootstrap update done" claim.
+
+## Bootstrap should classify the end state
+
+One of the most important operating improvements is requiring a settled classification.
+
+A run should end with something like:
+- `committed/pushed`
+- `pending-review`
+- `blocked`
+
+That sounds simple, but it closes a common governance hole.
+
+Too many agent or tooling flows stop with a locally changed repo and a confident summary, while the actual operational state is unresolved.
+Maybe changes were not committed.
+Maybe GitHub access was missing.
+Maybe branch protection could not be verified.
+Maybe a key bootstrap artifact is still absent.
+
+Classification forces the system to say what state it actually reached.
+That makes handoff, follow-through, and recovery much cleaner.
+
+## Small shorthand should still be governed
+
+The BI / BU / BF shorthand cleanup might look minor compared with the rest.
+It is not.
+
+Small naming drift is how operating systems get fuzzy over time.
+If teams start using shorthand references that no longer map cleanly back to the canonical bootstrap contract, they slowly create parallel meanings and weaker expectations.
+
+Keeping shorthand aligned is a small control that protects a much bigger thing: a shared operational language.
+
+## The broader point
+
+Bootstrap should not be judged by whether it created files.
+It should be judged by whether it left the repo in a governed, legible, operationally honest state.
+
+That means:
+- one canonical contract across modes
+- repair instead of cosmetic preservation
+- explicit artifacts instead of chat-only reporting
+- settled end-state classification instead of ambiguous drift
+
+If a repo is still uncertain after bootstrap, then bootstrap is not finished yet.
+
+## Related reading
+
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Update](/docs/bootstrap-update)
+- [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt)

--- a/docs/agent-continuity-bootstrap.md
+++ b/docs/agent-continuity-bootstrap.md
@@ -1,0 +1,104 @@
+---
+sidebar_position: 10
+---
+
+# Agent Continuity Bootstrap
+
+Agents should not rely on live chat context as their only continuity system.
+
+If continuity matters only inside a shrinking context window, projects will repeatedly lose decisions, reopen settled questions, and relearn the same operating constraints.
+
+VibeGov treats continuity as part of delivery.
+
+## The continuity model
+
+Bootstrap should install a continuity model with four layers:
+
+1. **Session/thread continuity**
+2. **Recent/daily continuity**
+3. **Project continuity**
+4. **Durable global/operator continuity** when that scope exists
+
+The important part is not the exact filenames.
+The important part is that the project defines:
+- what each layer is for
+- where it lives
+- when the agent writes to it
+- how information gets promoted upward
+
+## Recommended structure
+
+```text
+memory/
+  YYYY-MM-DD.md
+  projects/
+    <project>.md
+  sessions/
+    <stable-thread>.md
+  README.md
+```
+
+Projects may adapt names/paths, but the continuity layers should still be explicit.
+
+## Required checkpoint triggers
+
+Agents should checkpoint when any of these occur:
+- a new instruction, correction, preference, or rule appears
+- a decision is made
+- a blocker or open loop is discovered
+- a task changes phase (start, blocked, resumed, finished)
+- work becomes long, multi-step, or compaction-sensitive
+- several meaningful turns have happened without a checkpoint
+
+## Session diaries
+
+Recurring chats and threads should keep concise session diaries.
+
+These are **not** full transcript archives.
+They should capture:
+- important discussion points
+- decisions
+- open loops
+- follow-ups
+- thread-specific norms
+
+The goal is future resumability, not chat duplication.
+
+## Promotion flow
+
+Use a deliberate promotion path:
+
+- session/thread notes -> recent/daily continuity
+- recent/daily continuity -> project continuity
+- project continuity -> durable global/operator continuity only when truly cross-project
+
+This keeps continuity structured instead of collapsing into one giant memory file.
+
+## Bootstrap implications
+
+Bootstrap should install both:
+- continuity structure
+- continuity operating rules
+
+That means a new project should leave bootstrap with:
+- continuity paths or equivalents in place
+- repo-local agent instructions that mention checkpointing
+- guidance on when to write memory
+- guidance on what belongs in each continuity layer
+
+Without this, teams often end up with governance text but no durable continuity behavior.
+
+## Anti-patterns
+
+Avoid:
+- treating live chat context as durable state
+- waiting until the very end to write memory
+- using transcript archaeology as the main resumption mechanism
+- hiding important decisions only in chat
+- importing personal/local semantics into generic project governance
+
+## Related guidance
+
+- [Bootstrap](/docs/bootstrap)
+- [Quickstart](/docs/quickstart)
+- [Published GOV 09](/docs/published/gov-09-agent-continuity-bootstrap)

--- a/docs/agents-template.md
+++ b/docs/agents-template.md
@@ -20,6 +20,7 @@ This repository uses VibeGov with `.governance/` as the governance source of tru
 6. `.governance/rules/gov-06-issues.mdc`
 7. `.governance/rules/gov-07-tasks.mdc`
 8. `.governance/rules/gov-08-exploratory-review.mdc`
+9. `.governance/rules/gov-09-agent-continuity-bootstrap.mdc`
 
 ## Repo Defaults
 - Source of truth: `.governance/`
@@ -32,6 +33,12 @@ This repository uses VibeGov with `.governance/` as the governance source of tru
 - Record prerequisite checks and blockers there before continuing.
 - Do not treat partial bootstrap as complete.
 - Keep bootstrap run-history artifacts under `.governance/project/bootstrap-runs/`.
+
+## Continuity Discipline
+- Install and use a repo-local continuity model (for example session, daily, and project continuity layers).
+- Checkpoint important instructions, decisions, blockers, and phase changes during work, not only at the end.
+- Maintain concise session/thread diaries for recurring operating contexts.
+- Promote durable continuity upward deliberately instead of relying on transcript archaeology.
 ```
 
 ## Notes

--- a/docs/bootstrap-validation.md
+++ b/docs/bootstrap-validation.md
@@ -493,12 +493,13 @@ Read and follow:
 
 Before writing any product code:
 1. Create `.governance/rules/`, `.governance/project/`, and `.governance/specs/`.
-2. Install the active VibeGov rule set (`GOV-01` through `GOV-08`) into `.governance/rules/`.
+2. Install the active VibeGov rule set (`GOV-01` through `GOV-09`) into `.governance/rules/`.
 3. Create `.governance/project/PROJECT_INTENT.md` from `PROJECT_TEMPLATE.md`.
 4. Create the first feature/change spec as `.governance/specs/SPEC-001-<feature>.md` from `SPEC_TEMPLATE.md`.
 5. Create or normalize a backlog mapped to the spec sections.
 6. Detect any existing provider-native rules directory in the repo. If one exists, mirror the active `.governance/rules/*.mdc` files into it and report the exact target path(s). If none exists, keep `.governance/` canonical and do not invent a mirror path.
-7. Report the active governance sources you are using.
+7. Install or report continuity bootstrap guidance and continuity paths or equivalents.
+8. Report the active governance sources you are using.
 
 Then stop before product-code implementation.
 ```

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -35,7 +35,7 @@ Do not fork or weaken the pass gate by mode.
 
 Before writing any product code (or before claiming bootstrap review is complete):
 1. Create/normalize `.governance/rules/`, `.governance/project/`, and `.governance/specs/` as needed for the selected mode.
-2. Ensure the active VibeGov rule set (`GOV-01` through `GOV-08`) is installed in `.governance/rules/`.
+2. Ensure the active VibeGov rule set (`GOV-01` through `GOV-09`) is installed in `.governance/rules/`.
 3. Detect existing provider-native rules directories and mirror `.governance/rules/*.mdc` only when they already exist.
 4. Create or normalize `.governance/project/PROJECT_INTENT.md`.
 5. Create `SPEC-001` as either:
@@ -48,14 +48,20 @@ Before writing any product code (or before claiming bootstrap review is complete
    - `.github/pull_request_template.md`
    - `.github/branch-protection-checklist.md`
    - documented default issue-pickup flow
-8. Classify starting repo state before edits or review conclusions:
+8. Install or verify continuity bootstrap artifacts before implementation:
+   - documented continuity layers (session/thread, recent/daily, project, and durable global/operator continuity when that scope exists)
+   - repo-local continuity paths or equivalent scaffolding
+   - checkpoint trigger guidance for instructions, decisions, blockers, phase changes, and compaction risk
+   - session-diary guidance for recurring threads/contexts
+   - promotion guidance between continuity layers
+9. Classify starting repo state before edits or review conclusions:
    - current branch
    - clean/dirty working tree
    - untracked files
    - uncommitted changes
-9. Run with explicit commit policy: `required`, `allowed`, or `forbidden`.
-10. If repo is dirty, do exactly one: resolve first, stop blocked, or continue in explicit review mode.
-11. If GitHub-hosted, run preflight before board mutation:
+10. Run with explicit commit policy: `required`, `allowed`, or `forbidden`.
+11. If repo is dirty, do exactly one: resolve first, stop blocked, or continue in explicit review mode.
+12. If GitHub-hosted, run preflight before board mutation:
    - `git` available
    - `gh` available
    - GitHub auth
@@ -65,7 +71,7 @@ Before writing any product code (or before claiming bootstrap review is complete
    - branch-protection/admin capability when relevant
    - if any required capability is missing, record it in `INIT-TODO.md` with the exact remediation command or next action before proceeding
    - if branch-protection verification is unavailable only because of a known hosted-feature/private-repo limitation, record it as degraded verification with exact evidence and next action rather than pretending the repo normalization failed
-12. If GitHub automation is available, create/adopt/normalize one canonical board target:
+13. If GitHub automation is available, create/adopt/normalize one canonical board target:
    - if multiple matching boards exist, choose one canonical target explicitly and report why it was chosen
    - normalize `Status`: `Backlog`, `Ready`, `In progress`, `In review`, `Done`, `Blocked`
    - normalize `Priority`: `P0`, `P1`, `P2`
@@ -74,15 +80,15 @@ Before writing any product code (or before claiming bootstrap review is complete
    - import/attach existing issues
    - if no issues exist, report board as intentionally empty
    - clean accidental duplicate empty boards and report cleanup
-13. If GitHub automation is unavailable, report exact missing capability and leave a tracked blocker artifact.
-14. Write durable local output artifacts into `.governance/project/bootstrap-runs/`:
+14. If GitHub automation is unavailable, report exact missing capability and leave a tracked blocker artifact.
+15. Write durable local output artifacts into `.governance/project/bootstrap-runs/`:
    - `<timestamp>-status.md`
    - `<timestamp>-analysis.md`
    - `<timestamp>-feedback.md`
    - optional `<timestamp>-blockers.md`
    - stable top-level files may exist only as latest-run summaries/pointers (`BOOTSTRAP_STATUS.md`, `BOOTSTRAP_ANALYSIS.md`, `BOOTSTRAP_FEEDBACK.md`, `BOOTSTRAP_BLOCKERS.md`)
-15. Reconcile generated docs against final live git/GitHub state before claiming completion.
-16. Distinguish final current state from historical evidence gathered earlier in the run.
+16. Reconcile generated docs against final live git/GitHub state before claiming completion.
+17. Distinguish final current state from historical evidence gathered earlier in the run.
 
 Mode-specific behavior:
 - `init`: create the missing bootstrap state required by the contract
@@ -96,13 +102,14 @@ Then stop before product-code implementation.
 
 Continue only if all are true:
 
-- `.governance/rules/` exists with `GOV-01` through `GOV-08`
+- `.governance/rules/` exists with `GOV-01` through `GOV-09`
 - `.governance/project/PROJECT_INTENT.md` exists
 - `.governance/specs/` has `SPEC-001` (feature spec or bootstrap-setup spec for vague repos)
 - backlog maps to spec scope
 - `AGENTS.md` exists and points to canonical governance sources
 - `INIT-TODO.md` exists for bootstrap/adoption/remediation work and records any missing prerequisite with exact remediation when relevant
 - strict Git workflow artifacts exist
+- continuity structure and continuity operating guidance exist
 - starting repo state and commit-policy mode are reported
 - for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`), and known hosted-feature verification limits are distinguished from core bootstrap failure
 - for GitHub repos with automation, canonical board target is adopted/created/normalized, repo-link status is reported, and multiple-match selection is explained when relevant

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -85,3 +85,4 @@ Canonical-source model:
 - [GOV-06: Issues](/docs/published/gov-06-issues)
 - [GOV-07: Tasks](/docs/published/gov-07-tasks)
 - [GOV-08: Exploratory Review](/docs/published/gov-08-exploratory-review)
+- [GOV-09: Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)

--- a/docs/published/gov-01-instructions.md
+++ b/docs/published/gov-01-instructions.md
@@ -26,6 +26,7 @@ Apply these files in order:
 5. `gov-06-issues.mdc` (issue lifecycle)
 6. `gov-07-tasks.mdc` (task hygiene)
 7. `gov-08-exploratory-review.mdc` (continuous exploratory discovery + backlog hydration)
+8. `gov-09-agent-continuity-bootstrap.mdc` (continuity layers, checkpoint triggers, and bootstrap memory discipline)
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 

--- a/docs/published/gov-06-issues.md
+++ b/docs/published/gov-06-issues.md
@@ -75,6 +75,31 @@ Only after review/confirmation can the issue enter active implementation.
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
+## Active Work Visibility (mandatory)
+
+While an issue is actively being worked, the issue comments must show the work as it happens.
+
+Leave a visible issue comment at every meaningful state change, not just at the end.
+Minimum states to comment:
+- start/resume
+- meaningful plan change
+- blocker/risk
+- validation result
+- final outcome, including commit/PR links when present
+
+Do not spam micro-steps with no durable state change, for example:
+- opening files
+- reading code
+- rerunning the same command without a new result
+
+Preferred behavior:
+- update the current working comment for small same-phase follow-ups when practical
+- create a new comment when the issue changes phase
+
+Goal: someone reading only the issue should be able to see what was planned, what happened, what evidence exists, and what remains.
+
+> Commentary: Marks non-optional behavior to reduce ambiguity during execution.
+
 ## Closure Standard
 
 Before closing, ensure:

--- a/docs/published/gov-09-agent-continuity-bootstrap.md
+++ b/docs/published/gov-09-agent-continuity-bootstrap.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 9
+---
+
+# GOV 09 AGENT CONTINUITY BOOTSTRAP
+
+- Source rule: [gov-09-agent-continuity-bootstrap.mdc](https://github.com/governance-foundation/vibegov.io/blob/main/.governance/rules/gov-09-agent-continuity-bootstrap.mdc)
+- Download raw file: [gov-09-agent-continuity-bootstrap.mdc](https://raw.githubusercontent.com/governance-foundation/vibegov.io/main/.governance/rules/gov-09-agent-continuity-bootstrap.mdc)
+
+This page embeds the canonical rule text and adds commentary after each section to explain why the section exists.
+
+## Governance: Agent Continuity Bootstrap
+
+Continuity is part of execution, not cleanup after execution.
+
+Governed projects should bootstrap agents with durable continuity structure and explicit checkpoint behavior early, before long-running work depends on live chat context.
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
+## Continuity Layers
+
+- `GOV-09-CONT-001` Governed projects should define four continuity layers: session/thread continuity, recent/daily continuity, project continuity, and durable global/operator continuity when that scope exists.
+- `GOV-09-CONT-002` The continuity model should define what belongs in each layer, where it lives, and how information is promoted between layers.
+- `GOV-09-CONT-003` Projects should prefer concise factual continuity artifacts over transcript dumps or undocumented chat memory.
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
+## Checkpoint Triggers
+
+- `GOV-09-CONT-004` Agents must checkpoint important state during work, not only at the end.
+- `GOV-09-CONT-005` Required checkpoint triggers should include new instructions or corrections, decisions made, blockers or open loops discovered, task phase changes, prolonged multi-step execution, and likely compaction or handoff risk.
+- `GOV-09-CONT-006` When several meaningful turns occur without a checkpoint, the agent should write a compact continuity update before proceeding.
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
+## Session Diaries and Promotion
+
+- `GOV-09-CONT-007` Recurring chats, threads, or operating contexts should maintain concise session diaries that capture important discussion points, decisions, open loops, follow-ups, and thread-specific norms.
+- `GOV-09-CONT-008` Session diaries should not be treated as raw transcript archives; they should preserve substance needed for future resumption.
+- `GOV-09-CONT-009` Continuity information should flow upward deliberately: session or recent notes into project continuity when they become durable project context, and into global/operator continuity only when they are truly cross-project and safe for that scope.
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
+## Bootstrap Expectations
+
+- `GOV-09-CONT-010` Bootstrap should install both continuity structure and operating rules, not merely mention memory as a future concern.
+- `GOV-09-CONT-011` Bootstrap/adoption guidance should create or normalize repo-local continuity scaffolding, recommended continuity paths, and agent operating instructions for checkpointing and promotion.
+- `GOV-09-CONT-012` Bootstrap completion should not be claimed when continuity artifacts or continuity operating rules expected by the project contract are still missing.
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- treating live chat context as the only continuity system
+- waiting until the end of a long run to write memory
+- storing all continuity in one undifferentiated global file
+- relying on transcript archaeology instead of structured continuity artifacts
+- importing person-specific wording into generic bootstrap semantics when the rule is meant to be reusable
+
+> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.

--- a/scripts/generate-published-rules.js
+++ b/scripts/generate-published-rules.js
@@ -14,6 +14,7 @@ const files = [
   { file: "gov-06-issues.mdc", out: "gov-06-issues.md", pos: 6 },
   { file: "gov-07-tasks.mdc", out: "gov-07-tasks.md", pos: 7 },
   { file: "gov-08-exploratory-review.mdc", out: "gov-08-exploratory-review.md", pos: 8 },
+  { file: "gov-09-agent-continuity-bootstrap.mdc", out: "gov-09-agent-continuity-bootstrap.md", pos: 9 },
 ];
 
 function stripFrontmatter(text) {

--- a/sidebars.js
+++ b/sidebars.js
@@ -31,6 +31,7 @@ const sidebars = {
     },
     'branch-protection-checklist',
     'vibegov-sdlc',
+    'agent-continuity-bootstrap',
     'contribute',
     {
       type: 'category',
@@ -56,6 +57,7 @@ const sidebars = {
         'published/gov-06-issues',
         'published/gov-07-tasks',
         'published/gov-08-exploratory-review',
+        'published/gov-09-agent-continuity-bootstrap',
       ],
     },
   ],

--- a/static/agent.txt
+++ b/static/agent.txt
@@ -32,6 +32,12 @@ hard gate before product code:
   - INIT-TODO.md (create/update this early during bootstrap/adoption/remediation work)
   - pull request template
   - branch-protection checklist
+- install or report continuity bootstrap guidance before implementation:
+  - documented continuity layers
+  - repo-local continuity paths or equivalent scaffolding
+  - checkpoint triggers for instructions, decisions, blockers, phase changes, and compaction risk
+  - session-diary guidance for recurring threads/contexts
+  - promotion guidance between continuity layers
   - documented default issue-pickup flow
 - if the repo is GitHub-hosted, run GitHub preflight before project-board mutation:
   - git available
@@ -69,7 +75,7 @@ delivery loop:
 - Observe -> Plan -> Implement -> Verify -> Document
 
 active rules:
-- GOV-01 through GOV-08 (including exploratory review behavior in GOV-08)
+- GOV-01 through GOV-09 (including continuity bootstrap behavior in GOV-09)
 
 completion rule:
 - each completed task must include verification evidence and traceability update

--- a/static/bootstrap.json
+++ b/static/bootstrap.json
@@ -59,7 +59,8 @@
     "gov-05-testing",
     "gov-06-issues",
     "gov-07-tasks",
-    "gov-08-exploratory-review"
+    "gov-08-exploratory-review",
+    "gov-09-agent-continuity-bootstrap"
   ],
   "hard_gate_before_product_code": true,
   "pre_coding_required_outputs": [
@@ -67,9 +68,23 @@
     ".governance/specs/SPEC-001-<feature>.md_or_bootstrap_setup_spec",
     "backlog_mapped_to_spec_sections",
     "AGENTS.md",
+    "continuity_structure_and_checkpoint_guidance",
     "git_workflow_artifacts",
     "documented_default_issue_pickup_flow"
   ],
+  "continuity_bootstrap": {
+    "required": true,
+    "layers": [
+      "session_or_thread_continuity",
+      "recent_or_daily_continuity",
+      "project_continuity",
+      "durable_global_or_operator_continuity_when_applicable"
+    ],
+    "mustDefineCheckpointTriggers": true,
+    "mustDocumentPromotionFlow": true,
+    "mustInstallSessionDiaryGuidance": true,
+    "preferConciseStructuredArtifactsOverTranscriptDumps": true
+  },
   "github_hosted_bootstrap": {
     "preflightChecks": [
       "git_available",


### PR DESCRIPTION
## Summary
- add GOV-09 agent continuity bootstrap as a canonical VibeGov rule
- add supporting spec and public docs for continuity layers, checkpoint triggers, session diaries, and promotion flow
- update bootstrap contract/template surfaces so BI/BU/review install continuity guidance early

## Verification
- `node scripts/generate-published-rules.js`
- `npm run build`

## Issue
- Closes #81
