### PR TITLE
#83 Add harness-engineering governance rules (GOV-10..GOV-13)

### DIFF
--- a/.governance/rules/gov-01-instructions.mdc
+++ b/.governance/rules/gov-01-instructions.mdc
@@ -19,6 +19,10 @@ Apply these files in order:
 6. `gov-07-tasks.mdc` (task hygiene)
 7. `gov-08-exploratory-review.mdc` (continuous exploratory discovery + backlog hydration)
 8. `gov-09-agent-continuity-bootstrap.mdc` (continuity layers, checkpoint triggers, and bootstrap memory discipline)
+9. `gov-10-agent-state-closure-git-hygiene.mdc` (work-unit state closure and repository accounting discipline)
+10. `gov-11-agent-legibility-in-repo-truth.mdc` (in-repo truth and durable knowledge promotion)
+11. `gov-12-drift-control-garbage-collection.mdc` (continuous cleanup and drift-control governance)
+12. `gov-13-review-loops-completion-discipline.mdc` (review-loop closure and completion semantics)
 
 ## Source-of-Truth Layout
 

--- a/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
+++ b/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
@@ -1,0 +1,55 @@
+---
+description: agent state closure, working tree accounting, and git hygiene
+alwaysApply: true
+---
+# Governance: Agent State Closure and Git Hygiene
+
+Agent work should end in explicit state, not residue.
+
+Governed repositories should treat repository state as a control surface for agent reliability, reviewability, and recovery.
+
+## Core Principle
+
+- `GOV-10-GIT-001` Every substantive work unit must end with full working-tree accounting.
+- `GOV-10-GIT-002` Agents must not carry ambiguous repository state into the next work unit.
+- `GOV-10-GIT-003` Repository cleanliness is not cosmetic. It is part of execution correctness.
+
+## Working-Tree Accounting
+
+- `GOV-10-GIT-004` Before a work unit is considered complete, blocked, deferred, or handed off, every modified, deleted, and untracked file in scope must be classified.
+- `GOV-10-GIT-005` Allowed classifications are:
+  - committed as intended governed change,
+  - reverted because it is junk, noise, or failed experimentation,
+  - ignored through an explicit ignore rule when the file is generated or intentionally untracked,
+  - intentionally deferred with an explicit note that names the file, reason, and next follow-up path.
+- `GOV-10-GIT-006` "I think this file is probably from earlier work" is not sufficient accounting.
+- `GOV-10-GIT-007` If a file cannot be explained, the work unit is not yet closed.
+
+## Dirty-Tree Discipline
+
+- `GOV-10-GIT-008` Agents must treat unresolved dirty state as actionable repository state, not passive background context.
+- `GOV-10-GIT-009` In single-actor repos or isolated worktrees, unresolved dirty state should be presumed agent-caused until proven otherwise.
+- `GOV-10-GIT-010` Reporting "tree is dirty" without classification, resolution intent, or follow-up path is non-compliant.
+- `GOV-10-GIT-011` If prior residue is discovered while starting new work, the agent should either resolve it first or explicitly escalate why safe resolution cannot happen yet.
+
+## Commit and Ignore Hygiene
+
+- `GOV-10-GIT-012` Durable kept changes should normally be committed before the work unit ends so the intended state has a real tracking boundary.
+- `GOV-10-GIT-013` Commits should be cohesive, reviewable, and limited to the intended governed change.
+- `GOV-10-GIT-014` Generated or environment-specific noise that should persist locally but not be tracked must be handled through explicit ignore rules rather than repeated manual omission.
+- `GOV-10-GIT-015` Ignore rules should be as narrow as practical so legitimate changes are not accidentally hidden.
+
+## Completion and Handoff Rules
+
+- `GOV-10-GIT-016` Completion claims are invalid if the repository state that remains is unexplained.
+- `GOV-10-GIT-017` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
+- `GOV-10-GIT-018` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- letting partial experiments silently roll into later commits
+- treating untracked temp files as harmless background clutter
+- leaving generated noise unignored across repeated runs
+- carrying mixed unrelated diffs across work units
+- using dirty state as a substitute for real tracking

--- a/.governance/rules/gov-11-agent-legibility-in-repo-truth.mdc
+++ b/.governance/rules/gov-11-agent-legibility-in-repo-truth.mdc
@@ -1,0 +1,49 @@
+---
+description: agent legibility, in-repo truth, and promotion of durable operating knowledge
+alwaysApply: true
+---
+# Governance: Agent Legibility and In-Repo Truth
+
+If durable operating knowledge is not discoverable in repository artifacts, it is not reliable system knowledge.
+
+Governed systems should optimize for agent legibility by making intent, constraints, invariants, and prior decisions discoverable in versioned repo truth.
+
+## Core Principle
+
+- `GOV-11-LEG-001` Governed repositories should treat repo-local, versioned artifacts as the primary operating memory for agents.
+- `GOV-11-LEG-002` Durable decisions, constraints, invariants, and execution norms should be promoted into repository truth instead of remaining trapped in chat, review comments, or private human memory.
+- `GOV-11-LEG-003` Agents should prefer discoverable repo truth over transcript archaeology or informal conversational recall when both exist.
+
+## Reliable Knowledge Rules
+
+- `GOV-11-LEG-004` If an instruction or decision is important enough to affect future work repeatedly, it should be encoded into a durable repo artifact.
+- `GOV-11-LEG-005` Acceptable durable artifacts include governance rules, architecture docs, project intent docs, feature specs, execution plans, reference docs, templates, tests, and lint/config enforcement.
+- `GOV-11-LEG-006` Knowledge that exists only in transient chat history should be treated as fragile until promoted.
+- `GOV-11-LEG-007` Agents should not assume hidden human context, unwritten team norms, or remembered chat context will still be available on the next run.
+
+## Promotion Expectations
+
+- `GOV-11-LEG-008` Repeated human corrections should trigger promotion into durable repo truth when they describe reusable behavior rather than one-off preference.
+- `GOV-11-LEG-009` Durable promotion should happen at the narrowest authoritative layer that fits the fact, for example spec, project doc, governance rule, reference doc, test, or lint rule.
+- `GOV-11-LEG-010` When promotion does not happen immediately, the missing promotion path should be tracked explicitly rather than assumed away.
+
+## Discoverability Expectations
+
+- `GOV-11-LEG-011` Important repository knowledge should be organized so a future agent can find it without reading the full repository or relying on external narration.
+- `GOV-11-LEG-012` Entry-point files should act as maps to deeper source-of-truth artifacts rather than attempting to be giant manuals.
+- `GOV-11-LEG-013` Knowledge architecture should support progressive disclosure: brief entry points, structured deeper docs, and stable canonical locations.
+- `GOV-11-LEG-014` When durable knowledge moves, links and references should be updated so discoverability does not silently degrade.
+
+## Enforcement Orientation
+
+- `GOV-11-LEG-015` When a repeated rule or invariant is mechanically enforceable, governed systems should prefer enforcing it through code, tests, or linting over relying only on prose reminders.
+- `GOV-11-LEG-016` Human review should be treated as a source of new invariants to encode, not only as a one-time correction channel.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- relying on chat logs as the main system of record
+- leaving architectural decisions only in pull request discussion
+- expecting future agents to infer unwritten norms from scattered examples
+- storing critical intent in one giant unstructured instruction file
+- keeping durable rules in people’s heads instead of repo artifacts

--- a/.governance/rules/gov-12-drift-control-garbage-collection.mdc
+++ b/.governance/rules/gov-12-drift-control-garbage-collection.mdc
@@ -1,0 +1,46 @@
+---
+description: drift control, cleanup cadence, and garbage collection for agent-generated systems
+alwaysApply: true
+---
+# Governance: Drift Control and Garbage Collection
+
+Agent-generated systems accumulate drift unless cleanup is continuous, explicit, and tracked.
+
+Governed repositories should treat cleanup as part of normal delivery rather than a rare rescue phase.
+
+## Core Principle
+
+- `GOV-12-DRIFT-001` Drift control is a first-class maintenance loop, not optional housekeeping.
+- `GOV-12-DRIFT-002` Small continuous cleanup is preferable to large infrequent cleanup campaigns.
+- `GOV-12-DRIFT-003` Human taste and review findings should compound through recurring cleanup and enforcement, not reset every run.
+
+## What Counts as Drift
+
+- `GOV-12-DRIFT-004` Drift includes stale docs, duplicated local patterns, weak or inconsistent naming, obsolete generated artifacts, lingering temporary files, repeated low-quality agent patterns, and unowned deviations from current standards.
+- `GOV-12-DRIFT-005` Drift also includes governance/process drift, such as outdated templates, stale instructions, broken cross-links, or review expectations that no longer match actual delivery behavior.
+
+## Cleanup Expectations
+
+- `GOV-12-DRIFT-006` Governed repositories should maintain a recurring cleanup path that inspects for drift and converts meaningful findings into tracked work or immediate bounded cleanup.
+- `GOV-12-DRIFT-007` Cleanup work should prefer focused, reviewable corrections over sweeping unfocused rewrites.
+- `GOV-12-DRIFT-008` When cleanup is deferred, the drift item should be captured as explicit backlog work rather than left as ambient known mess.
+- `GOV-12-DRIFT-009` Repeatedly rediscovered drift should be treated as an enforcement gap, not just a maintenance todo.
+
+## Promotion from Cleanup
+
+- `GOV-12-DRIFT-010` If the same class of cleanup keeps reappearing, the governing system should promote the remedy into stronger controls such as templates, reference docs, tests, generators, or lint rules.
+- `GOV-12-DRIFT-011` Cleanup findings should inform quality grading, governance updates, or harness improvements when they reveal systemic weakness.
+
+## Reviewability and Evidence
+
+- `GOV-12-DRIFT-012` Drift cleanup should leave evidence of what pattern was corrected, why it mattered, and what prevents recurrence when known.
+- `GOV-12-DRIFT-013` Large cleanup claims without scoped examples, evidence, or recurrence prevention should be treated skeptically.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- saving cleanup for occasional heroics
+- accepting AI slop as inevitable background cost
+- repeatedly fixing the same smell manually without strengthening the harness
+- allowing stale governance/docs/templates to survive because product code changed faster
+- treating repository clutter as harmless when it actively degrades future agent runs

--- a/.governance/rules/gov-13-review-loops-completion-discipline.mdc
+++ b/.governance/rules/gov-13-review-loops-completion-discipline.mdc
@@ -1,0 +1,52 @@
+---
+description: self-review, feedback loops, and completion discipline for governed agent work
+alwaysApply: true
+---
+# Governance: Review Loops and Completion Discipline
+
+Implemented is not complete.
+
+Governed agent work should close the loop through review, evidence, and feedback incorporation before claiming completion.
+
+## Core Principle
+
+- `GOV-13-REV-001` A first-pass implementation is an intermediate state, not a trustworthy completion signal.
+- `GOV-13-REV-002` Completion requires explicit review of the produced change and its evidence, not only confidence in the act of producing it.
+- `GOV-13-REV-003` Review loops should be designed to strengthen correctness, maintainability, and harness learning.
+
+## Required Review Loop
+
+- `GOV-13-REV-004` Before claiming a governed work unit complete, the agent should perform a targeted self-review against intent, scope, diff quality, evidence quality, and residual risk.
+- `GOV-13-REV-005` The review should ask at minimum:
+  - does the change satisfy the intended requirement or issue,
+  - does the diff stay inside scope,
+  - is the evidence direct enough,
+  - are docs/spec/traceability updated where required,
+  - what remains unverified, blocked, or deferred.
+- `GOV-13-REV-006` If the review reveals material weakness, the agent should continue the loop rather than claiming done and hoping later review catches it.
+
+## Feedback Incorporation
+
+- `GOV-13-REV-007` Human, automated, or agent review feedback should be incorporated as part of the same governed work loop until the active review scope is honestly resolved, re-scoped, or blocked.
+- `GOV-13-REV-008` Responding to feedback should include updating affected evidence, docs, and traceability when those artifacts are impacted.
+- `GOV-13-REV-009` Repeated feedback themes should be considered candidates for governance or harness promotion.
+
+## Completion Semantics
+
+- `GOV-13-REV-010` Completion claims should distinguish clearly between implemented, verified, reviewed, and released states rather than collapsing them into one vague "done".
+- `GOV-13-REV-011` A governed work unit is not complete if review, evidence, or follow-up handling is still materially open.
+- `GOV-13-REV-012` If confidence is partial, the claimed state should say so explicitly, for example blocked, partial, scoped-complete, or awaiting review.
+
+## Escalation and Stop Conditions
+
+- `GOV-13-REV-013` When repeated review/fix loops stop producing clear progress, the agent should escalate the blocker, ambiguity, or missing capability instead of performing aimless churn.
+- `GOV-13-REV-014` When judgment is required beyond the current governance and evidence, the agent should make the decision boundary visible instead of silently guessing.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- equating implementation with completion
+- claiming done immediately after the first passing check
+- leaving review comments or feedback themes unincorporated without explicit state change
+- using a summary as a substitute for a real review loop
+- moving on while material review debt remains hidden

--- a/docs/published/gov-01-instructions.md
+++ b/docs/published/gov-01-instructions.md
@@ -27,6 +27,10 @@ Apply these files in order:
 6. `gov-07-tasks.mdc` (task hygiene)
 7. `gov-08-exploratory-review.mdc` (continuous exploratory discovery + backlog hydration)
 8. `gov-09-agent-continuity-bootstrap.mdc` (continuity layers, checkpoint triggers, and bootstrap memory discipline)
+9. `gov-10-agent-state-closure-git-hygiene.mdc` (work-unit state closure and repository accounting discipline)
+10. `gov-11-agent-legibility-in-repo-truth.mdc` (in-repo truth and durable knowledge promotion)
+11. `gov-12-drift-control-garbage-collection.mdc` (continuous cleanup and drift-control governance)
+12. `gov-13-review-loops-completion-discipline.mdc` (review-loop closure and completion semantics)
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 

--- a/docs/published/gov-10-agent-state-closure-git-hygiene.md
+++ b/docs/published/gov-10-agent-state-closure-git-hygiene.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 10
+---
+
+# GOV 10 AGENT STATE CLOSURE AND GIT HYGIENE
+
+- Source rule: [gov-10-agent-state-closure-git-hygiene.mdc](https://github.com/governance-foundation/vibegov.io/blob/main/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc)
+- Download raw file: [gov-10-agent-state-closure-git-hygiene.mdc](https://raw.githubusercontent.com/governance-foundation/vibegov.io/main/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc)
+
+This page embeds the canonical rule text and adds commentary after each section to explain why the section exists.
+
+## Governance: Agent State Closure and Git Hygiene
+
+Agent work should end in explicit state, not residue.
+
+Governed repositories should treat repository state as a control surface for agent reliability, reviewability, and recovery.
+
+> Commentary: Makes repository state part of delivery correctness rather than an afterthought.
+
+## Core Principle
+
+- `GOV-10-GIT-001` Every substantive work unit must end with full working-tree accounting.
+- `GOV-10-GIT-002` Agents must not carry ambiguous repository state into the next work unit.
+- `GOV-10-GIT-003` Repository cleanliness is not cosmetic. It is part of execution correctness.
+
+> Commentary: Defines the baseline expectation that repo state must be intentional before work can honestly move on.
+
+## Working-Tree Accounting
+
+- `GOV-10-GIT-004` Before a work unit is considered complete, blocked, deferred, or handed off, every modified, deleted, and untracked file in scope must be classified.
+- `GOV-10-GIT-005` Allowed classifications are:
+  - committed as intended governed change,
+  - reverted because it is junk, noise, or failed experimentation,
+  - ignored through an explicit ignore rule when the file is generated or intentionally untracked,
+  - intentionally deferred with an explicit note that names the file, reason, and next follow-up path.
+- `GOV-10-GIT-006` "I think this file is probably from earlier work" is not sufficient accounting.
+- `GOV-10-GIT-007` If a file cannot be explained, the work unit is not yet closed.
+
+> Commentary: Forces explicit file-by-file accounting so previous-turn residue cannot silently contaminate later work.
+
+## Dirty-Tree Discipline
+
+- `GOV-10-GIT-008` Agents must treat unresolved dirty state as actionable repository state, not passive background context.
+- `GOV-10-GIT-009` In single-actor repos or isolated worktrees, unresolved dirty state should be presumed agent-caused until proven otherwise.
+- `GOV-10-GIT-010` Reporting "tree is dirty" without classification, resolution intent, or follow-up path is non-compliant.
+- `GOV-10-GIT-011` If prior residue is discovered while starting new work, the agent should either resolve it first or explicitly escalate why safe resolution cannot happen yet.
+
+> Commentary: Prevents the common failure mode where agents report dirty state but leave the human to reason about it.
+
+## Commit and Ignore Hygiene
+
+- `GOV-10-GIT-012` Durable kept changes should normally be committed before the work unit ends so the intended state has a real tracking boundary.
+- `GOV-10-GIT-013` Commits should be cohesive, reviewable, and limited to the intended governed change.
+- `GOV-10-GIT-014` Generated or environment-specific noise that should persist locally but not be tracked must be handled through explicit ignore rules rather than repeated manual omission.
+- `GOV-10-GIT-015` Ignore rules should be as narrow as practical so legitimate changes are not accidentally hidden.
+
+> Commentary: Keeps git history meaningful while preventing recurring local noise from leaking across work units.
+
+## Completion and Handoff Rules
+
+- `GOV-10-GIT-016` Completion claims are invalid if the repository state that remains is unexplained.
+- `GOV-10-GIT-017` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
+- `GOV-10-GIT-018` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
+
+> Commentary: Extends state-closure discipline beyond successful completion into blockers, deferrals, and handoffs.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- letting partial experiments silently roll into later commits
+- treating untracked temp files as harmless background clutter
+- leaving generated noise unignored across repeated runs
+- carrying mixed unrelated diffs across work units
+- using dirty state as a substitute for real tracking
+
+> Commentary: Names the residue patterns this rule is designed to eliminate.

--- a/docs/published/gov-11-agent-legibility-in-repo-truth.md
+++ b/docs/published/gov-11-agent-legibility-in-repo-truth.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 11
+---
+
+# GOV 11 AGENT LEGIBILITY AND IN-REPO TRUTH
+
+- Source rule: [gov-11-agent-legibility-in-repo-truth.mdc](https://github.com/governance-foundation/vibegov.io/blob/main/.governance/rules/gov-11-agent-legibility-in-repo-truth.mdc)
+- Download raw file: [gov-11-agent-legibility-in-repo-truth.mdc](https://raw.githubusercontent.com/governance-foundation/vibegov.io/main/.governance/rules/gov-11-agent-legibility-in-repo-truth.mdc)
+
+This page embeds the canonical rule text and adds commentary after each section to explain why the section exists.
+
+## Governance: Agent Legibility and In-Repo Truth
+
+If durable operating knowledge is not discoverable in repository artifacts, it is not reliable system knowledge.
+
+Governed systems should optimize for agent legibility by making intent, constraints, invariants, and prior decisions discoverable in versioned repo truth.
+
+> Commentary: Makes discoverable repo truth the default memory model for repeatable agent execution.
+
+## Core Principle
+
+- `GOV-11-LEG-001` Governed repositories should treat repo-local, versioned artifacts as the primary operating memory for agents.
+- `GOV-11-LEG-002` Durable decisions, constraints, invariants, and execution norms should be promoted into repository truth instead of remaining trapped in chat, review comments, or private human memory.
+- `GOV-11-LEG-003` Agents should prefer discoverable repo truth over transcript archaeology or informal conversational recall when both exist.
+
+> Commentary: Establishes where trustworthy knowledge should live and what should take precedence.
+
+## Reliable Knowledge Rules
+
+- `GOV-11-LEG-004` If an instruction or decision is important enough to affect future work repeatedly, it should be encoded into a durable repo artifact.
+- `GOV-11-LEG-005` Acceptable durable artifacts include governance rules, architecture docs, project intent docs, feature specs, execution plans, reference docs, templates, tests, and lint/config enforcement.
+- `GOV-11-LEG-006` Knowledge that exists only in transient chat history should be treated as fragile until promoted.
+- `GOV-11-LEG-007` Agents should not assume hidden human context, unwritten team norms, or remembered chat context will still be available on the next run.
+
+> Commentary: Turns “we talked about this before” into explicit promotion duties.
+
+## Promotion Expectations
+
+- `GOV-11-LEG-008` Repeated human corrections should trigger promotion into durable repo truth when they describe reusable behavior rather than one-off preference.
+- `GOV-11-LEG-009` Durable promotion should happen at the narrowest authoritative layer that fits the fact, for example spec, project doc, governance rule, reference doc, test, or lint rule.
+- `GOV-11-LEG-010` When promotion does not happen immediately, the missing promotion path should be tracked explicitly rather than assumed away.
+
+> Commentary: Ensures feedback compounds into system memory instead of resetting each run.
+
+## Discoverability Expectations
+
+- `GOV-11-LEG-011` Important repository knowledge should be organized so a future agent can find it without reading the full repository or relying on external narration.
+- `GOV-11-LEG-012` Entry-point files should act as maps to deeper source-of-truth artifacts rather than attempting to be giant manuals.
+- `GOV-11-LEG-013` Knowledge architecture should support progressive disclosure: brief entry points, structured deeper docs, and stable canonical locations.
+- `GOV-11-LEG-014` When durable knowledge moves, links and references should be updated so discoverability does not silently degrade.
+
+> Commentary: Keeps knowledge legible at scale instead of collapsing into one stale instruction blob.
+
+## Enforcement Orientation
+
+- `GOV-11-LEG-015` When a repeated rule or invariant is mechanically enforceable, governed systems should prefer enforcing it through code, tests, or linting over relying only on prose reminders.
+- `GOV-11-LEG-016` Human review should be treated as a source of new invariants to encode, not only as a one-time correction channel.
+
+> Commentary: Pushes repeatable human taste from comments into enforceable controls.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- relying on chat logs as the main system of record
+- leaving architectural decisions only in pull request discussion
+- expecting future agents to infer unwritten norms from scattered examples
+- storing critical intent in one giant unstructured instruction file
+- keeping durable rules in people’s heads instead of repo artifacts
+
+> Commentary: Calls out the exact hidden-knowledge patterns that break agent reliability.

--- a/docs/published/gov-12-drift-control-garbage-collection.md
+++ b/docs/published/gov-12-drift-control-garbage-collection.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 12
+---
+
+# GOV 12 DRIFT CONTROL AND GARBAGE COLLECTION
+
+- Source rule: [gov-12-drift-control-garbage-collection.mdc](https://github.com/governance-foundation/vibegov.io/blob/main/.governance/rules/gov-12-drift-control-garbage-collection.mdc)
+- Download raw file: [gov-12-drift-control-garbage-collection.mdc](https://raw.githubusercontent.com/governance-foundation/vibegov.io/main/.governance/rules/gov-12-drift-control-garbage-collection.mdc)
+
+This page embeds the canonical rule text and adds commentary after each section to explain why the section exists.
+
+## Governance: Drift Control and Garbage Collection
+
+Agent-generated systems accumulate drift unless cleanup is continuous, explicit, and tracked.
+
+Governed repositories should treat cleanup as part of normal delivery rather than a rare rescue phase.
+
+> Commentary: Frames cleanup as core delivery maintenance, not optional housekeeping.
+
+## Core Principle
+
+- `GOV-12-DRIFT-001` Drift control is a first-class maintenance loop, not optional housekeeping.
+- `GOV-12-DRIFT-002` Small continuous cleanup is preferable to large infrequent cleanup campaigns.
+- `GOV-12-DRIFT-003` Human taste and review findings should compound through recurring cleanup and enforcement, not reset every run.
+
+> Commentary: Establishes the cadence and leverage model for keeping agent-generated repos healthy.
+
+## What Counts as Drift
+
+- `GOV-12-DRIFT-004` Drift includes stale docs, duplicated local patterns, weak or inconsistent naming, obsolete generated artifacts, lingering temporary files, repeated low-quality agent patterns, and unowned deviations from current standards.
+- `GOV-12-DRIFT-005` Drift also includes governance/process drift, such as outdated templates, stale instructions, broken cross-links, or review expectations that no longer match actual delivery behavior.
+
+> Commentary: Expands drift beyond code smells to include governance and documentation entropy.
+
+## Cleanup Expectations
+
+- `GOV-12-DRIFT-006` Governed repositories should maintain a recurring cleanup path that inspects for drift and converts meaningful findings into tracked work or immediate bounded cleanup.
+- `GOV-12-DRIFT-007` Cleanup work should prefer focused, reviewable corrections over sweeping unfocused rewrites.
+- `GOV-12-DRIFT-008` When cleanup is deferred, the drift item should be captured as explicit backlog work rather than left as ambient known mess.
+- `GOV-12-DRIFT-009` Repeatedly rediscovered drift should be treated as an enforcement gap, not just a maintenance todo.
+
+> Commentary: Requires drift findings to produce action instead of recurring complaints.
+
+## Promotion from Cleanup
+
+- `GOV-12-DRIFT-010` If the same class of cleanup keeps reappearing, the governing system should promote the remedy into stronger controls such as templates, reference docs, tests, generators, or lint rules.
+- `GOV-12-DRIFT-011` Cleanup findings should inform quality grading, governance updates, or harness improvements when they reveal systemic weakness.
+
+> Commentary: Converts repeated cleanup into stronger system-level prevention.
+
+## Reviewability and Evidence
+
+- `GOV-12-DRIFT-012` Drift cleanup should leave evidence of what pattern was corrected, why it mattered, and what prevents recurrence when known.
+- `GOV-12-DRIFT-013` Large cleanup claims without scoped examples, evidence, or recurrence prevention should be treated skeptically.
+
+> Commentary: Prevents vague “cleaned up” claims from masking unchanged underlying behavior.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- saving cleanup for occasional heroics
+- accepting AI slop as inevitable background cost
+- repeatedly fixing the same smell manually without strengthening the harness
+- allowing stale governance/docs/templates to survive because product code changed faster
+- treating repository clutter as harmless when it actively degrades future agent runs
+
+> Commentary: Names the quality-debt patterns this rule is designed to stop from compounding.

--- a/docs/published/gov-13-review-loops-completion-discipline.md
+++ b/docs/published/gov-13-review-loops-completion-discipline.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 13
+---
+
+# GOV 13 REVIEW LOOPS AND COMPLETION DISCIPLINE
+
+- Source rule: [gov-13-review-loops-completion-discipline.mdc](https://github.com/governance-foundation/vibegov.io/blob/main/.governance/rules/gov-13-review-loops-completion-discipline.mdc)
+- Download raw file: [gov-13-review-loops-completion-discipline.mdc](https://raw.githubusercontent.com/governance-foundation/vibegov.io/main/.governance/rules/gov-13-review-loops-completion-discipline.mdc)
+
+This page embeds the canonical rule text and adds commentary after each section to explain why the section exists.
+
+## Governance: Review Loops and Completion Discipline
+
+Implemented is not complete.
+
+Governed agent work should close the loop through review, evidence, and feedback incorporation before claiming completion.
+
+> Commentary: Separates first-pass output from trustworthy completion.
+
+## Core Principle
+
+- `GOV-13-REV-001` A first-pass implementation is an intermediate state, not a trustworthy completion signal.
+- `GOV-13-REV-002` Completion requires explicit review of the produced change and its evidence, not only confidence in the act of producing it.
+- `GOV-13-REV-003` Review loops should be designed to strengthen correctness, maintainability, and harness learning.
+
+> Commentary: Defines review as a required control loop, not optional polish.
+
+## Required Review Loop
+
+- `GOV-13-REV-004` Before claiming a governed work unit complete, the agent should perform a targeted self-review against intent, scope, diff quality, evidence quality, and residual risk.
+- `GOV-13-REV-005` The review should ask at minimum:
+  - does the change satisfy the intended requirement or issue,
+  - does the diff stay inside scope,
+  - is the evidence direct enough,
+  - are docs/spec/traceability updated where required,
+  - what remains unverified, blocked, or deferred.
+- `GOV-13-REV-006` If the review reveals material weakness, the agent should continue the loop rather than claiming done and hoping later review catches it.
+
+> Commentary: Makes internal review explicit and prevents premature completion claims.
+
+## Feedback Incorporation
+
+- `GOV-13-REV-007` Human, automated, or agent review feedback should be incorporated as part of the same governed work loop until the active review scope is honestly resolved, re-scoped, or blocked.
+- `GOV-13-REV-008` Responding to feedback should include updating affected evidence, docs, and traceability when those artifacts are impacted.
+- `GOV-13-REV-009` Repeated feedback themes should be considered candidates for governance or harness promotion.
+
+> Commentary: Turns review comments into an execution loop and a governance learning loop.
+
+## Completion Semantics
+
+- `GOV-13-REV-010` Completion claims should distinguish clearly between implemented, verified, reviewed, and released states rather than collapsing them into one vague "done".
+- `GOV-13-REV-011` A governed work unit is not complete if review, evidence, or follow-up handling is still materially open.
+- `GOV-13-REV-012` If confidence is partial, the claimed state should say so explicitly, for example blocked, partial, scoped-complete, or awaiting review.
+
+> Commentary: Improves handoff clarity and reduces false certainty in progress reporting.
+
+## Escalation and Stop Conditions
+
+- `GOV-13-REV-013` When repeated review/fix loops stop producing clear progress, the agent should escalate the blocker, ambiguity, or missing capability instead of performing aimless churn.
+- `GOV-13-REV-014` When judgment is required beyond the current governance and evidence, the agent should make the decision boundary visible instead of silently guessing.
+
+> Commentary: Prevents endless churn loops and forces explicit escalation boundaries.
+
+## Anti-Patterns
+
+Avoid these failure modes:
+- equating implementation with completion
+- claiming done immediately after the first passing check
+- leaving review comments or feedback themes unincorporated without explicit state change
+- using a summary as a substitute for a real review loop
+- moving on while material review debt remains hidden
+
+> Commentary: Names the output-first behaviors this rule is meant to correct.


### PR DESCRIPTION
## Summary\n- add GOV-10 agent state closure and git hygiene rule\n- add GOV-11 agent legibility and in-repo truth rule\n- add GOV-12 drift control and garbage collection rule\n- add GOV-13 review loops and completion discipline rule\n- update GOV-01 rule loading order to include GOV-10..GOV-13\n- add published docs pages for GOV-10..GOV-13\n- mirror GOV-01 published load-order update\n\n## Validation\n- 
pm run build (pass)\n\n## Traceability\n- Closes #83\n