### PR TITLE
#87 Add article: Harness engineering and what VibeGov does with it

### DIFF
--- a/blog/2026-04-17-harness-engineering-what-we-do-with-it.md
+++ b/blog/2026-04-17-harness-engineering-what-we-do-with-it.md
@@ -1,0 +1,132 @@
+---
+slug: harness-engineering-what-we-do-with-it
+title: "Harness Engineering and What VibeGov Does With It"
+authors: [VibeGov_team]
+tags: [harness-engineering, agents, governance, quality, delivery]
+---
+
+Harness engineering is not mainly about making agents type faster.
+It is about making agent work **controllable, verifiable, and recoverable**.
+
+A useful harness gives you:
+- a repeatable delivery loop,
+- explicit quality gates,
+- durable state across sessions,
+- bounded work units,
+- clear failure handling,
+- and clean handoffs.
+
+If those are missing, you usually get activity instead of delivery.
+
+## What harness engineering means in practice
+
+At a practical level, harness engineering means shifting from:
+- "run a smart model and hope"
+
+to:
+- "run agent work inside a governed control system"
+
+That control system should answer:
+- what unit is being worked right now,
+- what proof is required before completion,
+- how quality is evaluated,
+- where durable state is written,
+- what happens when checks fail,
+- and what counts as truly done.
+
+## What VibeGov does with it
+
+VibeGov treats harness engineering as governance + operating behavior, not just a runtime implementation detail.
+
+### 1) Explicit workflow and bounded work units
+
+We encode the loop directly in governance:
+
+`Observe -> Plan -> Implement -> Verify -> Document`
+
+And we require explicit bounded units, ownership, intent, and evidence expectations.
+
+This prevents hidden nested orchestration and vague "it is running" status.
+
+See:
+- [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
+
+### 2) Separate quality judgment from generation pressure
+
+A key harness pattern is separating building from skeptical evaluation.
+
+VibeGov applies this through quality gates and review-loop discipline:
+- implementation is not completion,
+- evidence is required,
+- review loops must close before done claims,
+- unresolved review debt cannot be hidden under summaries.
+
+See:
+- [Published GOV 04 Quality](/docs/published/gov-04-quality)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)
+
+### 3) Durable state over transcript luck
+
+Harnesses fail when the system relies on "remembering chat context".
+
+VibeGov pushes durable in-repo truth, continuity layers, and checkpoint behavior so state survives resets, compaction, and handoff.
+
+See:
+- [Agent Continuity Bootstrap](/docs/agent-continuity-bootstrap)
+- [Published GOV 09 Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+
+### 4) Work-unit state closure and git hygiene
+
+A harness is weak if each session leaks residue into the next one.
+
+VibeGov now treats repository state as part of execution correctness:
+- every modified file must be accounted for,
+- dirty-tree state is actionable, not ambient,
+- completion claims are invalid if repository state is unexplained.
+
+See:
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+
+### 5) Drift control as continuous maintenance
+
+Agent systems accumulate entropy quickly.
+
+VibeGov treats cleanup and anti-slop behavior as a recurring control loop, not occasional heroics.
+
+See:
+- [Published GOV 12 Drift Control and Garbage Collection](/docs/published/gov-12-drift-control-garbage-collection)
+
+## Core governance vs tool-specific profiles
+
+A common mistake is to confuse harness principles with one specific toolchain.
+
+VibeGov keeps those separate:
+- **core governance** defines what good controlled execution requires,
+- **profiles/adapters** show how specific runtimes can satisfy those controls.
+
+That keeps the system portable while still allowing practical runtime guides.
+
+## What this gives teams
+
+When harness engineering is done well, teams get:
+- less babysitting,
+- better reliability under long-running/multi-session work,
+- faster recovery from failures,
+- clearer audit trail of decisions and evidence,
+- and stronger confidence that "done" means something real.
+
+That is the point.
+
+Harness engineering is not complexity for its own sake.
+It is the discipline that turns agent output into dependable delivery.
+
+## Related reading
+
+- [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
+- [Published GOV 04 Quality](/docs/published/gov-04-quality)
+- [Published GOV 09 Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 12 Drift Control and Garbage Collection](/docs/published/gov-12-drift-control-garbage-collection)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)


### PR DESCRIPTION
## Summary\n- add new blog post: 2026-04-17-harness-engineering-what-we-do-with-it.md\n- explain harness engineering in practical terms\n- explain how VibeGov applies harness principles through shipped governance controls\n- clarify core governance vs tool-specific profile separation\n- link related published GOV pages\n\n## Validation\n- 
pm run build (pass)\n\n## Traceability\n- Closes #87\n