### PR TITLE
#91 Add article: Governance from harness engineering and beyond

### DIFF
--- a/blog/2026-04-17-governance-from-harness-engineering-and-beyond.md
+++ b/blog/2026-04-17-governance-from-harness-engineering-and-beyond.md
@@ -1,0 +1,124 @@
+---
+slug: governance-from-harness-engineering-and-beyond
+title: "Governance from Harness Engineering and Beyond"
+authors: [VibeGov_team]
+tags: [governance, harness-engineering, agents, delivery, quality]
+---
+
+Harness engineering gave teams a practical breakthrough:
+stop treating agent output as magic, and start treating it as a controlled system.
+
+That shift matters.
+But harness engineering by itself is not the endpoint.
+
+To run agent-enabled delivery at scale, teams also need governance.
+
+## What harness engineering already gave us
+
+The strongest harness patterns changed the default operating model from:
+
+- prompt -> output -> hope
+
+to:
+
+- plan -> execute -> verify -> evaluate -> iterate
+
+In practical terms, that gave teams:
+- clearer loops,
+- better quality gates,
+- more durable state between sessions,
+- and faster recovery when runs fail.
+
+That is a big upgrade over ad hoc agent usage.
+
+## Why governance is the next layer
+
+Harnesses answer: "How do we run this loop?"
+
+Governance answers: "What counts as valid work, valid evidence, and valid completion across all loops, repos, and runtimes?"
+
+Without governance, good harness behavior often stays local and fragile:
+- one team runs disciplined loops,
+- another skips evidence,
+- a third claims done from partial checks,
+- and nobody can compare outcomes consistently.
+
+The result is uneven reliability.
+
+## What VibeGov adds beyond baseline harnessing
+
+VibeGov takes harness ideas and makes them explicit, portable controls.
+
+### 1) Completion semantics that are hard to fake
+
+We separate implementation activity from trustworthy completion.
+
+Completion requires evidence, traceability updates, and explicit residual risk handling.
+
+See:
+- [Published GOV 04 Quality](/docs/published/gov-04-quality)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)
+
+### 2) Repository-state closure as an execution contract
+
+A run is not complete if repository state is ambiguous.
+
+This closes one of the biggest real-world failure modes in agent work: silent residue leaking into later tasks.
+
+See:
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+
+### 3) In-repo truth over transcript dependence
+
+Durable operating knowledge must be discoverable in repository artifacts, not trapped in chat memory.
+
+See:
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 09 Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)
+
+### 4) Drift control as a first-class maintenance loop
+
+Agent systems accumulate entropy quickly.
+
+VibeGov treats cleanup and anti-slop behavior as recurring controlled work, not occasional cleanup bursts.
+
+See:
+- [Published GOV 12 Drift Control and Garbage Collection](/docs/published/gov-12-drift-control-garbage-collection)
+
+### 5) Portable governance over tool lock-in
+
+VibeGov keeps core governance tool-agnostic.
+
+Runtime-specific harnesses should be profile/adaptor layers, not the core governance definition.
+
+That allows multiple runtimes to satisfy the same governance contract.
+
+## "And beyond" means system-level reliability
+
+Beyond harness engineering means adding the controls needed for durable operations:
+- comparable evidence standards,
+- repeatable completion semantics,
+- explicit escalation and blocker handling,
+- and governance that survives model/runtime churn.
+
+The goal is not to make agent systems heavier.
+The goal is to make results more trustworthy.
+
+## Practical takeaway
+
+Harness engineering is the execution engine.
+Governance is the control plane.
+
+You need both.
+
+If harness engineering made agent work possible, governance is what makes it dependable.
+
+## Related reading
+
+- [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
+- [Published GOV 04 Quality](/docs/published/gov-04-quality)
+- [Published GOV 09 Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 12 Drift Control and Garbage Collection](/docs/published/gov-12-drift-control-garbage-collection)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)

--- a/blog/2026-04-17-governance-from-harness-engineering-and-beyond.md
+++ b/blog/2026-04-17-governance-from-harness-engineering-and-beyond.md
@@ -93,6 +93,27 @@ Runtime-specific harnesses should be profile/adaptor layers, not the core govern
 
 That allows multiple runtimes to satisfy the same governance contract.
 
+## General approach across tools
+
+The practical rule is:
+- keep core controls stable,
+- adapt runtime behavior through profiles,
+- verify outcomes against the same evidence standards.
+
+That lets teams run Claude-oriented, Codex-oriented, or mixed setups without rewriting governance every time tooling changes.
+
+## Process hardening is the point
+
+Hardening means replacing "good intentions" with explicit controls:
+- state closure rules at work-unit boundaries,
+- durable in-repo truth instead of transcript dependence,
+- recurring drift cleanup,
+- explicit review-loop completion discipline,
+- and issue-visible evidence trails.
+
+This is where many harnesses stop too early.
+A loop is useful, but a hardened loop is dependable.
+
 ## "And beyond" means system-level reliability
 
 Beyond harness engineering means adding the controls needed for durable operations:


### PR DESCRIPTION
## Summary\n- add article governance-from-harness-engineering-and-beyond\n- explain harness engineering baseline and where governance extends it\n- frame VibeGov as control-plane hardening beyond runtime harness loops\n- link relevant published GOV controls\n\n## Validation\n- 
pm run build (pass)\n\n## Traceability\n- Closes #91\n