### PR TITLE
#94 Add feedback assimilation pattern to review discipline

### DIFF
--- a/.governance/rules/gov-13-review-loops-completion-discipline.mdc
+++ b/.governance/rules/gov-13-review-loops-completion-discipline.mdc
@@ -31,16 +31,23 @@ Governed agent work should close the loop through review, evidence, and feedback
 - `GOV-13-REV-008` Responding to feedback should include updating affected evidence, docs, and traceability when those artifacts are impacted.
 - `GOV-13-REV-009` Repeated feedback themes should be considered candidates for governance or harness promotion.
 
+## Feedback Assimilation and Self-Improvement
+
+- `GOV-13-REV-010` When approved or edited feedback reveals a reusable lesson, the agent should compare the original draft with the approved or edited version and identify the concrete pattern of change.
+- `GOV-13-REV-011` That pattern should be translated into a short future rule, drafting rule, governance rule, or harness adjustment when the lesson is durable enough to matter again.
+- `GOV-13-REV-012` Material feedback lessons should be persisted to the relevant governed artifact before long posting phases, long continuation phases, or likely context-loss transitions when practical.
+- `GOV-13-REV-013` New learned rules should be checked against existing rules for contradiction, overlap, or duplication and then merged or reconciled instead of appended blindly.
+
 ## Completion Semantics
 
-- `GOV-13-REV-010` Completion claims should distinguish clearly between implemented, verified, reviewed, and released states rather than collapsing them into one vague "done".
-- `GOV-13-REV-011` A governed work unit is not complete if review, evidence, or follow-up handling is still materially open.
-- `GOV-13-REV-012` If confidence is partial, the claimed state should say so explicitly, for example blocked, partial, scoped-complete, or awaiting review.
+- `GOV-13-REV-014` Completion claims should distinguish clearly between implemented, verified, reviewed, and released states rather than collapsing them into one vague "done".
+- `GOV-13-REV-015` A governed work unit is not complete if review, evidence, or follow-up handling is still materially open.
+- `GOV-13-REV-016` If confidence is partial, the claimed state should say so explicitly, for example blocked, partial, scoped-complete, or awaiting review.
 
 ## Escalation and Stop Conditions
 
-- `GOV-13-REV-013` When repeated review/fix loops stop producing clear progress, the agent should escalate the blocker, ambiguity, or missing capability instead of performing aimless churn.
-- `GOV-13-REV-014` When judgment is required beyond the current governance and evidence, the agent should make the decision boundary visible instead of silently guessing.
+- `GOV-13-REV-017` When repeated review/fix loops stop producing clear progress, the agent should escalate the blocker, ambiguity, or missing capability instead of performing aimless churn.
+- `GOV-13-REV-018` When judgment is required beyond the current governance and evidence, the agent should make the decision boundary visible instead of silently guessing.
 
 ## Anti-Patterns
 
@@ -48,5 +55,7 @@ Avoid these failure modes:
 - equating implementation with completion
 - claiming done immediately after the first passing check
 - leaving review comments or feedback themes unincorporated without explicit state change
+- treating approved edits as one-off fixes with no learning loop when they reveal a reusable pattern
+- adding duplicate learned rules without contradiction checking
 - using a summary as a substitute for a real review loop
 - moving on while material review debt remains hidden

--- a/.governance/specs/feedback-assimilation-self-improvement.md
+++ b/.governance/specs/feedback-assimilation-self-improvement.md
@@ -1,0 +1,48 @@
+# Spec: Feedback assimilation and self-improvement loop
+
+## Goal
+
+Strengthen VibeGov review discipline so approved or edited feedback is not merely incorporated into the current output, but also mined for reusable governance or drafting rules before context-risky continuation.
+
+## Why
+
+VibeGov already says repeated feedback themes should be promoted into governance or harness controls. The missing piece is a sharper loop for when a human or reviewer directly edits or approves a draft.
+
+A stronger governed loop should:
+- compare the original draft with the approved or edited version
+- identify what changed and why that change matters
+- extract a reusable future rule from the change pattern
+- persist the rule or learning artifact before long continuation, posting, or context-risky execution
+- merge or reconcile the new rule with existing rules instead of silently duplicating or conflicting
+
+## Requirements
+
+- `FB-ASSIM-001` GOV-13 explicitly distinguishes ordinary feedback incorporation from stronger feedback assimilation/self-improvement.
+- `FB-ASSIM-002` Public docs define a feedback-assimilation pattern that compares an original draft with the approved or edited version.
+- `FB-ASSIM-003` The pattern requires identifying the concrete change pattern, not just noting that feedback occurred.
+- `FB-ASSIM-004` The pattern requires extracting a reusable future rule, drafting rule, governance rule, or harness adjustment when the feedback reveals one.
+- `FB-ASSIM-005` The pattern requires persisting the learning before long posting phases, long execution phases, or other likely context-loss/compaction transitions when practical.
+- `FB-ASSIM-006` The pattern requires contradiction/overlap checking so new rules are merged, updated, or reconciled rather than duplicated blindly.
+- `FB-ASSIM-007` Public docs explain the minimum durable outputs for a complete feedback-assimilation pass.
+- `FB-ASSIM-008` GOV-13 published docs mirror the canonical rule update.
+- `FB-ASSIM-009` Relevant public guidance links to the dedicated pattern page.
+
+## Non-goals
+
+- requiring every tiny preference change to become a permanent rule
+- prescribing one exact diffing tool or UI workflow
+- forcing all feedback assimilation to happen publicly rather than in local governed artifacts
+
+## Verification
+
+Success requires:
+- canonical and published GOV-13 wording align
+- a public feedback-assimilation pattern page exists
+- related docs link to it where useful
+- the site build passes
+
+## Notes
+
+A useful distinction:
+- **Feedback incorporation** = fix the current output in response to review.
+- **Feedback assimilation** = learn from the pattern of change so future outputs improve too.

--- a/docs/checkpoint-reporting.md
+++ b/docs/checkpoint-reporting.md
@@ -125,8 +125,11 @@ Strong reporting creates:
 - faster review,
 - cleaner governance history.
 
+When checkpoint/reporting feedback is materially edited by a human or reviewer, that can also become input to the [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern) so the system learns from the change instead of only applying it once.
+
 ## Related docs
 
 - [Execution Modes](/docs/execution-modes)
+- [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
 - [Blocker Escalation](/docs/blocker-escalation)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)

--- a/docs/feedback-assimilation-pattern.md
+++ b/docs/feedback-assimilation-pattern.md
@@ -1,0 +1,113 @@
+---
+sidebar_position: 9
+---
+
+# Feedback Assimilation Pattern
+
+Feedback incorporation fixes the current output.
+
+Feedback assimilation improves the next one too.
+
+That is the difference.
+
+## What this pattern is for
+
+Use this pattern when a human, reviewer, or stronger evaluator has approved, edited, or materially rewritten an output and you want the learning to compound instead of resetting at the end of the current loop.
+
+Typical examples:
+- a user edits a drafted comment, post, or message before publishing
+- a reviewer rewrites the framing of a rule or doc section
+- a human repeatedly removes the same kind of phrase, structure, or overreach
+- an evaluator keeps failing the same quality dimension for the same reason
+
+## Core idea
+
+A weak review loop stops at:
+- apply the correction
+- send the updated output
+- move on
+
+A stronger governed loop does one more thing:
+- compare the original draft with the approved or edited version,
+- identify the pattern of change,
+- extract the reusable rule,
+- persist it before risky continuation.
+
+## Minimum assimilation loop
+
+When the feedback is material enough to teach the system something reusable:
+
+1. **Capture the before/after**
+   - keep the original draft and the approved or edited version available for comparison.
+
+2. **Identify the change pattern**
+   - what changed?
+   - what kind of mistake or mismatch was corrected?
+   - was it tone, scope, sequencing, proof standard, verbosity, framing, assumption, or something else?
+
+3. **Extract the future rule**
+   - turn the pattern into a short reusable rule.
+   - examples:
+     - "Do not present exploratory findings without creating governed follow-up artifacts."
+     - "When the user rewrites tone to be more direct, avoid the softer framing next time in the same context."
+     - "If a user consistently removes speculative wording, prefer exact contract language over hedged summary language."
+
+4. **Persist the learning**
+   - update the relevant governed artifact before a long posting phase, long execution phase, or likely context-loss transition when practical.
+   - possible destinations include governance rules, profile docs, templates, local memory, or repo-specific operating notes.
+
+5. **Check contradiction and overlap**
+   - do not blindly append new rules.
+   - merge, refine, or reconcile with what already exists.
+
+## What counts as material feedback
+
+Not every tiny edit needs a new rule.
+
+This pattern is most useful when the change reveals:
+- a repeated failure theme
+- a stable user preference
+- a governance gap
+- a harness weakness
+- a misleading wording habit
+- a recurring structure or sequencing problem
+
+## Required durable outputs
+
+A complete feedback-assimilation pass should leave behind:
+- the identified change pattern
+- the extracted future rule or adjustment
+- the destination where it was persisted
+- any merge/reconciliation note if an existing rule was updated instead of adding a new one
+
+## Feedback incorporation vs feedback assimilation
+
+### Feedback incorporation
+- update the current artifact
+- rerun affected checks if needed
+- continue the governed loop
+
+### Feedback assimilation
+- learn from the pattern of change
+- improve the instructions, rule set, harness, or durable memory
+- reduce the odds of repeating the same mistake later
+
+Both matter.
+
+VibeGov should not confuse them.
+
+## Anti-patterns
+
+Avoid these:
+- treating user edits as one-off corrections with no learning path
+- adding duplicate rules without contradiction checking
+- waiting until after a long risky continuation to record the lesson
+- calling a lesson "learned" when it still only lives in chat history
+- promoting trivial edits into bloated permanent governance
+
+## Related docs
+
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Execution Modes](/docs/execution-modes)
+- [Harness Profile: Minimal Claude Harness](/docs/harness-profile-minimal-claude)

--- a/docs/harness-profile-minimal-claude.md
+++ b/docs/harness-profile-minimal-claude.md
@@ -69,6 +69,7 @@ When adopting this profile in a target repo:
 
 8. **Promote repeated feedback into controls**
    - convert recurring review comments into docs/rules/tests/lints.
+   - when approved edits reveal a reusable lesson, run a feedback-assimilation step so the pattern is persisted before the next long continuation.
 
 ## Minimum quality bar for this profile
 
@@ -109,6 +110,7 @@ Prefer:
 
 - [Execution Modes](/docs/execution-modes)
 - [Simplicity-First Guidance](/docs/simplicity-first)
+- [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Workflow Quality Rubric](/docs/workflow-quality-rubric)
 - [GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)

--- a/docs/published/gov-13-review-loops-completion-discipline.md
+++ b/docs/published/gov-13-review-loops-completion-discipline.md
@@ -46,18 +46,27 @@ Governed agent work should close the loop through review, evidence, and feedback
 
 > Commentary: Turns review comments into an execution loop and a governance learning loop.
 
+## Feedback Assimilation and Self-Improvement
+
+- `GOV-13-REV-010` When approved or edited feedback reveals a reusable lesson, the agent should compare the original draft with the approved or edited version and identify the concrete pattern of change.
+- `GOV-13-REV-011` That pattern should be translated into a short future rule, drafting rule, governance rule, or harness adjustment when the lesson is durable enough to matter again.
+- `GOV-13-REV-012` Material feedback lessons should be persisted to the relevant governed artifact before long posting phases, long continuation phases, or likely context-loss transitions when practical.
+- `GOV-13-REV-013` New learned rules should be checked against existing rules for contradiction, overlap, or duplication and then merged or reconciled instead of appended blindly.
+
+> Commentary: Makes review-driven learning explicit so approved edits improve the future system, not just the current artifact.
+
 ## Completion Semantics
 
-- `GOV-13-REV-010` Completion claims should distinguish clearly between implemented, verified, reviewed, and released states rather than collapsing them into one vague "done".
-- `GOV-13-REV-011` A governed work unit is not complete if review, evidence, or follow-up handling is still materially open.
-- `GOV-13-REV-012` If confidence is partial, the claimed state should say so explicitly, for example blocked, partial, scoped-complete, or awaiting review.
+- `GOV-13-REV-014` Completion claims should distinguish clearly between implemented, verified, reviewed, and released states rather than collapsing them into one vague "done".
+- `GOV-13-REV-015` A governed work unit is not complete if review, evidence, or follow-up handling is still materially open.
+- `GOV-13-REV-016` If confidence is partial, the claimed state should say so explicitly, for example blocked, partial, scoped-complete, or awaiting review.
 
 > Commentary: Improves handoff clarity and reduces false certainty in progress reporting.
 
 ## Escalation and Stop Conditions
 
-- `GOV-13-REV-013` When repeated review/fix loops stop producing clear progress, the agent should escalate the blocker, ambiguity, or missing capability instead of performing aimless churn.
-- `GOV-13-REV-014` When judgment is required beyond the current governance and evidence, the agent should make the decision boundary visible instead of silently guessing.
+- `GOV-13-REV-017` When repeated review/fix loops stop producing clear progress, the agent should escalate the blocker, ambiguity, or missing capability instead of performing aimless churn.
+- `GOV-13-REV-018` When judgment is required beyond the current governance and evidence, the agent should make the decision boundary visible instead of silently guessing.
 
 > Commentary: Prevents endless churn loops and forces explicit escalation boundaries.
 
@@ -67,6 +76,8 @@ Avoid these failure modes:
 - equating implementation with completion
 - claiming done immediately after the first passing check
 - leaving review comments or feedback themes unincorporated without explicit state change
+- treating approved edits as one-off fixes with no learning loop when they reveal a reusable pattern
+- adding duplicate learned rules without contradiction checking
 - using a summary as a substitute for a real review loop
 - moving on while material review debt remains hidden
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -42,6 +42,7 @@ const sidebars = {
         'quick-decisions',
         'simplicity-first',
         'output-quality-and-anti-slop',
+        'feedback-assimilation-pattern',
         'harness-profile-minimal-claude',
         'harness-profile-codex',
         'exploratory-review-mode',


### PR DESCRIPTION
## Summary
- add a dedicated Feedback Assimilation Pattern doc
- strengthen GOV-13 with explicit self-improvement / approved-edit learning rules
- link the pattern from checkpoint reporting and the minimal harness profile

## Validation
- npm run build

Closes #94