### PR TITLE
#97 Make VibeGov simplicity-first guidance more explicit

### DIFF
--- a/docs/harness-profile-minimal-claude.md
+++ b/docs/harness-profile-minimal-claude.md
@@ -8,6 +8,8 @@ This profile integrates a minimal generator/evaluator harness pattern into VibeG
 
 Use this when you want autonomous multi-session delivery with explicit quality gates and durable state, while still keeping VibeGov portable.
 
+It should be adopted with a simplicity-first bias: do not add harness layers faster than the real failure modes justify.
+
 ## Why this is a profile, not the core runtime
 
 VibeGov governs behavior and evidence standards across tools.
@@ -93,9 +95,20 @@ Avoid these when implementing the profile:
 - Strengthen enforcement before adding orchestration complexity.
 - Reassess complexity each model/runtime upgrade and remove stale scaffolding.
 
+## Simplicity-first reminder
+
+This profile is a way to apply VibeGov controls, not a requirement to start with a heavy harness.
+
+Prefer:
+- the smallest coherent loop first,
+- one responsible worker before many,
+- stronger verification/evaluation before added coordination,
+- and removal of stale scaffolding when simpler paths become good enough.
+
 ## Related docs
 
 - [Execution Modes](/docs/execution-modes)
+- [Simplicity-First Guidance](/docs/simplicity-first)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Workflow Quality Rubric](/docs/workflow-quality-rubric)
 - [GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -65,6 +65,7 @@ Canonical-source model:
 
 - [The VibeGov SDLC](/docs/vibegov-sdlc)
 - [VibeGov Quick Decisions](/docs/quick-decisions)
+- [Simplicity-First Guidance](/docs/simplicity-first)
 - [Execution Modes](/docs/execution-modes)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)

--- a/docs/simplicity-first.md
+++ b/docs/simplicity-first.md
@@ -1,0 +1,92 @@
+---
+sidebar_position: 8
+---
+
+# Simplicity-First Guidance
+
+VibeGov is not anti-agent.
+
+It is anti-unearned complexity.
+
+The default progression should be:
+- workflow before agent
+- single owner before multi-agent
+- explicit evaluation before extra orchestration
+- simple loop before layered harness
+- proven need before permanent complexity
+
+## Why this matters
+
+AI teams often add complexity too early.
+
+They introduce:
+- multi-agent splits before the task is even clear
+- evaluator loops before the acceptance contract exists
+- memory systems before the basic workflow is stable
+- orchestration layers before a single-owner loop has been made reliable
+
+That usually creates more movement, not more control.
+
+## The progression VibeGov prefers
+
+### 1. Start with the smallest coherent workflow
+Use a simple sequence first when the work can be handled as a bounded direct flow.
+
+Examples:
+- observe -> plan -> implement -> verify -> document
+- review -> classify -> create artifacts -> move on
+- build -> verify -> package -> release-check
+
+### 2. Add an agent only when the workflow benefits from it
+Use an agent when there is meaningful reasoning, adaptation, or tool-driven work to perform, not just because an agent sounds more advanced.
+
+### 3. Stay single-owner as long as possible
+A single responsible worker is easier to supervise, easier to evaluate, and easier to close cleanly.
+
+Single-owner work should remain the default until there is a demonstrated need for bounded delegation.
+
+### 4. Add delegation only for a real boundary
+Good reasons to delegate:
+- a clearly separable work unit
+- a distinct competency or tool boundary
+- a bounded parallel slice that still has visible supervision
+
+Bad reasons to delegate:
+- hiding uncertainty
+- avoiding direct ownership
+- creating the appearance of sophistication
+- compensating for weak issue/spec clarity
+
+### 5. Add evaluator loops before adding orchestration sprawl
+If quality is the problem, the next useful control is often a better verifier or evaluator contract, not a bigger worker graph.
+
+### 6. Remove stale scaffolding when it stops earning its keep
+Model and process improvements should simplify the system where possible.
+
+A control that used to be necessary but no longer adds enough value becomes governance debt.
+
+## Fast decision table
+
+| Situation | Default |
+| --- | --- |
+| task is clear and bounded | simple workflow |
+| one worker can do it | single owner |
+| quality is weak but scope is still bounded | strengthen evaluation / verification |
+| work crosses a real boundary | delegate carefully |
+| complexity was added for past limitations that no longer apply | simplify |
+
+## Anti-patterns
+
+Avoid these:
+- adding orchestration before proving the simple loop works
+- turning delegation into a substitute for supervision
+- treating multi-agent as the default sign of maturity
+- adding memory, evaluation, and coordination layers all at once
+- preserving complexity after the original reason for it has disappeared
+
+## Related docs
+
+- [Execution Modes](/docs/execution-modes)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Harness Profile: Minimal Claude Harness](/docs/harness-profile-minimal-claude)
+- [Published GOV 02 Workflow](/docs/published/gov-02-workflow)

--- a/docs/vibegov-sdlc.md
+++ b/docs/vibegov-sdlc.md
@@ -6,6 +6,8 @@ sidebar_position: 4
 
 VibeGov is a governed SDLC for AI-assisted software delivery. It starts by shaping intent before coding, binds work to issues and specs, forces explicit mode selection between Development and Exploration, requires evidence before completion claims, keeps blockers visible, treats delegation as supervised orchestration instead of fire-and-forget, and feeds discoveries back into backlog, specs, traceability, and release decisions so the system keeps getting more reliable instead of more confusing.
 
+Its default posture is also simplicity-first: use the smallest coherent workflow that can do the job, keep ownership singular as long as possible, and add orchestration only when the need is real and visible.
+
 ## Lifecycle flow
 
 ```text
@@ -93,10 +95,25 @@ If you want the shortest possible version:
 
 > Bootstrap governance, turn requests into issue/spec-bound work, choose Development or Exploration explicitly, execute one bounded unit at a time, require evidence, report honestly, feed findings back into backlog/specs/traceability, and repeat.
 
+## Why simplicity-first matters too
+
+VibeGov is not trying to maximize visible complexity.
+
+It is trying to maximize governed throughput and honest control.
+
+That means the default progression should be:
+- workflow before agent
+- single owner before multi-agent
+- evaluation and verification before orchestration sprawl
+- proven need before permanent complexity
+
+When teams skip that progression, they often create systems that look advanced but are harder to supervise, harder to close, and easier to misunderstand.
+
 ## Related docs
 
 - [VibeGov](/docs/intro)
 - [Bootstrap](/docs/bootstrap)
 - [Execution Modes](/docs/execution-modes)
+- [Simplicity-First Guidance](/docs/simplicity-first)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [GOV 02 Workflow](/docs/published/gov-02-workflow)

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,6 +39,7 @@ const sidebars = {
       items: [
         'execution-modes',
         'quick-decisions',
+        'simplicity-first',
         'harness-profile-minimal-claude',
         'harness-profile-codex',
         'exploratory-review-mode',


### PR DESCRIPTION
## Summary
- add a dedicated public Simplicity-First Guidance page
- reinforce the simplicity-first progression in the SDLC and minimal harness docs
- link the new guidance from intro and docs navigation

## Validation
- npm run build

Closes #97