### PR TITLE
#99 Improve onboarding with a clearer start-here path

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -63,6 +63,7 @@ Canonical-source model:
 
 ## Best next reads
 
+- [Start Here](/docs/start-here)
 - [The VibeGov SDLC](/docs/vibegov-sdlc)
 - [Execution Modes](/docs/execution-modes)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,6 +6,8 @@ sidebar_position: 3
 
 Use this to install VibeGov quickly with the hardened bootstrap contract.
 
+If you are not sure whether Quick Start is the right entry point yet, read [Start Here](/docs/start-here) first.
+
 Bootstrap now uses one canonical contract with explicit modes:
 - `init`
 - `update`

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 2
+---
+
+# Start Here
+
+If you are new to VibeGov, start here.
+
+This page is the shortest path to the smallest useful adoption step.
+
+## First: what are you trying to do?
+
+### 1. I want the fastest explanation of what VibeGov is
+Read:
+- [VibeGov](/docs/intro)
+- [The VibeGov SDLC](/docs/vibegov-sdlc)
+
+### 2. I want to install or bootstrap VibeGov in a repo
+Read:
+- [Quick Start](/docs/quickstart)
+- [Bootstrap](/docs/bootstrap)
+
+### 3. I want to understand how work is supposed to run
+Read:
+- [Execution Modes](/docs/execution-modes)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Blocker Escalation](/docs/blocker-escalation)
+
+### 4. I want the shortest practical operating guide
+Read:
+- [Execution Modes](/docs/execution-modes)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+
+### 5. I want to understand the deeper governance model
+Read:
+- [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)
+
+## The smallest useful adoption path
+
+If you only want the minimum useful path, do this:
+
+1. read [VibeGov](/docs/intro)
+2. read [Execution Modes](/docs/execution-modes)
+3. read [Checkpoint Reporting](/docs/checkpoint-reporting)
+4. run [Quick Start](/docs/quickstart) when you are ready to bootstrap a repo
+
+That is enough to understand the basic shape:
+- choose the right mode
+- keep evidence honest
+- report clearly
+- bootstrap governance before trying to scale the workflow
+
+## What VibeGov is not
+
+VibeGov is not:
+- a magical agent runtime
+- a provider-specific tool wrapper
+- a replacement for engineering judgment
+- a license to add process everywhere
+
+It is a governance layer that helps teams run AI-assisted delivery more legibly and more reliably.
+
+## If you are still unsure
+
+Use this shortcut:
+
+- if you want **orientation**, start with [VibeGov](/docs/intro)
+- if you want **action**, start with [Quick Start](/docs/quickstart)
+- if you want **operator clarity**, start with [Execution Modes](/docs/execution-modes)
+- if you want **deeper doctrine**, start with [The VibeGov SDLC](/docs/vibegov-sdlc)
+
+## Related docs
+
+- [VibeGov](/docs/intro)
+- [Quick Start](/docs/quickstart)
+- [Execution Modes](/docs/execution-modes)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [The VibeGov SDLC](/docs/vibegov-sdlc)

--- a/sidebars.js
+++ b/sidebars.js
@@ -15,6 +15,7 @@
 const sidebars = {
   docsSidebar: [
     'intro',
+    'start-here',
     'bootstrap',
     'bootstrap-update',
     'quickstart',


### PR DESCRIPTION
## Summary
- add a public Start Here page for smallest-useful-adoption guidance
- link it from intro, quickstart, and docs navigation
- keep onboarding aligned with current canonical docs instead of a parallel beginner model

## Validation
- npm run build

Closes #99