### PR TITLE
#93 clarify exploration vs evaluation

### DIFF
--- a/.governance/specs/exploration-and-evaluation-clarity.md
+++ b/.governance/specs/exploration-and-evaluation-clarity.md
@@ -1,0 +1,20 @@
+# Spec: exploration and evaluation clarity
+
+## Summary
+Clarify how VibeGov distinguishes Exploration from Evaluation so teams do not confuse backlog-hydration discovery with bounded skeptical judgment.
+
+## Intent
+Keep the operating model coherent: two primary modes, Development and Exploration, with Evaluation used as a bounded control pattern inside a mode rather than as a third peer mode.
+
+## Requirements
+- `EXP-EVAL-001` add a dedicated public doc for the evaluation pattern.
+- `EXP-EVAL-002` explain that Evaluation is criteria-based bounded judgment, not backlog-hydration discovery.
+- `EXP-EVAL-003` explain that Exploration remains a primary operating mode for surface discovery and artifact creation.
+- `EXP-EVAL-004` update public operating docs so the relationship between Exploration, Development, Evaluation, and release verification is explicit.
+- `EXP-EVAL-005` update harness profile docs so generator/evaluator patterns are clearly framed as controls inside the broader VibeGov operating model.
+- `EXP-EVAL-006` preserve the two-primary-mode model rather than introducing Evaluation as a third peer mode.
+
+## Done when
+- `docs/evaluation-pattern.md` exists
+- related docs link to it and explain the distinction clearly
+- `npm run build` passes

--- a/docs/evaluation-pattern.md
+++ b/docs/evaluation-pattern.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 10
+---
+
+# Evaluation Pattern
+
+Evaluation is a real VibeGov control, but it is **not** a third peer operating mode.
+
+Use it when you need a bounded judgment against explicit criteria.
+
+## What evaluation is
+
+Evaluation is the pattern for asking:
+
+- did this bounded output meet the stated criteria?
+- what is the verdict?
+- what evidence supports that verdict?
+- what fails, and why?
+
+Typical evaluation use-cases:
+- score a draft against explicit writing criteria
+- judge whether a route/report/checkpoint satisfies a rubric
+- run a skeptical reviewer pass over a bounded implementation result
+- decide whether a validator output passes a known contract
+
+## What evaluation is not
+
+Evaluation is **not**:
+- broad discovery across a surface
+- backlog hydration by route/page/workflow review
+- a substitute for Development evidence after changing behavior
+- a free-floating excuse to say "reviewed" without a contract
+
+Fast rule:
+- **Exploration** asks, "what is true across this surface?"
+- **Evaluation** asks, "did this bounded thing pass the criteria?"
+
+## Where evaluation fits in the model
+
+VibeGov has two primary operating modes:
+- **Exploration** for discovery
+- **Development** for changing behavior and carrying it safely toward release
+
+Evaluation fits **inside** one of those modes when bounded judgment is useful.
+
+Examples:
+- in **Exploration**, an evaluator may judge whether a route report is artifact-complete
+- in **Development**, an evaluator may judge whether an implementation result meets quality criteria
+- in **release verification**, an evaluator may help apply go/no-go criteria to a candidate inside Development
+
+That makes evaluation a **control pattern**, not a separate top-level lane.
+
+## Evaluation requires an explicit contract
+
+A real evaluation pass should define:
+
+- **unit under judgment**: the exact bounded thing being judged
+- **criteria**: what counts as pass/fail/score
+- **evidence input**: what artifacts, tests, screenshots, diffs, or reports are being judged
+- **verdict shape**: pass/fail/score plus rationale
+- **failure consequences**: retry, fix, block, or escalate
+
+Without that contract, "evaluation" usually collapses into vibes or vague commentary.
+
+## Minimum evaluation output
+
+A useful evaluation result should include:
+- the unit judged
+- the criteria or rubric used
+- the verdict
+- the supporting evidence inspected
+- the key failure reasons, if any
+- the required next action
+
+## Evaluation vs Exploration
+
+| Question | Exploration | Evaluation |
+| --- | --- | --- |
+| primary goal | discover reality and hydrate backlog | judge a bounded unit against explicit criteria |
+| normal scope | wider surface, route, workflow, or feature area | one bounded artifact, report, build, draft, or result |
+| normal output | findings, classifications, issues, spec gaps, residual scope | verdict, criteria result, failure reasons, next action |
+| completion signal | reviewed scope is classified and findings are artifact-linked | explicit verdict is produced against defined criteria |
+| common failure | reporting findings without artifacts | declaring pass/fail without a real contract |
+
+## Evaluation vs Release Verification
+
+Release verification is a Development-shaped activity focused on integrated readiness.
+
+Evaluation can be used **inside** release verification, but release verification itself is broader because it also cares about:
+- build/version identity
+- integrated environment checks
+- deployment state
+- promotion or rollback decision
+
+So:
+- evaluation may help judge part of release readiness
+- release verification is still the broader Development closure activity
+
+## Common anti-patterns
+
+Avoid these:
+- calling surface exploration an evaluation just because a reviewer was involved
+- calling a vague opinion an evaluation when no criteria were defined
+- treating evaluator commentary as a replacement for implementation proof
+- using evaluation language to hide unclear ownership or unclear completion state
+- promoting every review pass into a separate mode instead of keeping the model coherent
+
+## Fast selection rule
+
+Ask:
+
+1. Am I discovering across a surface? → **Exploration**
+2. Am I changing behavior? → **Development**
+3. Inside that mode, do I need a bounded judgment against explicit criteria? → **Evaluation pattern**
+
+## Related docs
+
+- [Execution Modes](/docs/execution-modes)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Exploratory Review Mode](/docs/exploratory-review-mode)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Harness Profile: Minimal Claude Harness](/docs/harness-profile-minimal-claude)
+- [Harness Profile: Codex](/docs/harness-profile-codex)

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -56,6 +56,20 @@ What not to do:
 - collapse multiple unrelated findings into one vague change
 - claim done without proof
 
+## Evaluation lives inside a mode
+
+Evaluation is not a third peer mode either. It is a bounded judgment pattern used inside Exploration or Development when explicit criteria-based review is needed.
+
+Typical evaluation work includes:
+- judging a bounded artifact against a rubric
+- running a skeptical reviewer pass over a scoped result
+- deciding whether a report, draft, or validator result satisfies an explicit contract
+
+What evaluation does **not** mean:
+- replacing Exploration when the goal is surface discovery
+- replacing Development evidence when behavior changed
+- creating a vague "reviewed" state with no criteria or verdict
+
 ## Release verification lives inside Development
 
 Release verification is not a third peer mode. It is part of Development's delivery path.
@@ -73,6 +87,7 @@ Typical release-verification work includes:
 Without explicit mode selection, teams produce confusing status:
 
 - exploratory notes presented as development proof
+- evaluation language used where no real criteria/verdict exists
 - development updates without enough evidence
 - release confidence claimed from isolated ticket checks instead of encoded delivery gates
 
@@ -107,6 +122,7 @@ That answer should determine the mode.
 
 - [Quick Decisions](/docs/quick-decisions)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Evaluation Pattern](/docs/evaluation-pattern)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Blocker Escalation](/docs/blocker-escalation)

--- a/docs/harness-profile-codex.md
+++ b/docs/harness-profile-codex.md
@@ -28,6 +28,7 @@ A Codex harness loop should explicitly provide:
 
 3. **Evaluator contract**
    - separate skeptical evaluation path with explicit pass/fail output.
+   - treat that evaluator path as a bounded control inside the active Development or Exploration flow, not as a third top-level mode.
 
 4. **State artifacts**
    - durable plan/progress/evidence artifacts in repo.
@@ -92,6 +93,7 @@ This Codex profile is an adapter layer that helps teams implement the same gover
 ## Related docs
 
 - [Execution Modes](/docs/execution-modes)
+- [Evaluation Pattern](/docs/evaluation-pattern)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
 - [Published GOV 05 Testing](/docs/published/gov-05-testing)

--- a/docs/harness-profile-minimal-claude.md
+++ b/docs/harness-profile-minimal-claude.md
@@ -54,6 +54,7 @@ When adopting this profile in a target repo:
 
 3. **Define evaluator contract**
    - ensure evaluator role is separate from generator role and has explicit verdict schema.
+   - keep the evaluator framed as a bounded control inside the current Development or Exploration flow, not as a separate peer operating mode.
 
 4. **Define state model**
    - set plan/task/progress artifacts and enforce append/update rules mechanically where possible.
@@ -109,6 +110,7 @@ Prefer:
 ## Related docs
 
 - [Execution Modes](/docs/execution-modes)
+- [Evaluation Pattern](/docs/evaluation-pattern)
 - [Simplicity-First Guidance](/docs/simplicity-first)
 - [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -70,6 +70,7 @@ Canonical-source model:
 - [Simplicity-First Guidance](/docs/simplicity-first)
 - [Output Quality and Anti-Slop Guidance](/docs/output-quality-and-anti-slop)
 - [Execution Modes](/docs/execution-modes)
+- [Evaluation Pattern](/docs/evaluation-pattern)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Blocker Escalation](/docs/blocker-escalation)

--- a/docs/mode-selection-and-evidence-closing.md
+++ b/docs/mode-selection-and-evidence-closing.md
@@ -137,6 +137,7 @@ If the answers are blurry, the mode is probably blurry too.
 
 - [Quick Decisions](/docs/quick-decisions)
 - [Execution Modes](/docs/execution-modes)
+- [Evaluation Pattern](/docs/evaluation-pattern)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
 - [The VibeGov SDLC](/docs/vibegov-sdlc)

--- a/docs/quick-decisions.md
+++ b/docs/quick-decisions.md
@@ -124,6 +124,7 @@ Fast rule:
 
 - [Execution Modes](/docs/execution-modes)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Evaluation Pattern](/docs/evaluation-pattern)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Blocker Escalation](/docs/blocker-escalation)

--- a/sidebars.js
+++ b/sidebars.js
@@ -44,6 +44,7 @@ const sidebars = {
         'simplicity-first',
         'output-quality-and-anti-slop',
         'feedback-assimilation-pattern',
+        'evaluation-pattern',
         'harness-profile-minimal-claude',
         'harness-profile-codex',
         'exploratory-review-mode',


### PR DESCRIPTION
## Summary\n- add a dedicated evaluation-pattern guide\n- clarify how evaluation fits inside Exploration or Development rather than as a third peer mode\n- update execution/mode docs and harness profiles to use the same framing\n\n## Validation\n- npm run build\n\nCloses #93