### PR TITLE
#110 package agent-consumable releases

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build release artifact
-        run: npm run release:build
+      - name: Build docs site
+        run: npm run build
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Create VibeGov GitHub release
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Optional git ref to release (defaults to the current default branch ref)
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Compute release version
+        id: version
+        run: echo "version=$(node scripts/print-release-version.js)" >> "$GITHUB_OUTPUT"
+
+      - name: Build release bundle
+        run: npm run release:build
+
+      - name: Create git tag if missing
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists"
+          else
+            git tag "$VERSION"
+            git push origin "$VERSION"
+          fi
+
+      - name: Publish GitHub release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ASSET="artifacts/release/$VERSION/vibegov-$VERSION.zip"
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            gh release upload "$VERSION" "$ASSET" --clobber
+          else
+            gh release create "$VERSION" "$ASSET" --title "$VERSION" --generate-notes
+          fi

--- a/.governance/specs/agent-consumable-release-packaging.md
+++ b/.governance/specs/agent-consumable-release-packaging.md
@@ -1,0 +1,23 @@
+# Spec: agent-consumable release packaging
+
+## Summary
+Define the VibeGov GitHub release boundary around the main files agents actually use, and automate packaging + GitHub release publication with canonical versioning.
+
+## Intent
+Release the real VibeGov consumable surface rather than the built docs site. Keep Pages deployment as a separate concern.
+
+## Requirements
+- `REL-PKG-001` GitHub release packaging must target the agent-consumable VibeGov surface rather than the Docusaurus build output.
+- `REL-PKG-002` Canonical release version format is `yyyy.m.d-<shortsha>`.
+- `REL-PKG-003` The release bundle must include `agent.txt` and `bootstrap.json` from the canonical static sources.
+- `REL-PKG-004` The release bundle must include canonical `.governance/rules/`.
+- `REL-PKG-005` The release bundle must include the canonical bootstrap/use docs that define the real install/use path.
+- `REL-PKG-006` GitHub Pages deploy automation remains separate from GitHub release packaging.
+- `REL-PKG-007` The repo provides a local packaging script that creates the versioned release bundle.
+- `REL-PKG-008` The repo provides a GitHub Actions workflow that creates a GitHub release and uploads the packaged bundle.
+- `REL-PKG-009` Release metadata included in the bundle must stay minimal and directly useful to consumers.
+
+## Done when
+- local release packaging produces the versioned agent-consumable bundle
+- GitHub release automation publishes that bundle using the canonical version
+- Pages deployment still uses the docs-site build path rather than the release bundle path

--- a/docs/release-artifact-and-test-prep.md
+++ b/docs/release-artifact-and-test-prep.md
@@ -4,67 +4,106 @@ sidebar_position: 10
 
 # Release Artifact and Test Prep
 
-VibeGov now uses two linked scripts for release validation:
+VibeGov now separates two concerns clearly:
 
-1. **build the release artifact**
-2. **prepare a governed test-run folder from that artifact**
+1. **GitHub Pages deployment** builds the docs site
+2. **GitHub release packaging** bundles the main VibeGov files agents actually use
 
-The goal is simple: the candidate you test locally should come from the same build path used by CI, and the test run should start with enough context to be trustworthy and repeatable.
+The release bundle is not the built static site.
+It is the agent-consumable VibeGov surface.
 
-## Scripts
+## Release packaging
 
-### Build release artifact
+### Build release bundle
 
 ```bash
 npm run release:build
 ```
 
-This script:
-- runs the site build
-- packages the built artifact under `artifacts/release/<short-sha>/artifact/`
-- generates `artifact-manifest.json`
-- generates `checksums.txt`
+This script creates a versioned release bundle using the canonical format:
 
-### Prepare test run
+```text
+yyyy.m.d-<shortsha>
+```
+
+Example:
+
+```text
+2026.4.19-55b47ec
+```
+
+### What the release bundle contains
+
+The bundle is intentionally narrow.
+It includes the main files agents/runtime actually use:
+
+- `agent.txt`
+- `bootstrap.json`
+- canonical `.governance/rules/`
+- canonical bootstrap/use docs:
+  - `docs/bootstrap.md`
+  - `docs/quickstart.md`
+  - `docs/bootstrap-update.md`
+  - `docs/bootstrap-review.md`
+  - `docs/bootstrap-feedback-prompt.md`
+  - `docs/github-project-bootstrap.md`
+  - `docs/init-todo.md`
+- `VERSION.txt`
+
+### Release output
+
+```text
+artifacts/
+  release/
+    <version>/
+      vibegov-<version>/
+        agent.txt
+        bootstrap.json
+        .governance/
+          rules/
+        docs/
+          bootstrap.md
+          quickstart.md
+          bootstrap-update.md
+          bootstrap-review.md
+          bootstrap-feedback-prompt.md
+          github-project-bootstrap.md
+          init-todo.md
+        VERSION.txt
+      vibegov-<version>.zip
+      release-info.json
+```
+
+Notes:
+- `vibegov-<version>.zip` is the GitHub release asset.
+- `release-info.json` is local build metadata used by automation.
+- the Docusaurus `build/` output is for Pages deployment, not the GitHub release asset.
+
+## Test prep
+
+### Prepare a release test run
 
 ```bash
 npm run test:prepare
 ```
 
 This script:
-- locates the latest release artifact (or accepts an explicit one)
+- locates the latest packaged release bundle
 - creates a timestamp + SHA folder under `artifacts/test-runs/`
-- copies the release artifact into that folder
-- copies governance references and checklists
-- creates result/log/screenshot placeholders for the run
+- copies the release folder and zip asset into the test run
+- creates execution/evidence scaffolding for validating the release contents
 
-## Output structure
-
-### Release artifact output
-
-```text
-artifacts/
-  release/
-    <short-sha>/
-      artifact/
-      artifact-manifest.json
-      checksums.txt
-```
-
-### Test run output
+### Test-run output
 
 ```text
 artifacts/
   test-runs/
     <timestamp>_<short-sha>/
-      artifact/
-      governance/
-        artifact-manifest.json
-        checksums.txt
-        specs/
-        test-execution-expectations.md
-        quality-scaffolding-and-completeness-rubric.md
-        change-summary.md
+      release/
+        vibegov-<version>/
+        vibegov-<version>.zip
+        release-info.json
+      change-summary.md
       evidence/
         prior-validation/
           validation-summary.md
@@ -76,31 +115,17 @@ artifacts/
       run-manifest.json
 ```
 
-## What gets copied into the test folder
-
-The prepared folder copies:
-- the built release artifact
-- artifact identity metadata
-- checksums
-- `.governance/specs/`
-- testing expectations reference
-- quality/completeness rubric reference
-- a test execution checklist template
-- prior validation summary placeholder
-- empty result/log/screenshot folders
-
-This gives the test runner four immediate answers:
-1. what exact candidate is being tested
-2. what it is supposed to do
-3. what governance/testing context applies
-4. where to record the test run
-
 ## CI alignment
 
-The GitHub Pages workflow should call the same release-artifact build script rather than duplicating build logic. That keeps local and CI candidates aligned.
+- **Pages deploy** should run `npm run build` and publish the built docs site.
+- **GitHub release** should run `npm run release:build` and upload the versioned VibeGov bundle zip.
+
+Do not treat those as the same artifact boundary.
 
 ## Related docs
 
 - [Bootstrap](/docs/bootstrap)
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)
+- [INIT-TODO.md](/docs/init-todo)
 - [Test Execution Expectations](/docs/test-execution-expectations)
 - [Quality Scaffolding and Completeness Rubric](/docs/quality-scaffolding-and-completeness-rubric)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "docusaurus start --host localhost",
     "start:3005": "docusaurus start --host localhost --port 3005",
     "build": "docusaurus build",
+    "release:version": "node scripts/print-release-version.js",
     "release:build": "node scripts/build-release-artifact.js",
     "test:prepare": "node scripts/prepare-test-run.js",
     "serve:test": "docusaurus serve --host localhost --port 3000",

--- a/scripts/build-release-artifact.js
+++ b/scripts/build-release-artifact.js
@@ -1,34 +1,17 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const crypto = require('crypto');
 const cp = require('child_process');
+const {
+  REPO_ROOT,
+  RELEASE_FILE_MAP,
+  RELEASE_TIMEZONE,
+  SOURCE_REPO,
+  getGitMetadata,
+  getReleaseVersion,
+} = require('./release-utils');
 
-const repoRoot = path.resolve(__dirname, '..');
-const buildDir = path.join(repoRoot, 'build');
-const artifactsRoot = path.join(repoRoot, 'artifacts', 'release');
-
-function run(command, args, options = {}) {
-  cp.execFileSync(command, args, {
-    cwd: repoRoot,
-    stdio: 'inherit',
-    shell: process.platform === 'win32',
-    ...options,
-  });
-}
-
-function capture(command, args, fallback = '') {
-  try {
-    return cp.execFileSync(command, args, {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: process.platform === 'win32',
-    }).trim();
-  } catch {
-    return fallback;
-  }
-}
+const artifactsRoot = path.join(REPO_ROOT, 'artifacts', 'release');
 
 function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
@@ -40,82 +23,102 @@ function removeDir(dir) {
   }
 }
 
-function copyDir(src, dest) {
-  ensureDir(dest);
-  fs.cpSync(src, dest, { recursive: true, force: true });
-}
+function copyEntry(sourceRelative, targetRelative, bundleDir) {
+  const sourcePath = path.join(REPO_ROOT, sourceRelative);
+  const targetPath = path.join(bundleDir, targetRelative);
 
-function sha256File(filePath) {
-  const hash = crypto.createHash('sha256');
-  hash.update(fs.readFileSync(filePath));
-  return hash.digest('hex');
-}
-
-function walkFiles(dir, baseDir = dir) {
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  const files = [];
-  for (const entry of entries) {
-    const fullPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      files.push(...walkFiles(fullPath, baseDir));
-    } else {
-      files.push({
-        fullPath,
-        relativePath: path.relative(baseDir, fullPath).replace(/\\/g, '/'),
-      });
-    }
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Missing release source: ${sourceRelative}`);
   }
-  return files;
+
+  ensureDir(path.dirname(targetPath));
+  fs.cpSync(sourcePath, targetPath, { recursive: true, force: true });
 }
 
-function checksumDirectory(dir) {
-  return walkFiles(dir).map(({ fullPath, relativePath }) => ({
-    path: relativePath,
-    sha256: sha256File(fullPath),
-    bytes: fs.statSync(fullPath).size,
-  }));
+function createZip(bundleDir, zipPath) {
+  if (fs.existsSync(zipPath)) {
+    fs.rmSync(zipPath, { force: true });
+  }
+
+  if (process.platform === 'win32') {
+    cp.execFileSync(
+      'pwsh',
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-Command',
+        `Compress-Archive -Path '${bundleDir.replace(/'/g, "''")}\\*' -DestinationPath '${zipPath.replace(/'/g, "''")}' -Force`,
+      ],
+      { cwd: REPO_ROOT, stdio: 'inherit' }
+    );
+    return;
+  }
+
+  const pythonZip = [
+    'import os, sys, zipfile',
+    'bundle_dir = sys.argv[1]',
+    'zip_path = sys.argv[2]',
+    'root_name = os.path.basename(bundle_dir)',
+    'with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:',
+    '    for current_root, _, files in os.walk(bundle_dir):',
+    '        for file_name in files:',
+    '            full_path = os.path.join(current_root, file_name)',
+    '            rel_path = os.path.relpath(full_path, os.path.dirname(bundle_dir))',
+    '            zf.write(full_path, rel_path)',
+  ].join('; ');
+
+  cp.execFileSync('python3', ['-c', pythonZip, bundleDir, zipPath], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
 }
 
 function main() {
-  const commitSha = capture('git', ['rev-parse', 'HEAD'], 'unknown');
-  const shortSha = capture('git', ['rev-parse', '--short', 'HEAD'], 'unknown');
-  const branch = capture('git', ['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown');
-  const timestamp = new Date().toISOString();
+  const version = getReleaseVersion();
+  const { commitSha, shortSha, branch } = getGitMetadata();
+  const createdAt = new Date().toISOString();
+  const releaseDir = path.join(artifactsRoot, version);
+  const bundleName = `vibegov-${version}`;
+  const bundleDir = path.join(releaseDir, bundleName);
+  const zipPath = path.join(releaseDir, `${bundleName}.zip`);
 
-  run('npm', ['run', 'build']);
+  removeDir(releaseDir);
+  ensureDir(bundleDir);
 
-  if (!fs.existsSync(buildDir)) {
-    throw new Error('Expected build/ directory was not produced by npm run build.');
+  for (const entry of RELEASE_FILE_MAP) {
+    copyEntry(entry.source, entry.target, bundleDir);
   }
 
-  const releaseDir = path.join(artifactsRoot, shortSha);
-  const artifactDir = path.join(releaseDir, 'artifact');
-  removeDir(releaseDir);
-  ensureDir(releaseDir);
-  copyDir(buildDir, artifactDir);
+  const versionFile = [
+    `version=${version}`,
+    `commit=${commitSha}`,
+    `shortSha=${shortSha}`,
+    `branch=${branch}`,
+    `sourceRepo=${SOURCE_REPO}`,
+    `createdAt=${createdAt}`,
+    `timeZone=${RELEASE_TIMEZONE}`,
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(bundleDir, 'VERSION.txt'), versionFile);
 
-  const checksums = checksumDirectory(artifactDir);
-  const manifest = {
-    kind: 'vibegov-release-artifact',
-    createdAt: timestamp,
-    sourceRepo: 'governance-foundation/vibegov.io',
+  const releaseInfo = {
+    kind: 'vibegov-agent-release',
+    version,
+    bundleName,
+    bundleDir,
+    zipPath,
+    createdAt,
     branch,
     commitSha,
     shortSha,
-    buildCommand: 'npm run build',
-    artifactRoot: 'artifact',
-    artifactType: 'docusaurus-static-site',
-    artifactFileCount: checksums.length,
-    artifactFiles: checksums,
+    sourceRepo: SOURCE_REPO,
+    includedPaths: RELEASE_FILE_MAP.map((entry) => entry.target.replace(/\\/g, '/')).concat('VERSION.txt'),
   };
+  fs.writeFileSync(path.join(releaseDir, 'release-info.json'), JSON.stringify(releaseInfo, null, 2));
 
-  fs.writeFileSync(path.join(releaseDir, 'artifact-manifest.json'), JSON.stringify(manifest, null, 2));
-  fs.writeFileSync(
-    path.join(releaseDir, 'checksums.txt'),
-    checksums.map((item) => `${item.sha256}  artifact/${item.path}`).join('\n') + '\n'
-  );
+  createZip(bundleDir, zipPath);
 
-  console.log(`Release artifact created: ${releaseDir}`);
+  console.log(`Created VibeGov release bundle: ${zipPath}`);
 }
 
 main();

--- a/scripts/prepare-test-run.js
+++ b/scripts/prepare-test-run.js
@@ -1,24 +1,10 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const cp = require('child_process');
+const { REPO_ROOT } = require('./release-utils');
 
-const repoRoot = path.resolve(__dirname, '..');
-const releaseRoot = path.join(repoRoot, 'artifacts', 'release');
-const testRoot = path.join(repoRoot, 'artifacts', 'test-runs');
-
-function capture(command, args, fallback = '') {
-  try {
-    return cp.execFileSync(command, args, {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: process.platform === 'win32',
-    }).trim();
-  } catch {
-    return fallback;
-  }
-}
+const releaseRoot = path.join(REPO_ROOT, 'artifacts', 'release');
+const testRoot = path.join(REPO_ROOT, 'artifacts', 'test-runs');
 
 function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
@@ -51,60 +37,55 @@ function latestReleaseDir() {
 }
 
 function main() {
-  const releaseDir = process.argv[2] ? path.resolve(repoRoot, process.argv[2]) : latestReleaseDir();
-  const manifestPath = path.join(releaseDir, 'artifact-manifest.json');
+  const releaseDir = process.argv[2] ? path.resolve(REPO_ROOT, process.argv[2]) : latestReleaseDir();
+  const releaseInfoPath = path.join(releaseDir, 'release-info.json');
 
-  if (!fs.existsSync(manifestPath)) {
-    throw new Error(`Missing artifact-manifest.json in release dir: ${releaseDir}`);
+  if (!fs.existsSync(releaseInfoPath)) {
+    throw new Error(`Missing release-info.json in release dir: ${releaseDir}`);
   }
 
-  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const releaseInfo = JSON.parse(fs.readFileSync(releaseInfoPath, 'utf8'));
   const ts = new Date().toISOString().replace(/[:]/g, '-').replace(/\..+$/, '');
-  const runDirName = `${ts}_${manifest.shortSha}`;
+  const runDirName = `${ts}_${releaseInfo.shortSha}`;
   const runDir = path.join(testRoot, runDirName);
 
-  ensureDir(runDir);
-  ensureDir(path.join(runDir, 'artifact'));
-  ensureDir(path.join(runDir, 'governance', 'specs'));
+  ensureDir(path.join(runDir, 'release'));
   ensureDir(path.join(runDir, 'evidence', 'prior-validation'));
   ensureDir(path.join(runDir, 'execution', 'results'));
   ensureDir(path.join(runDir, 'execution', 'logs'));
   ensureDir(path.join(runDir, 'execution', 'screenshots'));
 
-  copyIfExists(path.join(releaseDir, 'artifact'), path.join(runDir, 'artifact'));
-  copyIfExists(path.join(releaseDir, 'artifact-manifest.json'), path.join(runDir, 'governance', 'artifact-manifest.json'));
-  copyIfExists(path.join(releaseDir, 'checksums.txt'), path.join(runDir, 'governance', 'checksums.txt'));
-  copyIfExists(path.join(repoRoot, '.governance', 'specs'), path.join(runDir, 'governance', 'specs'));
-  copyIfExists(path.join(repoRoot, 'docs', 'test-execution-expectations.md'), path.join(runDir, 'governance', 'test-execution-expectations.md'));
-  copyIfExists(path.join(repoRoot, 'docs', 'quality-scaffolding-and-completeness-rubric.md'), path.join(runDir, 'governance', 'quality-scaffolding-and-completeness-rubric.md'));
+  copyIfExists(path.join(releaseDir, releaseInfo.bundleName), path.join(runDir, 'release', releaseInfo.bundleName));
+  copyIfExists(releaseInfo.zipPath, path.join(runDir, 'release', path.basename(releaseInfo.zipPath)));
+  copyIfExists(releaseInfoPath, path.join(runDir, 'release', 'release-info.json'));
 
-  const issueSummary = [
-    '# Test Run Summary',
+  const changeSummary = [
+    '# Release Test Run Summary',
     '',
-    `- Source repo: governance-foundation/vibegov.io`,
-    `- Commit SHA: ${manifest.commitSha}`,
-    `- Short SHA: ${manifest.shortSha}`,
-    `- Branch: ${manifest.branch}`,
-    `- Release artifact source: ${releaseDir}`,
+    `- Source repo: ${releaseInfo.sourceRepo}`,
+    `- Version: ${releaseInfo.version}`,
+    `- Commit SHA: ${releaseInfo.commitSha}`,
+    `- Short SHA: ${releaseInfo.shortSha}`,
+    `- Branch: ${releaseInfo.branch}`,
+    `- Release bundle source: ${releaseInfo.zipPath}`,
     '',
     '## Testing focus',
-    '- Verify the candidate against the intended change set and relevant governance/spec expectations.',
-    '- Record verified, invalidated, blocked, deferred, and not-applicable results explicitly.',
-    '- Convert missing completeness into tracked follow-up work instead of leaving it invisible.',
+    '- Verify that the packaged agent-consumable files are present and readable.',
+    '- Verify that the release bundle matches the intended VibeGov bootstrap/governance surface.',
+    '- Record any missing, stale, or contradictory release contents as tracked follow-up work.',
     '',
   ].join('\n');
 
   const checklist = [
-    '# Test Execution Checklist',
+    '# Release Test Execution Checklist',
     '',
-    '- Claim under test:',
-    '- Requirement / acceptance criterion:',
-    '- Scenario classes exercised:',
-    '- Scenario classes blocked / deferred / not applicable:',
-    '- Evidence type:',
+    '- Version under test:',
+    '- Expected release files present:',
+    '- bootstrap entrypoints readable:',
+    '- governance rules included:',
+    '- bootstrap docs included:',
+    '- Missing or stale files:',
     '- Result classification (Verified / Invalidated / Blocked / Deferred / Not applicable):',
-    '- Proof strength (direct / partial / surrogate-only):',
-    '- Persistence / post-action checks:',
     '- Residual risks / unverified items:',
     '- Follow-up artifact(s) created:',
     '',
@@ -113,21 +94,21 @@ function main() {
   const validationSummary = [
     '# Prior Validation Summary',
     '',
-    `- Build command: ${manifest.buildCommand}`,
-    '- Copy any existing test/build/bootstrap validation evidence into this folder if you want it bundled with the run.',
+    '- Copy any existing validation/build/release evidence into this folder if you want it bundled with the run.',
     '',
   ].join('\n');
 
-  fs.writeFileSync(path.join(runDir, 'governance', 'change-summary.md'), issueSummary);
+  fs.writeFileSync(path.join(runDir, 'change-summary.md'), changeSummary);
   fs.writeFileSync(path.join(runDir, 'evidence', 'prior-validation', 'validation-summary.md'), validationSummary);
   fs.writeFileSync(path.join(runDir, 'execution', 'test-execution-checklist.md'), checklist);
 
   const metadata = {
-    kind: 'vibegov-test-run',
+    kind: 'vibegov-release-test-run',
     createdAt: new Date().toISOString(),
-    commitSha: manifest.commitSha,
-    shortSha: manifest.shortSha,
-    branch: manifest.branch,
+    version: releaseInfo.version,
+    commitSha: releaseInfo.commitSha,
+    shortSha: releaseInfo.shortSha,
+    branch: releaseInfo.branch,
     releaseDir,
     runDir,
   };

--- a/scripts/print-release-version.js
+++ b/scripts/print-release-version.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+const { getReleaseVersion } = require('./release-utils');
+
+console.log(getReleaseVersion());

--- a/scripts/release-utils.js
+++ b/scripts/release-utils.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+const cp = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const RELEASE_TIMEZONE = process.env.RELEASE_TIMEZONE || 'Australia/Sydney';
+const SOURCE_REPO = 'governance-foundation/vibegov.io';
+
+const RELEASE_FILE_MAP = [
+  { source: path.join('static', 'agent.txt'), target: 'agent.txt' },
+  { source: path.join('static', 'bootstrap.json'), target: 'bootstrap.json' },
+  { source: path.join('.governance', 'rules'), target: path.join('.governance', 'rules') },
+  { source: path.join('docs', 'bootstrap.md'), target: path.join('docs', 'bootstrap.md') },
+  { source: path.join('docs', 'quickstart.md'), target: path.join('docs', 'quickstart.md') },
+  { source: path.join('docs', 'bootstrap-update.md'), target: path.join('docs', 'bootstrap-update.md') },
+  { source: path.join('docs', 'bootstrap-review.md'), target: path.join('docs', 'bootstrap-review.md') },
+  { source: path.join('docs', 'bootstrap-feedback-prompt.md'), target: path.join('docs', 'bootstrap-feedback-prompt.md') },
+  { source: path.join('docs', 'github-project-bootstrap.md'), target: path.join('docs', 'github-project-bootstrap.md') },
+  { source: path.join('docs', 'init-todo.md'), target: path.join('docs', 'init-todo.md') },
+];
+
+function capture(command, args, fallback = '') {
+  try {
+    return cp.execFileSync(command, args, {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      shell: process.platform === 'win32',
+    }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+function getReleaseDateParts(date = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-AU', {
+    timeZone: RELEASE_TIMEZONE,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  }).formatToParts(date);
+
+  const lookup = Object.fromEntries(parts.filter((part) => part.type !== 'literal').map((part) => [part.type, part.value]));
+  return {
+    year: lookup.year,
+    month: String(Number(lookup.month)),
+    day: String(Number(lookup.day)),
+  };
+}
+
+function getGitMetadata() {
+  return {
+    commitSha: capture('git', ['rev-parse', 'HEAD'], 'unknown'),
+    shortSha: capture('git', ['rev-parse', '--short', 'HEAD'], 'unknown'),
+    branch: capture('git', ['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown'),
+  };
+}
+
+function getReleaseVersion(date = new Date()) {
+  const { year, month, day } = getReleaseDateParts(date);
+  const { shortSha } = getGitMetadata();
+  return `${year}.${month}.${day}-${shortSha}`;
+}
+
+module.exports = {
+  REPO_ROOT,
+  RELEASE_FILE_MAP,
+  RELEASE_TIMEZONE,
+  SOURCE_REPO,
+  capture,
+  getGitMetadata,
+  getReleaseDateParts,
+  getReleaseVersion,
+};


### PR DESCRIPTION
## Summary
- replace static-site-oriented release packaging with an agent-consumable VibeGov bundle
- add canonical yyyy.m.d-<shortsha> release version computation and GitHub release automation
- keep Pages deployment on the docs-site build path and update release/test-prep docs accordingly

## Validation
- npm run release:version
- npm run release:build
- npm run test:prepare
- npm run build

Closes #110