### PR TITLE
#112 publish flat release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,15 @@ jobs:
             git push origin "$VERSION"
           fi
 
-      - name: Publish GitHub release asset
+      - name: Publish GitHub release assets
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          ASSET="artifacts/release/$VERSION/vibegov-$VERSION.zip"
+          ZIP_ASSET="artifacts/release/$VERSION/vibegov-$VERSION.zip"
+          FLAT_DIR="artifacts/release/$VERSION/flat"
           if gh release view "$VERSION" >/dev/null 2>&1; then
-            gh release upload "$VERSION" "$ASSET" --clobber
+            gh release upload "$VERSION" "$ZIP_ASSET" "$FLAT_DIR"/* --clobber
           else
-            gh release create "$VERSION" "$ASSET" --title "$VERSION" --generate-notes
+            gh release create "$VERSION" "$ZIP_ASSET" "$FLAT_DIR"/* --title "$VERSION" --generate-notes
           fi

--- a/docs/release-artifact-and-test-prep.md
+++ b/docs/release-artifact-and-test-prep.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 VibeGov now separates two concerns clearly:
 
 1. **GitHub Pages deployment** builds the docs site
-2. **GitHub release packaging** bundles the main VibeGov files agents actually use
+2. **GitHub release packaging** prepares the main VibeGov files agents actually use
 
 The release bundle is not the built static site.
 It is the agent-consumable VibeGov surface.
@@ -20,7 +20,7 @@ It is the agent-consumable VibeGov surface.
 npm run release:build
 ```
 
-This script creates a versioned release bundle using the canonical format:
+This script creates a versioned release package using the canonical format:
 
 ```text
 yyyy.m.d-<shortsha>
@@ -32,9 +32,9 @@ Example:
 2026.4.19-55b47ec
 ```
 
-### What the release bundle contains
+### What the release package contains
 
-The bundle is intentionally narrow.
+The package is intentionally narrow.
 It includes the main files agents/runtime actually use:
 
 - `agent.txt`
@@ -70,14 +70,39 @@ artifacts/
           github-project-bootstrap.md
           init-todo.md
         VERSION.txt
+      flat/
+        agent.txt
+        bootstrap.json
+        gov-01-instructions.mdc
+        ...
+        gov-13-review-loops-completion-discipline.mdc
+        bootstrap.md
+        quickstart.md
+        bootstrap-update.md
+        bootstrap-review.md
+        bootstrap-feedback-prompt.md
+        github-project-bootstrap.md
+        init-todo.md
+        VERSION.txt
       vibegov-<version>.zip
       release-info.json
 ```
 
 Notes:
-- `vibegov-<version>.zip` is the GitHub release asset.
+- `vibegov-<version>.zip` remains available as a convenience bundle.
+- `flat/` contains the upload-ready individual GitHub release assets.
 - `release-info.json` is local build metadata used by automation.
-- the Docusaurus `build/` output is for Pages deployment, not the GitHub release asset.
+- the Docusaurus `build/` output is for Pages deployment, not the GitHub release assets.
+
+## GitHub release behavior
+
+The release workflow now uploads **both**:
+- the zip bundle
+- the flat individual files as separate release assets
+
+That means agents can either:
+- fetch the exact files directly from the release, or
+- download the zip bundle if that is easier for transport.
 
 ## Test prep
 
@@ -118,7 +143,7 @@ artifacts/
 ## CI alignment
 
 - **Pages deploy** should run `npm run build` and publish the built docs site.
-- **GitHub release** should run `npm run release:build` and upload the versioned VibeGov bundle zip.
+- **GitHub release** should run `npm run release:build` and upload both the versioned zip and flat VibeGov files.
 
 Do not treat those as the same artifact boundary.
 

--- a/scripts/build-release-artifact.js
+++ b/scripts/build-release-artifact.js
@@ -23,9 +23,9 @@ function removeDir(dir) {
   }
 }
 
-function copyEntry(sourceRelative, targetRelative, bundleDir) {
+function copyEntry(sourceRelative, targetRelative, destinationRoot) {
   const sourcePath = path.join(REPO_ROOT, sourceRelative);
-  const targetPath = path.join(bundleDir, targetRelative);
+  const targetPath = path.join(destinationRoot, targetRelative);
 
   if (!fs.existsSync(sourcePath)) {
     throw new Error(`Missing release source: ${sourceRelative}`);
@@ -58,7 +58,6 @@ function createZip(bundleDir, zipPath) {
     'import os, sys, zipfile',
     'bundle_dir = sys.argv[1]',
     'zip_path = sys.argv[2]',
-    'root_name = os.path.basename(bundle_dir)',
     'with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:',
     '    for current_root, _, files in os.walk(bundle_dir):',
     '        for file_name in files:',
@@ -73,6 +72,59 @@ function createZip(bundleDir, zipPath) {
   });
 }
 
+function walkFiles(dir, baseDir = dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(fullPath, baseDir));
+    } else {
+      files.push({
+        fullPath,
+        relativePath: path.relative(baseDir, fullPath).replace(/\\/g, '/'),
+      });
+    }
+  }
+  return files;
+}
+
+function flattenAssetName(targetPath, fileRelativePath = '') {
+  const normalizedTarget = targetPath.replace(/\\/g, '/');
+  if (normalizedTarget === 'agent.txt' || normalizedTarget === 'bootstrap.json') return normalizedTarget;
+  if (normalizedTarget === '.governance/rules') return path.posix.basename(fileRelativePath);
+  if (normalizedTarget.startsWith('docs/')) return path.posix.basename(normalizedTarget);
+  return normalizedTarget.replace(/[\\/]/g, '-');
+}
+
+function writeFlatAssets(flatDir) {
+  const seen = new Set();
+
+  for (const entry of RELEASE_FILE_MAP) {
+    const sourcePath = path.join(REPO_ROOT, entry.source);
+    const stat = fs.statSync(sourcePath);
+
+    if (stat.isDirectory()) {
+      for (const file of walkFiles(sourcePath)) {
+        const flatName = flattenAssetName(entry.target, file.relativePath);
+        if (seen.has(flatName)) {
+          throw new Error(`Duplicate flat asset name generated: ${flatName}`);
+        }
+        seen.add(flatName);
+        fs.copyFileSync(file.fullPath, path.join(flatDir, flatName));
+      }
+      continue;
+    }
+
+    const flatName = flattenAssetName(entry.target);
+    if (seen.has(flatName)) {
+      throw new Error(`Duplicate flat asset name generated: ${flatName}`);
+    }
+    seen.add(flatName);
+    fs.copyFileSync(sourcePath, path.join(flatDir, flatName));
+  }
+}
+
 function main() {
   const version = getReleaseVersion();
   const { commitSha, shortSha, branch } = getGitMetadata();
@@ -80,14 +132,18 @@ function main() {
   const releaseDir = path.join(artifactsRoot, version);
   const bundleName = `vibegov-${version}`;
   const bundleDir = path.join(releaseDir, bundleName);
+  const flatDir = path.join(releaseDir, 'flat');
   const zipPath = path.join(releaseDir, `${bundleName}.zip`);
 
   removeDir(releaseDir);
   ensureDir(bundleDir);
+  ensureDir(flatDir);
 
   for (const entry of RELEASE_FILE_MAP) {
     copyEntry(entry.source, entry.target, bundleDir);
   }
+
+  writeFlatAssets(flatDir);
 
   const versionFile = [
     `version=${version}`,
@@ -99,13 +155,18 @@ function main() {
     `timeZone=${RELEASE_TIMEZONE}`,
     '',
   ].join('\n');
+
   fs.writeFileSync(path.join(bundleDir, 'VERSION.txt'), versionFile);
+  fs.writeFileSync(path.join(flatDir, 'VERSION.txt'), versionFile);
+
+  const flatAssets = fs.readdirSync(flatDir).sort();
 
   const releaseInfo = {
     kind: 'vibegov-agent-release',
     version,
     bundleName,
     bundleDir,
+    flatDir,
     zipPath,
     createdAt,
     branch,
@@ -113,12 +174,14 @@ function main() {
     shortSha,
     sourceRepo: SOURCE_REPO,
     includedPaths: RELEASE_FILE_MAP.map((entry) => entry.target.replace(/\\/g, '/')).concat('VERSION.txt'),
+    flatAssets,
   };
   fs.writeFileSync(path.join(releaseDir, 'release-info.json'), JSON.stringify(releaseInfo, null, 2));
 
   createZip(bundleDir, zipPath);
 
   console.log(`Created VibeGov release bundle: ${zipPath}`);
+  console.log(`Prepared flat release assets: ${flatDir}`);
 }
 
 main();


### PR DESCRIPTION
## Summary\n- update release packaging to emit real flat individual release assets alongside the zip bundle\n- update the GitHub release workflow to upload both the flat files and the zip\n- update the release packaging doc to describe the new release output shape\n\n## Validation\n- npm run release:build\n- npm run build\n\nCloses #112