### PR TITLE
#114 Formalize preserve-before-destructive change

### DIFF
--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -52,6 +52,7 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-004C` Hotfix branches must be created from `main` only.
 - `GOV-02-GIT-004D` Any stacked-branch exception requires explicit human approval, a bounded reason, and an explicit reconciliation plan.
 - `GOV-02-GIT-005` Every agent-authored non-hotfix change must use a pull request into `develop` that links the governing issue/spec and records verification evidence.
+- `GOV-02-GIT-005A` Branch cleanup, retirement, deletion, or archival must not substitute for landing the intended result. A governed work branch should only be retired once the desired preserved outcome is safely landed through the repository's governed flow, or the retained state has been deliberately preserved elsewhere with an explicit follow-up path.
 - `GOV-02-GIT-006` Promotion from `develop` to `main` must be explicit and reviewable. Release or promotion pull requests should state what is being promoted and what release-readiness evidence supports the move.
 - `GOV-02-GIT-007` Hotfix work must branch from `main`, merge back to `main` through an explicit hotfix pull request, and then be back-merged or otherwise reconciled into `develop` immediately so the branches do not drift.
 - `GOV-02-GIT-008` Repositories adopting VibeGov should document branch protection expectations for `main` and `develop`, including required pull requests, review gates, status checks, and restricted direct pushes.

--- a/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
+++ b/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
@@ -39,17 +39,29 @@ Governed repositories should treat repository state as a control surface for age
 - `GOV-10-GIT-014` Generated or environment-specific noise that should persist locally but not be tracked must be handled through explicit ignore rules rather than repeated manual omission.
 - `GOV-10-GIT-015` Ignore rules should be as narrow as practical so legitimate changes are not accidentally hidden.
 
+## Preserve Before Destructive Change
+
+- `GOV-10-GIT-016` Meaningful state includes kept code, docs, specs, notes, captured investigation output, and generated artifacts that are intentionally being preserved as evidence or deliverable state.
+- `GOV-10-GIT-017` Disposable cache, build output, or other reproducible noise is not meaningful state unless the current work unit explicitly depends on it as evidence or deliverable content.
+- `GOV-10-GIT-018` Before deleting, overwriting, archiving, or otherwise destructively changing meaningful state, the agent should preserve that state in a traceable form when safe to do so, normally through a commit or another durable governed artifact.
+- `GOV-10-GIT-019` If material is secret, unsafe, or otherwise inappropriate to preserve in normal history, the agent should use a separate safe-handling path and record the exception explicitly instead of silently discarding context.
+- `GOV-10-GIT-020` Cleanup, rollback, and archival actions must not silently erase why a change existed, what was learned, or what state is being retired.
+- `GOV-10-GIT-021` If old behavior or prior content needs to return, it should come back through a new traceable change rather than hidden history surgery or convenience-driven destructive rollback.
+- `GOV-10-GIT-022` This preservation rule does not require noisy micro-commits for trivial or disposable edits, but it does require a deliberate preservation boundary before meaningful destructive change.
+
 ## Completion and Handoff Rules
 
-- `GOV-10-GIT-016` Completion claims are invalid if the repository state that remains is unexplained.
-- `GOV-10-GIT-017` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
-- `GOV-10-GIT-018` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
+- `GOV-10-GIT-023` Completion claims are invalid if the repository state that remains is unexplained.
+- `GOV-10-GIT-024` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
+- `GOV-10-GIT-025` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
 
 ## Anti-Patterns
 
 Avoid these failure modes:
 - letting partial experiments silently roll into later commits
+- deleting or overwriting meaningful state before it has a traceable preservation boundary
 - treating untracked temp files as harmless background clutter
 - leaving generated noise unignored across repeated runs
 - carrying mixed unrelated diffs across work units
 - using dirty state as a substitute for real tracking
+- using cleanup, archival, or rollback to erase rationale instead of preserving it

--- a/.governance/specs/preserve-before-destructive-change-and-forward-only-closure.md
+++ b/.governance/specs/preserve-before-destructive-change-and-forward-only-closure.md
@@ -1,0 +1,53 @@
+# Spec: preserve-before-destructive change and forward-only closure
+
+## Intent
+Make preservation-before-destruction and forward-only closure explicit in VibeGov so agents do not erase meaningful state while cleaning up, deleting, archiving, or reconciling branches.
+
+## Scope
+In scope:
+- `PBDC-001` tighten `GOV-10` so meaningful state is preserved before destructive changes
+- `PBDC-002` tighten `GOV-10` so secrets/unsafe-to-preserve material and disposable generated noise are explicit exceptions
+- `PBDC-003` tighten `GOV-02` so branch archival/retirement happens only after the desired result is safely landed
+- `PBDC-004` describe forward-only recovery and no-silent-revert behavior in the canonical/public rule text
+- `PBDC-005` update at least one practical public guide so the rule is easy to apply during real work
+
+Out of scope:
+- changing CI or release pipelines
+- imposing one universal branch model beyond the existing workflow rule
+- preserving secrets or unsafe material in git history
+- turning disposable generated output into a keep-by-default artifact
+
+## Acceptance Criteria
+- `PBDC-001` `GOV-10` explicitly distinguishes meaningful state from disposable/generated noise.
+- `PBDC-002` `GOV-10` explicitly requires preserving meaningful state in history before deletion, overwrite, archival move, or other destructive change when safe to do so.
+- `PBDC-003` `GOV-10` explicitly says cleanup/rollback must not silently erase why a change existed.
+- `PBDC-004` `GOV-10` explicitly frames recovery as forward-only and traceable when old behavior/code needs to return.
+- `PBDC-005` `GOV-02` explicitly says a governed work branch should be retired or archived only after the intended result is safely landed through the governed flow.
+- `PBDC-006` Published governance mirror pages reflect the same rule updates.
+- `PBDC-007` A practical public guide or operational doc translates the rule into fast decision guidance.
+- `PBDC-008` `npm run build` succeeds after the documentation changes.
+
+## Tests and Evidence
+- inspect `.governance/specs/preserve-before-destructive-change-and-forward-only-closure.md`
+- inspect `.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc`
+- inspect `.governance/rules/gov-02-workflow.mdc`
+- inspect `docs/published/gov-10-agent-state-closure-git-hygiene.md`
+- inspect `docs/published/gov-02-workflow.md`
+- inspect `docs/quick-decisions.md`
+- run `npm run build`
+
+## Documentation Impact
+- add `.governance/specs/preserve-before-destructive-change-and-forward-only-closure.md`
+- update `.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc`
+- update `.governance/rules/gov-02-workflow.mdc`
+- update `docs/published/gov-10-agent-state-closure-git-hygiene.md`
+- update `docs/published/gov-02-workflow.md`
+- update `docs/quick-decisions.md`
+
+## Verification
+Verification is documentation-driven. Success requires the canonical rules, published mirrors, and practical guide text to align on the same preserve-before-destructive and forward-only closure semantics, plus a successful site build.
+
+## Change Notes
+- Keep the rule focused on preserving meaningful state and traceability, not on forcing noisy micro-commits.
+- Preserve the distinction between safe preservation and content that should be scrubbed, rotated, or handled outside normal history.
+- Prefer extending the existing Git hygiene/workflow rules instead of inventing an unnecessary new rule file.

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -77,6 +77,7 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-004C` Hotfix branches must be created from `main` only.
 - `GOV-02-GIT-004D` Any stacked-branch exception requires explicit human approval, a bounded reason, and an explicit reconciliation plan.
 - `GOV-02-GIT-005` Every agent-authored non-hotfix change must use a pull request into `develop` that links the governing issue/spec and records verification evidence.
+- `GOV-02-GIT-005A` Branch cleanup, retirement, deletion, or archival must not substitute for landing the intended result. A governed work branch should only be retired once the desired preserved outcome is safely landed through the repository's governed flow, or the retained state has been deliberately preserved elsewhere with an explicit follow-up path.
 - `GOV-02-GIT-006` Promotion from `develop` to `main` must be explicit and reviewable. Release or promotion pull requests should state what is being promoted and what release-readiness evidence supports the move.
 - `GOV-02-GIT-007` Hotfix work must branch from `main`, merge back to `main` through an explicit hotfix pull request, and then be back-merged or otherwise reconciled into `develop` immediately so the branches do not drift.
 - `GOV-02-GIT-008` Repositories adopting VibeGov should document branch protection expectations for `main` and `develop`, including required pull requests, review gates, status checks, and restricted direct pushes.

--- a/docs/published/gov-10-agent-state-closure-git-hygiene.md
+++ b/docs/published/gov-10-agent-state-closure-git-hygiene.md
@@ -56,11 +56,23 @@ Governed repositories should treat repository state as a control surface for age
 
 > Commentary: Keeps git history meaningful while preventing recurring local noise from leaking across work units.
 
+## Preserve Before Destructive Change
+
+- `GOV-10-GIT-016` Meaningful state includes kept code, docs, specs, notes, captured investigation output, and generated artifacts that are intentionally being preserved as evidence or deliverable state.
+- `GOV-10-GIT-017` Disposable cache, build output, or other reproducible noise is not meaningful state unless the current work unit explicitly depends on it as evidence or deliverable content.
+- `GOV-10-GIT-018` Before deleting, overwriting, archiving, or otherwise destructively changing meaningful state, the agent should preserve that state in a traceable form when safe to do so, normally through a commit or another durable governed artifact.
+- `GOV-10-GIT-019` If material is secret, unsafe, or otherwise inappropriate to preserve in normal history, the agent should use a separate safe-handling path and record the exception explicitly instead of silently discarding context.
+- `GOV-10-GIT-020` Cleanup, rollback, and archival actions must not silently erase why a change existed, what was learned, or what state is being retired.
+- `GOV-10-GIT-021` If old behavior or prior content needs to return, it should come back through a new traceable change rather than hidden history surgery or convenience-driven destructive rollback.
+- `GOV-10-GIT-022` This preservation rule does not require noisy micro-commits for trivial or disposable edits, but it does require a deliberate preservation boundary before meaningful destructive change.
+
+> Commentary: Makes destructive actions reviewable and recoverable by requiring preservation before erasure, while keeping safe exceptions and disposable noise separate.
+
 ## Completion and Handoff Rules
 
-- `GOV-10-GIT-016` Completion claims are invalid if the repository state that remains is unexplained.
-- `GOV-10-GIT-017` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
-- `GOV-10-GIT-018` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
+- `GOV-10-GIT-023` Completion claims are invalid if the repository state that remains is unexplained.
+- `GOV-10-GIT-024` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
+- `GOV-10-GIT-025` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
 
 > Commentary: Extends state-closure discipline beyond successful completion into blockers, deferrals, and handoffs.
 
@@ -68,9 +80,11 @@ Governed repositories should treat repository state as a control surface for age
 
 Avoid these failure modes:
 - letting partial experiments silently roll into later commits
+- deleting or overwriting meaningful state before it has a traceable preservation boundary
 - treating untracked temp files as harmless background clutter
 - leaving generated noise unignored across repeated runs
 - carrying mixed unrelated diffs across work units
 - using dirty state as a substitute for real tracking
+- using cleanup, archival, or rollback to erase rationale instead of preserving it
 
 > Commentary: Names the residue patterns this rule is designed to eliminate.

--- a/docs/quick-decisions.md
+++ b/docs/quick-decisions.md
@@ -90,7 +90,22 @@ You still need:
 | **Release verification** | build/version reviewed, integrated results, known blockers/risks, go/no-go style decision |
 | **Blocker checkpoint** | exact blocker, attempted actions, confidence limits, blocker artifact, redirected next work |
 
-## 8. Should this become a rule, or just a note?
+## 8. Before I delete, archive, or clean up, what should I do?
+
+| Situation | Default choice |
+| --- | --- |
+| the state is meaningful and may need to be understood later | **preserve it first in a traceable form** |
+| it is disposable generated noise or reproducible cache | **clean it up directly** |
+| it contains secrets or unsafe material | **use a separate safe-handling path, do not casually commit it** |
+| you want old behavior back | **bring it back in a new traceable change** |
+| you are about to archive/retire a work branch | **land the intended result first, or preserve the retained state with explicit follow-up** |
+
+Fast rule:
+- preserve before destructive change when the state matters
+- cleanup should not erase rationale
+- archive after safe landing, not instead of it
+
+## 9. Should this become a rule, or just a note?
 
 | If the learning is... | Put it in... |
 | --- | --- |
@@ -102,7 +117,7 @@ Fast rule:
 - not every lesson deserves a rule
 - repeated durable failures usually do
 
-## 9. What are the most common failure modes?
+## 10. What are the most common failure modes?
 
 - exploratory findings with no artifacts
 - development claims with no direct proof
@@ -110,6 +125,8 @@ Fast rule:
 - delegating without supervision or closure
 - blocker claims with no blocker artifact
 - treating chat memory as durable state
+- deleting meaningful state before preserving it
+- archiving a branch as a substitute for landing traceable work
 - promoting every tiny preference into bloated governance
 
 ## Start here if you are unsure


### PR DESCRIPTION
## Summary
- add a focused spec for preserve-before-destructive change and forward-only closure
- tighten GOV-10 around meaningful-state preservation, safe exceptions, and forward-only recovery
- tighten GOV-02 so branch retirement/archive cannot substitute for safely landing the intended result
- update the published governance mirrors and quick-decisions guide to match

## Validation
- PASS `npm run build`

## Issue
- Closes #114
