### PR TITLE
#116 Restructure bootstrap reporting layout

### DIFF
--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -70,7 +70,9 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-020` Bootstrap must ensure repository linkage to the canonical board before claiming completion.
 - `GOV-02-GIT-021` GitHub built-in `Status` should be normalized in place when needed; bootstrap should not assume replacement via create/delete flows.
 - `GOV-02-GIT-022` If the repository has no issues, board setup may still be complete, but bootstrap must report the board as intentionally empty.
-- `GOV-02-GIT-023` Bootstrap must emit durable local run-history artifacts under a timestamped path such as `.governance/project/bootstrap-runs/<timestamp>-status.md` and `.governance/project/bootstrap-runs/<timestamp>-feedback.md` even when commit mode forbids committing.
+- `GOV-02-GIT-023` Bootstrap must emit durable local reporting artifacts even when commit mode forbids committing.
+- `GOV-02-GIT-023A` Current bootstrap reporting should live under `.governance/project/bootstrap/` using files such as `STATUS.md`, `ANALYSIS.md`, `FEEDBACK.md`, and optional `BLOCKERS.md`.
+- `GOV-02-GIT-023B` Historical bootstrap evidence should live under per-run bundle paths such as `.governance/project/bootstrap/history/<timestamp>/status.md`, `analysis.md`, `feedback.md`, and optional `blockers.md`.
 - `GOV-02-GIT-024` Bootstrap is incomplete until generated docs/artifacts are reconciled against final live git/GitHub state after any auth refresh, board mutation, or cleanup action.
 
 This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.

--- a/.governance/specs/bootstrap-reporting-current-vs-history.md
+++ b/.governance/specs/bootstrap-reporting-current-vs-history.md
@@ -1,0 +1,69 @@
+# Bootstrap Reporting: Current Surface and Historical Run Bundles
+
+## Intent
+Make bootstrap reporting look like intentional reporting instead of a flat pile of singleton files and timestamped leftovers. Bootstrap should clearly separate current reporting from historical run bundles so BU/BI/BR outputs are legible, durable, and easier to settle without manual interpretation.
+
+## Scope
+In scope:
+- `BOOT-REP-001` define a dedicated current bootstrap reporting surface
+- `BOOT-REP-002` define a dedicated historical bootstrap reporting surface
+- `BOOT-REP-003` use one folder per historical run bundle instead of only flat timestamped filenames
+- `BOOT-REP-004` describe what artifacts belong in the current surface vs history
+- `BOOT-REP-005` describe migration guidance from the older flat layout
+- `BOOT-REP-006` tighten BU wording around settled reporting artifacts and end-state classification
+- `BOOT-REP-007` update public docs, machine-readable sources, and governed workflow wording to match
+
+Out of scope:
+- a mandatory automatic pruning/retention engine
+- non-bootstrap reporting structures
+- binary report packaging
+- changing core GitHub board/bootstrap semantics beyond reporting layout and settled artifact guidance
+
+## Acceptance Criteria
+- `BOOT-REP-001` Canonical bootstrap docs define `.governance/project/bootstrap/` as the current reporting surface.
+- `BOOT-REP-002` Canonical bootstrap docs define `.governance/project/bootstrap/history/<timestamp>/` as the historical run-bundle surface.
+- `BOOT-REP-003` Expected current artifacts are documented as `STATUS.md`, `ANALYSIS.md`, `FEEDBACK.md`, and optional `BLOCKERS.md` under `.governance/project/bootstrap/`.
+- `BOOT-REP-004` Expected per-run historical artifacts are documented as `status.md`, `analysis.md`, `feedback.md`, and optional `blockers.md` under `.governance/project/bootstrap/history/<timestamp>/`.
+- `BOOT-REP-005` Migration guidance exists for repos still using flat `BOOTSTRAP_*` and `bootstrap-runs/<timestamp>-*.md` layouts.
+- `BOOT-REP-006` BU wording makes current-vs-history reporting and settled end-state behavior easier to understand.
+- `BOOT-REP-007` Machine-readable bootstrap sources reflect the same reporting structure.
+- `BOOT-REP-008` Governed workflow wording still requires durable bootstrap reporting artifacts and matches the new structure.
+- `BOOT-REP-009` `npm run build` succeeds after the doc/rule/spec changes.
+
+## Tests and Evidence
+- inspect `static/agent.txt`
+- inspect `static/bootstrap.json`
+- inspect `docs/bootstrap.md`
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/bootstrap-review.md`
+- inspect `docs/bootstrap-feedback-prompt.md`
+- inspect `docs/quickstart.md`
+- inspect `docs/contribute.md`
+- inspect `docs/faq/when-do-i-use-the-feedback-prompt.md`
+- inspect `docs/agents-template.md`
+- inspect `.governance/rules/gov-02-workflow.mdc`
+- inspect `docs/published/gov-02-workflow.md`
+- run `npm run build`
+
+## Documentation Impact
+- add `.governance/specs/bootstrap-reporting-current-vs-history.md`
+- update `static/agent.txt`
+- update `static/bootstrap.json`
+- update `docs/bootstrap.md`
+- update `docs/bootstrap-update.md`
+- update `docs/bootstrap-review.md`
+- update `docs/bootstrap-feedback-prompt.md`
+- update `docs/quickstart.md`
+- update `docs/contribute.md`
+- update `docs/faq/when-do-i-use-the-feedback-prompt.md`
+- update `docs/agents-template.md`
+- update `.governance/rules/gov-02-workflow.mdc`
+- update `docs/published/gov-02-workflow.md`
+
+## Verification
+Verification is documentation-driven. Success requires the public bootstrap docs, machine-readable bootstrap sources, and governed workflow wording to consistently describe current bootstrap reporting vs historical run bundles, plus a successful site build.
+
+## Change Notes
+- Prefer one directory per historical run so status/analysis/feedback/blockers stay grouped as a bundle.
+- Keep the current reporting surface small and obvious.
+- Make migration guidance explicit so older repo layouts are still understandable during transition.

--- a/.governance/specs/bootstrap-run-history-artifacts.md
+++ b/.governance/specs/bootstrap-run-history-artifacts.md
@@ -1,57 +1,16 @@
 # Bootstrap Run History Artifacts
 
-## Intent
-Preserve bootstrap evidence across repeated init, update, and review runs by writing bootstrap output artifacts into a timestamped run-history folder instead of relying only on singleton filenames. This matters because bootstrap is often iterative and stateful, and overwriting the prior status/feedback artifacts weakens reviewability, diffability, and audit history.
+## Note
+This earlier slice established the durable-history requirement for bootstrap reporting.
+Its flat `bootstrap-runs/<timestamp>-*.md` layout has now been refined by the newer structured reporting model in `bootstrap-reporting-current-vs-history.md`.
 
-## Scope
-In scope:
-- define timestamped bootstrap run-history artifact paths
-- define the expected status, feedback, and optional blockers files per run
-- allow stable top-level summary files only as convenience pointers/summaries to the latest run
-- update bootstrap, bootstrap-update, quickstart, feedback, contribute, FAQ, machine-readable bootstrap sources, and governed workflow wording accordingly
+The durable-history intent remains valid:
+- bootstrap should preserve historical run evidence
+- current reporting should not be the sole historical record
 
-Out of scope:
-- non-bootstrap run histories
-- binary artifact storage or compression
-- automatic pruning/retention policy for historical run artifacts
+The preferred current structure is now:
+- current reporting: `.governance/project/bootstrap/`
+- historical bundles: `.governance/project/bootstrap/history/<timestamp>/`
 
-## Acceptance Criteria
-- `BOOT-RUN-001` Bootstrap docs describe timestamped run-history artifacts under `.governance/project/bootstrap-runs/`.
-- `BOOT-RUN-002` Machine-readable bootstrap sources (`agent.txt`, `bootstrap.json`) describe the timestamped run-history structure.
-- `BOOT-RUN-003` The expected per-run artifacts include status and feedback files, with optional blockers files.
-- `BOOT-RUN-004` Stable top-level files may remain only as latest-run summaries/pointers and are not the sole historical artifact source.
-- `BOOT-RUN-005` Feedback guidance tells the agent to write the local feedback artifact into the timestamped run-history folder.
-- `BOOT-RUN-006` Governed workflow wording reflects durable timestamped bootstrap artifacts.
-- `BOOT-RUN-007` `npm run build` succeeds after the doc/rule/spec updates.
-
-## Tests and Evidence
-- inspect `static/agent.txt`
-- inspect `static/bootstrap.json`
-- inspect `docs/bootstrap.md`
-- inspect `docs/bootstrap-update.md`
-- inspect `docs/bootstrap-feedback-prompt.md`
-- inspect `docs/quickstart.md`
-- inspect `docs/contribute.md`
-- inspect FAQ pages
-- inspect `.governance/rules/gov-02-workflow.mdc`
-- inspect `docs/published/gov-02-workflow.md`
-- run `npm run build`
-
-## Documentation Impact
-- update `static/agent.txt`
-- update `static/bootstrap.json`
-- update `docs/bootstrap.md`
-- update `docs/bootstrap-update.md`
-- update `docs/bootstrap-feedback-prompt.md`
-- update `docs/quickstart.md`
-- update `docs/contribute.md`
-- update `docs/faq/when-do-i-use-the-feedback-prompt.md`
-- update `.governance/rules/gov-02-workflow.mdc`
-- update `docs/published/gov-02-workflow.md`
-
-## Verification
-Verification is documentation-driven. Success requires the public bootstrap docs, machine-readable bootstrap sources, and governed workflow wording to consistently describe timestamped bootstrap run-history artifacts, plus a successful site build.
-
-## Change Notes
-- Prefer `.governance/project/bootstrap-runs/<timestamp>-*.md` over singleton bootstrap artifact files.
-- Allow top-level summary files only as convenience pointers/summaries to the latest run.
+## Historical intent retained
+This spec remains useful as the change record for why bootstrap history became mandatory, but the path/layout details should now be taken from the newer structured reporting spec.

--- a/docs/agents-template.md
+++ b/docs/agents-template.md
@@ -32,7 +32,8 @@ This repository uses VibeGov with `.governance/` as the governance source of tru
 - Create or update `INIT-TODO.md` early during bootstrap or major remediation work.
 - Record prerequisite checks and blockers there before continuing.
 - Do not treat partial bootstrap as complete.
-- Keep bootstrap run-history artifacts under `.governance/project/bootstrap-runs/`.
+- Keep current bootstrap reporting under `.governance/project/bootstrap/`.
+- Keep historical bootstrap run bundles under `.governance/project/bootstrap/history/`.
 
 ## Continuity Discipline
 - Install and use a repo-local continuity model (for example session, daily, and project continuity layers).

--- a/docs/bootstrap-feedback-prompt.md
+++ b/docs/bootstrap-feedback-prompt.md
@@ -43,10 +43,10 @@ Before finalizing:
 - keep the feedback useful for a public issue
 
 Then produce BOTH:
-1) a local feedback artifact at `.governance/project/bootstrap-runs/<timestamp>-feedback.md`
-   - optional stable top-level summary/pointer: `.governance/project/BOOTSTRAP_FEEDBACK.md`
-2) a companion local analysis artifact at `.governance/project/bootstrap-runs/<timestamp>-analysis.md`
-   - optional stable top-level summary/pointer: `.governance/project/BOOTSTRAP_ANALYSIS.md`
+1) a local feedback artifact in the historical run bundle at `.governance/project/bootstrap/history/<timestamp>/feedback.md`
+   - refresh the current reporting surface at `.governance/project/bootstrap/FEEDBACK.md`
+2) a companion local analysis artifact in the historical run bundle at `.governance/project/bootstrap/history/<timestamp>/analysis.md`
+   - refresh the current reporting surface at `.governance/project/bootstrap/ANALYSIS.md`
 3) a GitHub issue-ready payload:
    - title
    - body
@@ -60,6 +60,6 @@ If issue filing is explicitly requested:
 ## What to do next
 
 1. Run the prompt.
-2. Review the generated timestamped local feedback artifact.
+2. Review the generated historical-run feedback artifact and the refreshed current reporting surface.
 3. Open/file the GitHub issue using the scrubbed title/body.
 4. Link affected page/rule/prompt sections.

--- a/docs/bootstrap-review.md
+++ b/docs/bootstrap-review.md
@@ -29,13 +29,19 @@ Do not fork the contract.
 Do not claim missing work was completed.
 
 Review the repo against the canonical bootstrap contract.
-Write timestamped run-history artifacts under `.governance/project/bootstrap-runs/`.
+Write current reporting artifacts under `.governance/project/bootstrap/` and a historical run bundle under `.governance/project/bootstrap/history/<timestamp>/`.
 Report:
 - what already satisfies the contract
 - what is missing or weak
 - what is blocked
 - what exact next fixes are required
 ```
+
+## Reporting shape
+
+Review mode should use the same reporting structure as init/update:
+- current reporting under `.governance/project/bootstrap/`
+- historical run bundles under `.governance/project/bootstrap/history/<timestamp>/`
 
 ## Rule
 

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -21,9 +21,10 @@ Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
 - create/update `INIT-TODO.md` early and record any missing prerequisite with exact remediation
 - if the repo still fails the contract, report exact blockers/gaps instead of claiming partial completion
 - do not leave the repo in ambiguous drift: classify the end state as committed/pushed, pending-review, or blocked
-- emit explicit status, analysis, and feedback artifacts instead of relying only on chat output
+- emit explicit current-reporting and historical-run artifacts instead of relying only on chat output
 - when update cannot complete all gaps, emit explicit blocker artifacts too
 - if a private-repo hosted-feature limit prevents live branch-protection verification but the rest of bootstrap normalization succeeds, report it as degraded verification/warning with exact evidence and next action rather than treating the whole run as a hard blocker
+- do not leave valid bootstrap reporting outputs in an ambiguous flat layout when the structured reporting layout can be normalized during the run
 
 ## Update prompt
 
@@ -42,7 +43,17 @@ Use the canonical bootstrap contract.
 Do not restart from scratch when valid artifacts already exist.
 Repair or normalize the repo until the same bootstrap contract is satisfied, including missing operational bootstrap artifacts, or report exact blockers.
 Do not stop in an ambiguous local end state; classify the result as committed/pushed, pending-review, or blocked.
-Write explicit status, analysis, and feedback artifacts for the run.
+Write explicit current-reporting artifacts under `.governance/project/bootstrap/` and a historical run bundle under `.governance/project/bootstrap/history/<timestamp>/` for the run.
 If update cannot complete all gaps, write explicit blocker artifacts describing what remains and the exact next actions.
 If a known private-repo hosted-feature limit blocks branch-protection verification, record that as a warning/degraded verification note with exact evidence and next action.
 ```
+
+## Reporting settlement
+
+BU should make bootstrap reporting easier to read, not harder to interpret.
+
+Preferred shape:
+- `.governance/project/bootstrap/` = current settled reporting surface
+- `.governance/project/bootstrap/history/<timestamp>/` = the historical run bundle for this pass
+
+When migrating a repo that still uses the older flat bootstrap layout, BU should normalize reporting into the structured layout instead of extending the old pattern.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -81,14 +81,22 @@ Before writing any product code (or before claiming bootstrap review is complete
    - if no issues exist, report board as intentionally empty
    - clean accidental duplicate empty boards and report cleanup
 14. If GitHub automation is unavailable, report exact missing capability and leave a tracked blocker artifact.
-15. Write durable local output artifacts into `.governance/project/bootstrap-runs/`:
-   - `<timestamp>-status.md`
-   - `<timestamp>-analysis.md`
-   - `<timestamp>-feedback.md`
-   - optional `<timestamp>-blockers.md`
-   - stable top-level files may exist only as latest-run summaries/pointers (`BOOTSTRAP_STATUS.md`, `BOOTSTRAP_ANALYSIS.md`, `BOOTSTRAP_FEEDBACK.md`, `BOOTSTRAP_BLOCKERS.md`)
+15. Write durable local bootstrap reporting artifacts using a two-surface layout:
+   - current reporting surface: `.governance/project/bootstrap/`
+     - `STATUS.md`
+     - `ANALYSIS.md`
+     - `FEEDBACK.md`
+     - optional `BLOCKERS.md`
+   - historical run bundles: `.governance/project/bootstrap/history/<timestamp>/`
+     - `status.md`
+     - `analysis.md`
+     - `feedback.md`
+     - optional `blockers.md`
+   - current files should act as the latest current reporting surface
+   - history folders should preserve the per-run bundle as historical evidence
 16. Reconcile generated docs against final live git/GitHub state before claiming completion.
 17. Distinguish final current state from historical evidence gathered earlier in the run.
+18. If migrating a repo from the older flat layout (`BOOTSTRAP_*.md` and `bootstrap-runs/<timestamp>-*.md`), normalize it into the current-surface plus historical-run-bundle structure instead of extending the legacy shape.
 
 Mode-specific behavior:
 - `init`: create the missing bootstrap state required by the contract
@@ -113,11 +121,56 @@ Continue only if all are true:
 - starting repo state and commit-policy mode are reported
 - for GitHub repos, preflight results are reported with explicit state (`configured`, `blocked-with-tracked-issue`, `not-applicable`), and known hosted-feature verification limits are distinguished from core bootstrap failure
 - for GitHub repos with automation, canonical board target is adopted/created/normalized, repo-link status is reported, and multiple-match selection is explained when relevant
-- timestamped bootstrap status + analysis + feedback artifacts are written under `.governance/project/bootstrap-runs/`
-- if update cannot complete all gaps or only reaches degraded verification, timestamped blocker artifacts make the incomplete state explicit with exact next actions
+- current bootstrap reporting artifacts exist under `.governance/project/bootstrap/`
+- historical bootstrap run bundles are written under `.governance/project/bootstrap/history/<timestamp>/`
+- if update cannot complete all gaps or only reaches degraded verification, blocker reporting makes the incomplete state explicit with exact next actions
 - final docs are reconciled with final live git/GitHub state
 - no product code was written
 
 If any fail:
 - `init` and `update` are incomplete
 - `review` must report the exact gaps and blockers without pretending the repo is bootstrapped
+
+## Reporting structure
+
+Bootstrap reporting should separate current state from history.
+
+### Current reporting surface
+
+Use `.governance/project/bootstrap/` for the current bootstrap reporting surface:
+- `STATUS.md`
+- `ANALYSIS.md`
+- `FEEDBACK.md`
+- optional `BLOCKERS.md`
+
+These files should describe or point to the current settled bootstrap picture, not act as a pile of historical reruns.
+
+### Historical run bundles
+
+Use `.governance/project/bootstrap/history/<timestamp>/` for historical bootstrap run evidence.
+
+Each run bundle should group the run’s artifacts together:
+- `status.md`
+- `analysis.md`
+- `feedback.md`
+- optional `blockers.md`
+
+One folder per run is preferred because it makes each bootstrap/reporting pass legible as a single reporting bundle.
+
+### Migration guidance
+
+If a repo still uses the older flat layout:
+- `.governance/project/BOOTSTRAP_STATUS.md`
+- `.governance/project/BOOTSTRAP_ANALYSIS.md`
+- `.governance/project/BOOTSTRAP_FEEDBACK.md`
+- `.governance/project/BOOTSTRAP_BLOCKERS.md`
+- `.governance/project/bootstrap-runs/<timestamp>-*.md`
+
+normalize it toward:
+- `.governance/project/bootstrap/STATUS.md`
+- `.governance/project/bootstrap/ANALYSIS.md`
+- `.governance/project/bootstrap/FEEDBACK.md`
+- `.governance/project/bootstrap/BLOCKERS.md`
+- `.governance/project/bootstrap/history/<timestamp>/...`
+
+During transition, older flat artifacts may remain as legacy history, but new bootstrap work should use the structured reporting layout.

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -38,8 +38,8 @@ Use the [Branch Protection Checklist](/docs/branch-protection-checklist) when se
 If you have just run a fresh bootstrap or an update/remediation pass, use the [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt).
 
 Expected feedback flow:
-1. write scrubbed feedback to `.governance/project/bootstrap-runs/<timestamp>-feedback.md`
-2. optionally update `.governance/project/BOOTSTRAP_FEEDBACK.md` as the latest summary/pointer
+1. write scrubbed feedback to `.governance/project/bootstrap/history/<timestamp>/feedback.md`
+2. refresh `.governance/project/bootstrap/FEEDBACK.md` as the current reporting surface
 3. then raise a GitHub issue with the scrubbed result (or auto-file when requested)
 
 Before posting, remove or obfuscate PII, secrets, tokens, emails, usernames, IDs, URLs, and environment-specific sensitive details.

--- a/docs/faq/when-do-i-use-the-feedback-prompt.md
+++ b/docs/faq/when-do-i-use-the-feedback-prompt.md
@@ -9,8 +9,8 @@ question: When do I use the feedback prompt?
 Use the **bootstrap feedback prompt** after bootstrap init/update when you want durable, scrubbed feedback.
 
 Expected output:
-1. local file: `.governance/project/bootstrap-runs/<timestamp>-feedback.md`
-2. optional latest summary/pointer: `.governance/project/BOOTSTRAP_FEEDBACK.md`
+1. local historical artifact: `.governance/project/bootstrap/history/<timestamp>/feedback.md`
+2. refreshed current reporting file: `.governance/project/bootstrap/FEEDBACK.md`
 3. issue-ready title/body for `governance-foundation/vibegov.io`
 
 If asked to file automatically, file and return the created issue URL.

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -95,7 +95,9 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-020` Bootstrap must ensure repository linkage to the canonical board before claiming completion.
 - `GOV-02-GIT-021` GitHub built-in `Status` should be normalized in place when needed; bootstrap should not assume replacement via create/delete flows.
 - `GOV-02-GIT-022` If the repository has no issues, board setup may still be complete, but bootstrap must report the board as intentionally empty.
-- `GOV-02-GIT-023` Bootstrap must emit durable local run-history artifacts under a timestamped path such as `.governance/project/bootstrap-runs/<timestamp>-status.md` and `.governance/project/bootstrap-runs/<timestamp>-feedback.md` even when commit mode forbids committing.
+- `GOV-02-GIT-023` Bootstrap must emit durable local reporting artifacts even when commit mode forbids committing.
+- `GOV-02-GIT-023A` Current bootstrap reporting should live under `.governance/project/bootstrap/` using files such as `STATUS.md`, `ANALYSIS.md`, `FEEDBACK.md`, and optional `BLOCKERS.md`.
+- `GOV-02-GIT-023B` Historical bootstrap evidence should live under per-run bundle paths such as `.governance/project/bootstrap/history/<timestamp>/status.md`, `analysis.md`, `feedback.md`, and optional `blockers.md`.
 - `GOV-02-GIT-024` Bootstrap is incomplete until generated docs/artifacts are reconciled against final live git/GitHub state after any auth refresh, board mutation, or cleanup action.
 
 This section defines the governance shape of repository flow. Platform-specific docs may describe the exact GitHub or Git-provider settings used to enforce it.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,11 +39,17 @@ Initialization contract:
    - `Priority`: P0, P1, P2
    - `Size`: XS, S, M, L, XL
 12) Import/attach existing issues; if none exist, report intentionally empty board.
-13) Write durable output artifacts into `.governance/project/bootstrap-runs/`:
-   - `<timestamp>-status.md`
-   - `<timestamp>-feedback.md`
-   - optional `<timestamp>-blockers.md`
-   - stable top-level files may exist only as latest-run summaries/pointers
+13) Write durable bootstrap reporting artifacts using:
+   - current reporting surface: `.governance/project/bootstrap/`
+     - `STATUS.md`
+     - `ANALYSIS.md`
+     - `FEEDBACK.md`
+     - optional `BLOCKERS.md`
+   - historical run bundle: `.governance/project/bootstrap/history/<timestamp>/`
+     - `status.md`
+     - `analysis.md`
+     - `feedback.md`
+     - optional `blockers.md`
 14) Reconcile docs against final live git/GitHub state.
 
 Then stop before product-code implementation.

--- a/static/agent.txt
+++ b/static/agent.txt
@@ -63,13 +63,20 @@ repo-state discipline:
 
 durable output artifacts:
 - every bootstrap run must leave durable local output artifacts even when commits are forbidden
-- write per-run artifacts into:
-  - .governance/project/bootstrap-runs/<timestamp>-status.md
-  - .governance/project/bootstrap-runs/<timestamp>-analysis.md
-  - .governance/project/bootstrap-runs/<timestamp>-feedback.md
-  - optional: .governance/project/bootstrap-runs/<timestamp>-blockers.md
-- stable top-level files such as BOOTSTRAP_STATUS.md / BOOTSTRAP_ANALYSIS.md / BOOTSTRAP_FEEDBACK.md may exist only as latest-run summaries or pointers
-- bootstrap feedback and analysis should be written to the timestamped local run-history files before or alongside any public GitHub issue filing
+- keep the current reporting surface under:
+  - .governance/project/bootstrap/STATUS.md
+  - .governance/project/bootstrap/ANALYSIS.md
+  - .governance/project/bootstrap/FEEDBACK.md
+  - optional: .governance/project/bootstrap/BLOCKERS.md
+- keep per-run historical bundles under:
+  - .governance/project/bootstrap/history/<timestamp>/status.md
+  - .governance/project/bootstrap/history/<timestamp>/analysis.md
+  - .governance/project/bootstrap/history/<timestamp>/feedback.md
+  - optional: .governance/project/bootstrap/history/<timestamp>/blockers.md
+- current reporting should describe the current settled bootstrap picture
+- historical bundles should preserve the per-run evidence bundle
+- bootstrap feedback and analysis should be written to the historical run bundle before or alongside any public GitHub issue filing
+- when normalizing older repos, prefer the structured bootstrap/ + bootstrap/history/ layout over the older flat BOOTSTRAP_* plus bootstrap-runs/ layout
 
 delivery loop:
 - Observe -> Plan -> Implement -> Verify -> Document

--- a/static/bootstrap.json
+++ b/static/bootstrap.json
@@ -107,16 +107,16 @@
       ".github/branch-protection-checklist.md"
     ],
     "requiredStatusArtifacts": [
-      ".governance/project/bootstrap-runs/<timestamp>-status.md",
-      ".governance/project/bootstrap-runs/<timestamp>-analysis.md",
-      ".governance/project/bootstrap-runs/<timestamp>-feedback.md"
+      ".governance/project/bootstrap/STATUS.md",
+      ".governance/project/bootstrap/ANALYSIS.md",
+      ".governance/project/bootstrap/FEEDBACK.md",
+      ".governance/project/bootstrap/history/<timestamp>/status.md",
+      ".governance/project/bootstrap/history/<timestamp>/analysis.md",
+      ".governance/project/bootstrap/history/<timestamp>/feedback.md"
     ],
     "optionalStatusArtifacts": [
-      ".governance/project/bootstrap-runs/<timestamp>-blockers.md",
-      ".governance/project/BOOTSTRAP_STATUS.md",
-      ".governance/project/BOOTSTRAP_ANALYSIS.md",
-      ".governance/project/BOOTSTRAP_FEEDBACK.md",
-      ".governance/project/BOOTSTRAP_BLOCKERS.md",
+      ".governance/project/bootstrap/BLOCKERS.md",
+      ".governance/project/bootstrap/history/<timestamp>/blockers.md",
       ".governance/project/GIT_WORKFLOW.md",
       ".governance/project/GITHUB_PROJECT_STATUS.md",
       ".governance/project/BOOTSTRAP_REPORT.md"
@@ -174,8 +174,10 @@
   },
   "feedback_flow": {
     "mustWriteLocalFeedbackFile": true,
-    "localAnalysisRunHistoryPath": ".governance/project/bootstrap-runs/<timestamp>-analysis.md",
-    "localFeedbackRunHistoryPath": ".governance/project/bootstrap-runs/<timestamp>-feedback.md",
+    "currentAnalysisPath": ".governance/project/bootstrap/ANALYSIS.md",
+    "currentFeedbackPath": ".governance/project/bootstrap/FEEDBACK.md",
+    "localAnalysisRunHistoryPath": ".governance/project/bootstrap/history/<timestamp>/analysis.md",
+    "localFeedbackRunHistoryPath": ".governance/project/bootstrap/history/<timestamp>/feedback.md",
     "writeBeforeOrAlongsidePublicIssueFiling": true,
     "mustScrubSensitiveData": true
   },


### PR DESCRIPTION
## Summary
- add a focused spec for structured bootstrap reporting
- separate current bootstrap reporting from historical run bundles across the canonical docs and machine-readable sources
- update GOV-02 wording and migration guidance to move repos away from the older flat bootstrap layout

## Validation
- PASS `npm run build`

## Issue
- Closes #116
