### PR TITLE
promote develop to main (2026-04-23)

### DIFF
--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -94,7 +94,7 @@ Governed agent execution should use explicit orchestration and bounded work unit
 
 This section governs work structure, not implementation details. It does not prescribe specific runtimes, queue settings, model choices, shell commands, or machine-local paths. It defines the accountability shape of delegation, while project/runbook docs may specify concrete supervision timings.
 
-## Execution Modes
+## Execution Modes and Parallel Loops
 
 All meaningful work must declare an active execution mode. Silent mode mixing produces weak evidence and false completion claims.
 
@@ -104,14 +104,27 @@ VibeGov uses two operating modes:
 
 Release verification is not a third peer mode. It is part of Development's delivery path and release-readiness checks.
 
+These modes often run inside a broader parallel loop model:
+- a **Build Loop** that consumes governed scoped work from the repo/backlog and writes clear delivery outputs back,
+- an **Exploratory Loop** that inspects UI/spec/issue reality and feeds governed backlog/spec work into delivery,
+- and a **Human Feedback Loop** that injects approval, correction, judgment, taste, and reprioritisation.
+
+The Build Loop must not recursively self-source its own next work from its own outputs. It should consume governed input and produce governed output.
+
+Exploratory work is the non-delivery discovery/analysis lane. It may include planner-style scoping and evaluator-style judgment when those roles are being used to explore, review, classify, and hydrate backlog work rather than deliver the product change itself.
+
+Human feedback should be first-class, but not automatically global. When human input is needed, the system should prefer scoped blocking over stop-the-world blocking whenever unrelated ready work can continue.
+
 ### Exploration mode
 
-Use when the objective is discovery, validation, or backlog hydration rather than immediate product change.
+Use when the objective is discovery, validation, review, judgment, or backlog hydration rather than immediate product change.
 
 Allowed work:
 - inspect live behavior from an end-user or operator perspective
 - compare observed behavior with specs, traceability, and existing test intent
 - create or refine backlog items, spec gaps, and planned verification follow-up
+- perform planner-style scoping of a review surface, route set, issue set, or analysis slice
+- perform evaluator-style judgment of exploratory artifacts, coverage, or review completeness
 
 Required evidence:
 - reviewed scope and scenarios exercised
@@ -119,6 +132,7 @@ Required evidence:
 - per-scenario classification: `Validated`, `Invalidated`, `Blocked`, or `Uncovered-spec-gap`
 - tracked follow-up artifacts for every invalidated, blocked, or uncovered item
 - next recommended backlog action
+- coverage or confidence limits when relevant
 
 ### Development mode
 
@@ -170,7 +184,7 @@ Backlog hydration is part of the core workflow, not a side activity.
 - Development release-readiness and post-ship checks must capture new regressions, drift, rollout gaps, or integration failures as tracked follow-up work.
 - Development may surface adjacent gaps, but those gaps must be tracked separately unless scope is explicitly expanded.
 
-## Blocker Escalation and Move-On Behavior
+## Scoped Blocking, Blocker Escalation, and Move-On Behavior
 
 Autonomy is expected, not unrestricted.
 
@@ -188,6 +202,12 @@ When blocked:
 - move on instead of freezing the whole loop unless no ready work remains
 
 A blocker pauses the current item. It does not pause delivery unless it removes all viable next work or requires a human decision.
+
+Prefer scoped blocking over global blocking:
+- only the lane that truly requires the missing approval, decision, or dependency should pause,
+- unrelated build work may continue,
+- unrelated exploratory work may continue,
+- and the blocked boundary should be made explicit in checkpoints or handoffs.
 
 ## Scope Discipline
 

--- a/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
+++ b/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
@@ -10,50 +10,78 @@ Governed repositories should treat repository state as a control surface for age
 
 ## Core Principle
 
-- `GOV-10-GIT-001` Every substantive work unit must end with full working-tree accounting.
-- `GOV-10-GIT-002` Agents must not carry ambiguous repository state into the next work unit.
+- `GOV-10-GIT-001` Every substantive turn or work unit must end with full working-tree accounting.
+- `GOV-10-GIT-002` Agents must not carry ambiguous repository state into the next substantive turn or work unit.
 - `GOV-10-GIT-003` Repository cleanliness is not cosmetic. It is part of execution correctness.
+- `GOV-10-GIT-004` Git hygiene is mandatory, not optional polish.
+- `GOV-10-GIT-005` New governed work must not begin unless the local repo is on `develop`, except for an explicitly documented recovery or escalation exception.
+
+## What Counts as a Substantive Turn
+
+- `GOV-10-GIT-006` A substantive turn is any execution turn that leaves durable repo or issue state behind, changes the governed state of a ticket, or would create carry-over risk if left unresolved.
+- `GOV-10-GIT-007` This includes changing code, docs, specs, tests, config, workflows, issue metadata, branch state, or validation state in a way that affects execution, review, or closure.
+- `GOV-10-GIT-008` This also includes decisions or checks that materially change ticket status, for example moving work into blocked, validated, follow-up-required, or merge-ready state.
+- `GOV-10-GIT-009` Pure discussion, reading, or ephemeral probing with no kept repo or ticket state is not a substantive turn.
+- `GOV-10-GIT-010` If a turn produced kept changes, changed ticket state, or would be risky to leave dirty, treat it as substantive.
+
+## Start-of-Work Preconditions
+
+- `GOV-10-GIT-011` Before starting a new governed slice, the agent must verify the local repo is on `develop`.
+- `GOV-10-GIT-012` If the repo is not on `develop`, the agent must not begin new work until the state is normalized or an explicit recovery/escalation note justifies the exception.
+- `GOV-10-GIT-013` Starting new governed work from an issue branch, archived branch, detached state, or another non-`develop` branch without explicit justification is non-compliant.
+- `GOV-10-GIT-014` This precondition exists to stop branch drift, hidden carry-over, and accidental continuation from the wrong base state.
+- `GOV-10-GIT-014A` Start-of-work hygiene must include an explicit assessment of the inherited repo state before new governed work begins.
+- `GOV-10-GIT-014B` The agent must classify inherited state, including branch position, modified files, untracked files, partial slices, and unmerged work, and decide what should be landed, deferred, archived, followed up, or escalated.
+- `GOV-10-GIT-014C` If the inherited state is mixed, unclear, or not safely attributable, the agent must not begin a new governed slice until treatment is chosen and recorded.
 
 ## Working-Tree Accounting
 
-- `GOV-10-GIT-004` Before a work unit is considered complete, blocked, deferred, or handed off, every modified, deleted, and untracked file in scope must be classified.
-- `GOV-10-GIT-005` Allowed classifications are:
+- `GOV-10-GIT-015` Before a substantive turn or work unit is considered complete, blocked, deferred, or handed off, every modified, deleted, and untracked file in scope must be classified.
+- `GOV-10-GIT-016` Allowed classifications are:
   - committed as intended governed change,
   - reverted because it is junk, noise, or failed experimentation,
   - ignored through an explicit ignore rule when the file is generated or intentionally untracked,
-  - intentionally deferred with an explicit note that names the file, reason, and next follow-up path.
-- `GOV-10-GIT-006` "I think this file is probably from earlier work" is not sufficient accounting.
-- `GOV-10-GIT-007` If a file cannot be explained, the work unit is not yet closed.
+  - intentionally deferred only when an explicit follow-up ticket or bounded follow-up path is recorded.
+- `GOV-10-GIT-017` Intentional deferral notes must name the file or branch, the reason it remains open, and the exact follow-up issue or path that will close it.
+- `GOV-10-GIT-018` "I think this file is probably from earlier work" is not sufficient accounting.
+- `GOV-10-GIT-019` If a file cannot be explained, the substantive turn or work unit is not yet closed.
 
 ## Dirty-Tree Discipline
 
-- `GOV-10-GIT-008` Agents must treat unresolved dirty state as actionable repository state, not passive background context.
-- `GOV-10-GIT-009` In single-actor repos or isolated worktrees, unresolved dirty state should be presumed agent-caused until proven otherwise.
-- `GOV-10-GIT-010` Reporting "tree is dirty" without classification, resolution intent, or follow-up path is non-compliant.
-- `GOV-10-GIT-011` If prior residue is discovered while starting new work, the agent should either resolve it first or explicitly escalate why safe resolution cannot happen yet.
+- `GOV-10-GIT-020` Agents must treat unresolved dirty state as actionable repository state, not passive background context.
+- `GOV-10-GIT-021` In single-actor repos or isolated worktrees, unresolved dirty state should be presumed agent-caused until proven otherwise.
+- `GOV-10-GIT-022` Reporting "tree is dirty" without classification, resolution intent, or follow-up path is non-compliant.
+- `GOV-10-GIT-023` If prior residue is discovered while starting new work, the agent should either resolve it first or explicitly escalate why safe resolution cannot happen yet.
 
 ## Commit and Ignore Hygiene
 
-- `GOV-10-GIT-012` Durable kept changes should normally be committed before the work unit ends so the intended state has a real tracking boundary.
-- `GOV-10-GIT-013` Commits should be cohesive, reviewable, and limited to the intended governed change.
-- `GOV-10-GIT-014` Generated or environment-specific noise that should persist locally but not be tracked must be handled through explicit ignore rules rather than repeated manual omission.
-- `GOV-10-GIT-015` Ignore rules should be as narrow as practical so legitimate changes are not accidentally hidden.
+- `GOV-10-GIT-024` Durable kept changes must be committed by the end of each substantive turn so the intended state has a real tracking boundary.
+- `GOV-10-GIT-025` Commits should be cohesive, reviewable, and limited to the intended governed change.
+- `GOV-10-GIT-026` Generated or environment-specific noise that should persist locally but not be tracked must be handled through explicit ignore rules rather than repeated manual omission.
+- `GOV-10-GIT-027` Ignore rules should be as narrow as practical so legitimate changes are not accidentally hidden.
 
 ## Preserve Before Destructive Change
 
-- `GOV-10-GIT-016` Meaningful state includes kept code, docs, specs, notes, captured investigation output, and generated artifacts that are intentionally being preserved as evidence or deliverable state.
-- `GOV-10-GIT-017` Disposable cache, build output, or other reproducible noise is not meaningful state unless the current work unit explicitly depends on it as evidence or deliverable content.
-- `GOV-10-GIT-018` Before deleting, overwriting, archiving, or otherwise destructively changing meaningful state, the agent should preserve that state in a traceable form when safe to do so, normally through a commit or another durable governed artifact.
-- `GOV-10-GIT-019` If material is secret, unsafe, or otherwise inappropriate to preserve in normal history, the agent should use a separate safe-handling path and record the exception explicitly instead of silently discarding context.
-- `GOV-10-GIT-020` Cleanup, rollback, and archival actions must not silently erase why a change existed, what was learned, or what state is being retired.
-- `GOV-10-GIT-021` If old behavior or prior content needs to return, it should come back through a new traceable change rather than hidden history surgery or convenience-driven destructive rollback.
-- `GOV-10-GIT-022` This preservation rule does not require noisy micro-commits for trivial or disposable edits, but it does require a deliberate preservation boundary before meaningful destructive change.
+- `GOV-10-GIT-028` Meaningful state includes kept code, docs, specs, notes, captured investigation output, and generated artifacts that are intentionally being preserved as evidence or deliverable state.
+- `GOV-10-GIT-029` Disposable cache, build output, or other reproducible noise is not meaningful state unless the current work unit explicitly depends on it as evidence or deliverable content.
+- `GOV-10-GIT-030` Before deleting, overwriting, archiving, or otherwise destructively changing meaningful state, the agent must preserve that state in a traceable form when safe to do so, normally through a commit or another durable governed artifact.
+- `GOV-10-GIT-031` If material is secret, unsafe, or otherwise inappropriate to preserve in normal history, the agent should use a separate safe-handling path and record the exception explicitly instead of silently discarding context.
+- `GOV-10-GIT-031A` Resetting, hard cleanup, deletion, or destructive overwrite of inherited state is a last resort, not a default cleanup move.
+- `GOV-10-GIT-031B` When the state may be meaningful, destructive normalization should happen only after discussion or explicit approval, unless the material is already classified as disposable generated noise.
+- `GOV-10-GIT-031C` Default preference is to assess, classify, preserve, land, archive, defer with follow-up, or escalate before considering destructive cleanup.
+- `GOV-10-GIT-032` Cleanup, rollback, and archival actions must not silently erase why a change existed, what was learned, or what state is being retired.
+- `GOV-10-GIT-033` If old behavior or prior content needs to return, it should come back through a new traceable change rather than hidden history surgery or convenience-driven destructive rollback.
+- `GOV-10-GIT-034` This preservation rule does not require noisy micro-commits for trivial or disposable edits, but it does require a deliberate preservation boundary before meaningful destructive change.
 
 ## Completion and Handoff Rules
 
-- `GOV-10-GIT-023` Completion claims are invalid if the repository state that remains is unexplained.
-- `GOV-10-GIT-024` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
-- `GOV-10-GIT-025` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
+- `GOV-10-GIT-035` Completion claims are invalid if the repository state that remains is unexplained.
+- `GOV-10-GIT-036` A blocked or deferred substantive turn or work unit must still leave the repository in a classified state, even when implementation is incomplete.
+- `GOV-10-GIT-037` If the intended work is not actually complete by turn end, a focused follow-up ticket must be created rather than carrying unresolved branch or dirty-state ambiguity forward.
+- `GOV-10-GIT-038` A slice is not closed until the original ticket is merged into `develop`.
+- `GOV-10-GIT-039` After closure, the branch where the work was done must be archived under an `archive/`-prefixed branch name.
+- `GOV-10-GIT-040` After merge and archival, the local working repo should be returned to `develop`.
+- `GOV-10-GIT-041` Handoff artifacts should state any intentionally deferred files, branches, or follow-up tickets explicitly rather than relying on a future reader to infer them from git status.
 
 ## Anti-Patterns
 
@@ -62,6 +90,12 @@ Avoid these failure modes:
 - deleting or overwriting meaningful state before it has a traceable preservation boundary
 - treating untracked temp files as harmless background clutter
 - leaving generated noise unignored across repeated runs
-- carrying mixed unrelated diffs across work units
+- carrying mixed unrelated diffs across substantive turns or work units
+- starting new governed work from a non-`develop` branch without explicit exception handling
+- skipping inherited-state assessment and just pushing ahead on top of mixed residue
+- auto-resetting, deleting, or force-cleaning inherited state to feel clean without first classifying it
 - using dirty state as a substitute for real tracking
+- marking a slice done before the original ticket is merged into `develop`
+- archiving a work branch without first closing the governed landing path
+- failing to create a follow-up ticket when the current turn cannot honestly close the slice
 - using cleanup, archival, or rollback to erase rationale instead of preserving it

--- a/.governance/specs/parallel-loops-scoped-blocking.md
+++ b/.governance/specs/parallel-loops-scoped-blocking.md
@@ -1,0 +1,57 @@
+# Spec: Build loop, exploratory loop, human feedback loop, and scoped blocking
+
+## Goal
+
+Make the emerging VibeGov loop model explicit so teams do not collapse delivery, exploration, and human judgment into one vague idea of "the agent is working."
+
+## Why
+
+The current governance already distinguishes Development from Exploration and already says blockers should redirect work rather than freeze the whole loop.
+
+The missing sharper model is:
+- the **Build Loop** should consume governed scoped work from the repo/issues/specs and produce clear delivery outputs,
+- the **Exploratory Loop** should inspect UI/spec/issue reality and feed governed backlog/spec work into delivery,
+- the **Human Feedback Loop** should inject approval, correction, judgment, taste, and reprioritisation,
+- and **Scoped Blocking** should pause only the lane that truly requires the missing input.
+
+Without this, teams tend to make one of four mistakes:
+- treating all agent activity as one loop with unclear boundaries,
+- letting build recursively self-source new work from its own outputs,
+- treating human-in-the-loop as a global stop condition,
+- or treating planner/evaluator behavior as inherently delivery-shaped rather than sometimes exploratory.
+
+## Requirements
+
+- `LOOPS-001` GOV-02 explicitly describes the broader parallel loop model of Build Loop, Exploratory Loop, and Human Feedback Loop.
+- `LOOPS-002` GOV-02 states that the Build Loop must not recursively self-source its own next work from its own outputs.
+- `LOOPS-003` GOV-02 states that exploratory work is the non-delivery discovery/analysis lane.
+- `LOOPS-004` GOV-02 allows planner-style scoping and evaluator-style judgment inside Exploration when they are used for non-delivery discovery, review, coverage, or backlog hydration.
+- `LOOPS-005` GOV-02 explicitly prefers scoped blocking over global blocking when unrelated ready work can continue.
+- `LOOPS-006` Public docs define the three-loop model and explain how scoped blocking works.
+- `LOOPS-007` Public docs keep Exploration and Development as the two execution modes, while explaining that the broader loop model can contain planner/evaluator behavior.
+- `LOOPS-008` A public article explains the loop model in plainer language for readers who are not starting from canonical GOV text.
+- `LOOPS-009` Canonical and published GOV-02 wording stay aligned.
+
+## Non-goals
+
+- creating a third peer execution mode beyond Development and Exploration
+- prescribing one exact multi-agent runtime architecture
+- requiring every project to run all three loops with equal intensity at all times
+- forbidding evaluator or planner roles inside Development when they are being used for delivery-shaped work
+
+## Verification
+
+Success requires:
+- canonical GOV-02 and published GOV-02 both reflect the loop model and scoped blocking
+- a dedicated public doc exists for the loop model
+- a public article exists for the loop model
+- execution/exploration/evaluation docs remain consistent with the updated framing
+- the site build passes
+
+## Notes
+
+Useful short form:
+- **Build changes reality.**
+- **Exploratory understands reality.**
+- **Human feedback reshapes intent.**
+- **Scoped blocking prevents one unanswered question from freezing the whole system.**

--- a/blog/2026-04-17-governance-from-harness-engineering-and-beyond.md
+++ b/blog/2026-04-17-governance-from-harness-engineering-and-beyond.md
@@ -136,6 +136,7 @@ If harness engineering made agent work possible, governance is what makes it dep
 
 ## Related reading
 
+- [Reference Reading](/docs/reference-reading)
 - [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
 - [Published GOV 04 Quality](/docs/published/gov-04-quality)
 - [Published GOV 09 Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)

--- a/blog/2026-04-17-harness-engineering-what-we-do-with-it.md
+++ b/blog/2026-04-17-harness-engineering-what-we-do-with-it.md
@@ -123,6 +123,7 @@ It is the discipline that turns agent output into dependable delivery.
 
 ## Related reading
 
+- [Reference Reading](/docs/reference-reading)
 - [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
 - [Published GOV 04 Quality](/docs/published/gov-04-quality)
 - [Published GOV 09 Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)

--- a/blog/2026-04-22-build-exploratory-human-feedback-and-scoped-blocking.md
+++ b/blog/2026-04-22-build-exploratory-human-feedback-and-scoped-blocking.md
@@ -1,0 +1,231 @@
+---
+slug: build-exploratory-human-feedback-and-scoped-blocking
+title: "Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking"
+authors: [VibeGov_team]
+tags: [governance, workflow, exploratory, human-feedback, blockers]
+---
+
+A lot of agent discussions still assume there is one loop.
+
+The agent is running.
+The loop is going.
+Work is happening.
+
+That sounds fine until you try to govern it.
+Then you discover that "the loop" is hiding several different kinds of work with different sources, different outputs, and different reasons to pause.
+
+VibeGov should be more explicit.
+
+## The real shape is usually three loops
+
+In practice, agent-enabled work often has at least three loops running in parallel:
+
+- a **Build Loop**
+- an **Exploratory Loop**
+- a **Human Feedback Loop**
+
+And once those exist, you also need one important rule for how they pause:
+
+- **Scoped Blocking**
+
+## 1) Build Loop
+
+The Build Loop is the delivery loop.
+
+Its job is not to invent work.
+Its job is to consume already-governed work and turn it into clear outputs.
+
+That means the Build Loop should take input from:
+- the repository,
+- the issue backlog,
+- the bound specs or requirements,
+- and the current governed delivery state.
+
+And it should write back:
+- code,
+- docs,
+- tests,
+- evidence,
+- issue or PR state,
+- release-readiness or shipping outputs when relevant.
+
+The important boundary is this:
+
+**build should not recursively self-source its own next work from its own outputs.**
+
+If it does, the delivery loop becomes unstable.
+Instead of a governed execution path, you get a self-expanding activity engine.
+
+## 2) Exploratory Loop
+
+The Exploratory Loop is the non-delivery intelligence loop.
+
+Its job is to inspect reality and feed governed work into delivery.
+
+That can include:
+- UI exploration,
+- workflow review,
+- spec exploration,
+- issue exploration,
+- drift detection,
+- gap analysis,
+- backlog hydration,
+- and exploratory report generation.
+
+This is also where a lot of confusion happens.
+People hear planner or evaluator and assume those roles must belong to a delivery harness.
+But that is too narrow.
+
+In VibeGov terms, exploratory work can absolutely include:
+- **planner-style scoping** of a review surface,
+- **evaluator-style judgment** of coverage, artifacts, or review quality,
+- and even **generator-style output** when the output is an exploratory artifact rather than a delivered product change.
+
+What makes the work exploratory is not the role name.
+What makes it exploratory is that it is **not directly delivering the product change**.
+
+## 3) Human Feedback Loop
+
+A lot of loop talk accidentally removes the human except as a final approver.
+That is too weak.
+
+The Human Feedback Loop should be first-class.
+
+Its job is to inject:
+- approval,
+- correction,
+- judgment,
+- taste,
+- reprioritisation,
+- missing context,
+- or strategic redirection.
+
+Without this loop, the human falls out of the operating model.
+Then teams start claiming the human is "in the loop" when the human is really only around to react to surprises.
+
+## 4) Scoped Blocking
+
+Once you accept that there are multiple loops, blocker handling has to get sharper too.
+
+A human question, missing dependency, or unresolved approval should not automatically freeze everything.
+
+That is why VibeGov needs **scoped blocking**.
+
+Scoped blocking means:
+- pause the exact lane that truly needs the answer,
+- keep unrelated build work moving,
+- keep unrelated exploratory work moving,
+- and make the blocked boundary explicit.
+
+This is stronger than simply saying "blockers should redirect work."
+It explains **which work should pause and which should continue**.
+
+## Why this matters
+
+Without this model, teams drift into four bad habits:
+
+- treating all agent work as one vague loop,
+- letting build recursively invent new work for itself,
+- turning human-in-the-loop into stop-the-world behavior,
+- or misclassifying exploratory planner/evaluator work as delivery.
+
+The result is usually motion without clean governance.
+
+## Diagram
+
+### Loop system view
+
+```mermaid
+flowchart LR
+    subgraph CORE["Governed Core"]
+        REPO["Repo / Code"]
+        SPECS["Specs / Requirements"]
+        ISSUES["Issues / Backlog"]
+    end
+
+    subgraph BUILD["Build Loop"]
+        DEV["Develop / Validate"]
+        DEPLOY["Deploy / Update Demo"]
+    end
+
+    subgraph EXPLORE["Exploratory Loop"]
+        REVIEW["Explore UI / Specs / Issues"]
+        HYDRATE["Create or Update Governed Work"]
+    end
+
+    subgraph HUMAN["Human Feedback Loop"]
+        HUMANREVIEW["Human Uses Demo"]
+        INTAKE["Bot / Intake"]
+        NORMALISE["Convert Feedback to Proper Issues / Specs"]
+    end
+
+    DEMO["Demo Instance"]
+
+    REPO --> DEV
+    SPECS --> DEV
+    ISSUES --> DEV
+
+    DEV --> REPO
+    DEV --> DEPLOY
+    DEPLOY --> DEMO
+
+    REPO --> REVIEW
+    SPECS --> REVIEW
+    ISSUES --> REVIEW
+    DEMO --> REVIEW
+
+    REVIEW --> HYDRATE
+    HYDRATE --> ISSUES
+    HYDRATE --> SPECS
+
+    DEMO --> HUMANREVIEW
+    HUMANREVIEW --> INTAKE
+    INTAKE --> NORMALISE
+    NORMALISE --> ISSUES
+    NORMALISE --> SPECS
+```
+
+This is the important boundary to notice: build consumes governed work from repo/specs/issues and writes clear outputs back, while exploration and human feedback feed new governed work into the source side.
+
+### Scoped blocking view
+
+```mermaid
+flowchart LR
+    HB["Human decision needed"]
+
+    subgraph BUILD["Build Loop"]
+        B1["Ready build work continues"]
+        B2["Blocked build lane pauses"]
+    end
+
+    subgraph EXPLORE["Exploratory Loop"]
+        E1["Ready exploratory work continues"]
+        E2["Blocked exploratory lane pauses"]
+    end
+
+    HB --> B2
+    HB --> E2
+
+    B1 -. unrelated work keeps moving .-> B1
+    E1 -. unrelated work keeps moving .-> E1
+```
+
+This is the important blocker rule: pause only the lane that truly needs the missing answer. Do not let one unresolved human input freeze every build and exploratory path by default.
+
+With the three-loop model, the system becomes easier to reason about:
+
+- **Build changes reality.**
+- **Exploratory understands reality.**
+- **Human feedback reshapes intent.**
+- **Scoped blocking prevents one unanswered question from freezing the whole system.**
+
+That is a much better operating model than pretending there is just one loop and hoping everyone means the same thing.
+
+## Related reading
+
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
+- [Execution Modes](/docs/execution-modes)
+- [Exploratory Review Mode](/docs/exploratory-review-mode)
+- [Evaluation Pattern](/docs/evaluation-pattern)
+- [Reference Reading](/docs/reference-reading)
+- [Published GOV 02 Workflow](/docs/published/gov-02-workflow)

--- a/docs/build-exploratory-human-feedback-loops.md
+++ b/docs/build-exploratory-human-feedback-loops.md
@@ -15,6 +15,22 @@ A healthy agent-enabled system usually has at least three loops running in paral
 These loops should not be collapsed into one vague idea of "the agent is working."
 They have different jobs, different sources, and different outputs.
 
+## Loop model vs mode model
+
+This page describes **loops**, not operating modes.
+That distinction matters.
+
+- a **loop** tells you where work sits in the wider system and how work enters or leaves it,
+- a **mode** tells you what kind of work you are doing right now and what evidence closes it.
+
+In practice:
+- the **Build Loop** usually runs **Development** work,
+- the **Exploratory Loop** usually runs **Exploration** work,
+- the **Human Feedback Loop** can reshape either one,
+- and the **Evaluation pattern** may appear inside either mode when bounded judgment is needed.
+
+That is why loops and modes should support each other, not compete with each other.
+
 ## 1) Build Loop
 
 The Build Loop is the delivery loop.
@@ -267,8 +283,9 @@ Ask four questions:
 ## Related docs
 
 - [Execution Modes](/docs/execution-modes)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
 - [Evaluation Pattern](/docs/evaluation-pattern)
 - [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
-- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Reference Reading](/docs/reference-reading)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)

--- a/docs/build-exploratory-human-feedback-loops.md
+++ b/docs/build-exploratory-human-feedback-loops.md
@@ -1,0 +1,274 @@
+---
+sidebar_position: 7
+---
+
+# Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking
+
+VibeGov works better when teams stop pretending there is only one loop.
+
+A healthy agent-enabled system usually has at least three loops running in parallel:
+
+- a **Build Loop**,
+- an **Exploratory Loop**,
+- and a **Human Feedback Loop**.
+
+These loops should not be collapsed into one vague idea of "the agent is working."
+They have different jobs, different sources, and different outputs.
+
+## 1) Build Loop
+
+The Build Loop is the delivery loop.
+
+Its job is to consume already-scoped work and turn it into validated outputs.
+
+### Source of truth
+
+The Build Loop should take its input from:
+- the repository,
+- the issue backlog,
+- the bound requirement/spec artifacts,
+- and the active delivery state.
+
+### Outputs
+
+The Build Loop should write back:
+- code changes,
+- doc/spec changes,
+- tests,
+- validation evidence,
+- issue or PR state updates,
+- release-readiness or shipping evidence when relevant.
+
+### Important boundary
+
+The Build Loop should **not** recursively self-source its own next work from its own outputs.
+
+That boundary matters.
+If build starts inventing its own new backlog from its own emissions, it becomes unstable and harder to govern.
+
+Build should be execution-stable:
+- consume scoped work,
+- produce clear outputs,
+- close or advance the work item,
+- continue to the next governed item.
+
+## 2) Exploratory Loop
+
+The Exploratory Loop is the non-delivery intelligence loop.
+
+Its job is to inspect reality, judge coverage, discover drift, and feed governed work into delivery.
+
+### What counts as exploratory work
+
+Exploration is not only free-roaming inspection.
+In VibeGov terms, it can include planner and evaluator behavior when the goal is non-delivery discovery.
+
+Typical exploratory activity includes:
+- UI exploration,
+- workflow or route review,
+- spec exploration,
+- issue exploration,
+- drift detection,
+- gap analysis,
+- backlog hydration,
+- review/report generation,
+- planner-style scoping of a review surface,
+- evaluator-style judgment of exploratory artifacts or coverage.
+
+So exploratory may involve:
+- **planner roles** to choose or shape the review slice,
+- **evaluator roles** to judge completeness, quality, or coverage,
+- and sometimes **generator roles** to produce reports, inventories, or proposed follow-up artifacts.
+
+What makes it exploratory is not the agent role name.
+What makes it exploratory is that the work is **not directly delivering the product change**.
+
+### Outputs
+
+The Exploratory Loop should write back:
+- findings,
+- classifications,
+- issue creation or linking,
+- spec links or `SPEC_GAP` markers,
+- coverage or confidence notes,
+- scoped recommendations for delivery.
+
+## 3) Human Feedback Loop
+
+The Human Feedback Loop brings judgment, correction, taste, approval, and reprioritisation back into the system.
+
+This loop exists so the human does not fall out of the operating model.
+
+### Typical human-feedback inputs
+
+- approval or rejection,
+- correction of framing or scope,
+- prioritisation changes,
+- taste or quality direction,
+- missing context,
+- product judgment,
+- strategic redirection,
+- explicit blocking or go-ahead.
+
+### Outputs
+
+The Human Feedback Loop should feed back into the system by:
+- changing backlog priority,
+- narrowing or broadening scope,
+- creating or reshaping governed work,
+- changing acceptance criteria,
+- or explicitly blocking/unblocking a specific path.
+
+## 4) Scoped Blocking
+
+Human feedback should not become a global stop-the-world gate by default.
+
+That is where **scoped blocking** matters.
+
+### Scoped blocking means
+
+- only the work that truly requires human input should pause,
+- unrelated build work can continue,
+- unrelated exploratory work can continue,
+- and the system should make the blocked boundary explicit.
+
+### Examples
+
+#### Good scoped blocking
+- "Do not ship this PR until human approval is given."
+- "Pause this design direction until the user chooses option A or B."
+- "Do not merge the release candidate until the blocker issue is resolved."
+
+#### Bad global blocking
+- "A question was asked somewhere, so all progress stops."
+- "The human has not replied yet, so no loop may continue."
+- "One route is blocked, therefore the full exploratory pass stops."
+
+## How the loops relate
+
+### Build Loop
+- consumes governed scoped work
+- changes reality
+- produces delivery artifacts
+
+### Exploratory Loop
+- inspects reality
+- finds gaps and uncovered work
+- feeds governed work into backlog/specs
+
+### Human Feedback Loop
+- reshapes intent, priority, judgment, and approval state
+- feeds corrections and decisions into build and exploration
+
+## A practical model
+
+A healthy project can look like this:
+
+- **Build Loop** continues on ready issue-bound work from the repo/backlog.
+- **Exploratory Loop** reviews UI, specs, and issues, and keeps adding focused follow-up work.
+- **Human Feedback Loop** injects approval, correction, redirection, and new scope where needed.
+- **Scoped blocking** pauses only the exact lane that truly needs a human decision.
+
+That gives you:
+- delivery momentum,
+- continuous backlog hydration,
+- and real human-in-the-loop governance without freezing everything.
+
+## Diagram
+
+### Loop system view
+
+```mermaid
+flowchart LR
+    subgraph CORE["Governed Core"]
+        REPO["Repo / Code"]
+        SPECS["Specs / Requirements"]
+        ISSUES["Issues / Backlog"]
+    end
+
+    subgraph BUILD["Build Loop"]
+        DEV["Develop / Validate"]
+        DEPLOY["Deploy / Update Demo"]
+    end
+
+    subgraph EXPLORE["Exploratory Loop"]
+        REVIEW["Explore UI / Specs / Issues"]
+        HYDRATE["Create or Update Governed Work"]
+    end
+
+    subgraph HUMAN["Human Feedback Loop"]
+        HUMANREVIEW["Human Uses Demo"]
+        INTAKE["Bot / Intake"]
+        NORMALISE["Convert Feedback to Proper Issues / Specs"]
+    end
+
+    DEMO["Demo Instance"]
+
+    REPO --> DEV
+    SPECS --> DEV
+    ISSUES --> DEV
+
+    DEV --> REPO
+    DEV --> DEPLOY
+    DEPLOY --> DEMO
+
+    REPO --> REVIEW
+    SPECS --> REVIEW
+    ISSUES --> REVIEW
+    DEMO --> REVIEW
+
+    REVIEW --> HYDRATE
+    HYDRATE --> ISSUES
+    HYDRATE --> SPECS
+
+    DEMO --> HUMANREVIEW
+    HUMANREVIEW --> INTAKE
+    INTAKE --> NORMALISE
+    NORMALISE --> ISSUES
+    NORMALISE --> SPECS
+```
+
+Key rule: the Build Loop consumes governed work from the repo, specs, and issues, but new work should usually be fed into that source side by Exploration and Human Feedback rather than by build recursively inventing its own backlog.
+
+### Scoped blocking view
+
+```mermaid
+flowchart LR
+    HB["Human decision needed"]
+
+    subgraph BUILD["Build Loop"]
+        B1["Ready build work continues"]
+        B2["Blocked build lane pauses"]
+    end
+
+    subgraph EXPLORE["Exploratory Loop"]
+        E1["Ready exploratory work continues"]
+        E2["Blocked exploratory lane pauses"]
+    end
+
+    HB --> B2
+    HB --> E2
+
+    B1 -. unrelated work keeps moving .-> B1
+    E1 -. unrelated work keeps moving .-> E1
+```
+
+This is the important blocker rule: pause only the lane that truly needs the missing answer. Do not let one unresolved human input freeze every build and exploratory path by default.
+
+## Fast rule
+
+Ask four questions:
+
+1. Am I consuming governed work and changing reality? → **Build Loop**
+2. Am I reviewing reality and feeding new governed work? → **Exploratory Loop**
+3. Am I injecting human judgment, approval, or reprioritisation? → **Human Feedback Loop**
+4. Does this input block everything, or only one specific lane? → apply **Scoped Blocking**
+
+## Related docs
+
+- [Execution Modes](/docs/execution-modes)
+- [Exploratory Review Mode](/docs/exploratory-review-mode)
+- [Evaluation Pattern](/docs/evaluation-pattern)
+- [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)

--- a/docs/evaluation-pattern.md
+++ b/docs/evaluation-pattern.md
@@ -44,11 +44,13 @@ VibeGov has two primary operating modes:
 Evaluation fits **inside** one of those modes when bounded judgment is useful.
 
 Examples:
-- in **Exploration**, an evaluator may judge whether a route report is artifact-complete
+- in **Exploration**, an evaluator may judge whether a route report is artifact-complete, whether a review surface was covered adequately, or whether a backlog-hydration pass met its contract
 - in **Development**, an evaluator may judge whether an implementation result meets quality criteria
 - in **release verification**, an evaluator may help apply go/no-go criteria to a candidate inside Development
 
 That makes evaluation a **control pattern**, not a separate top-level lane.
+
+In other words: exploratory work may use evaluator behavior heavily without ceasing to be exploratory.
 
 ## Evaluation requires an explicit contract
 
@@ -115,6 +117,7 @@ Ask:
 
 ## Related docs
 
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
 - [Execution Modes](/docs/execution-modes)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -11,7 +11,7 @@ A review pass and a delivery pass are not interchangeable. They need different o
 ## The two operating modes
 
 ### 1) Exploration mode
-Use Exploration mode when the goal is discovery.
+Use Exploration mode when the goal is discovery, review, judgment, or backlog hydration on non-delivery surfaces.
 
 Typical use-cases:
 - route/page review
@@ -19,6 +19,10 @@ Typical use-cases:
 - end-user validation
 - backlog hydration
 - drift detection
+- UI/spec/issue exploration
+- exploratory report generation
+- planner-style scoping of a review surface
+- evaluator-style judgment of exploratory artifacts or coverage
 
 Expected outputs:
 - scenario classifications
@@ -26,6 +30,7 @@ Expected outputs:
 - focused issues
 - spec links or `SPEC_GAP`
 - planned traceability/test follow-up
+- coverage/confidence notes
 
 What not to do:
 - claim a fix was delivered
@@ -59,6 +64,8 @@ What not to do:
 ## Evaluation lives inside a mode
 
 Evaluation is not a third peer mode either. It is a bounded judgment pattern used inside Exploration or Development when explicit criteria-based review is needed.
+
+In practice, exploratory work will often use planner and evaluator roles heavily. That does not make evaluation a separate mode. It means Exploration can contain planning and judgment activity when the work is still non-delivery discovery.
 
 Typical evaluation work includes:
 - judging a bounded artifact against a rubric
@@ -120,6 +127,7 @@ That answer should determine the mode.
 
 ## Related docs
 
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
 - [Quick Decisions](/docs/quick-decisions)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Evaluation Pattern](/docs/evaluation-pattern)

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -63,7 +63,7 @@ What not to do:
 
 ## Evaluation lives inside a mode
 
-Evaluation is not a third peer mode either. It is a bounded judgment pattern used inside Exploration or Development when explicit criteria-based review is needed.
+Evaluation is not a third peer mode. It is a bounded judgment pattern used inside Exploration or Development when explicit criteria-based review is needed.
 
 In practice, exploratory work will often use planner and evaluator roles heavily. That does not make evaluation a separate mode. It means Exploration can contain planning and judgment activity when the work is still non-delivery discovery.
 
@@ -80,6 +80,11 @@ What evaluation does **not** mean:
 ## Release verification lives inside Development
 
 Release verification is not a third peer mode. It is part of Development's delivery path.
+
+This is also where loops and modes meet cleanly:
+- release verification usually sits inside the **Build Loop**,
+- exploratory review usually sits inside the **Exploratory Loop**,
+- and human feedback can reshape either one without becoming a separate execution mode.
 
 Typical release-verification work includes:
 - confirming the build succeeded

--- a/docs/exploratory-review-mode.md
+++ b/docs/exploratory-review-mode.md
@@ -11,6 +11,8 @@ It does not replace your normal delivery lifecycle.
 - **Development flow** changes behavior and carries it through release readiness.
 - **Exploratory flow** audits real behavior and turns gaps into tracked work.
 
+In VibeGov terms, exploratory work is the broader non-delivery intelligence lane. That means it can include planner and evaluator behavior when the work is aimed at UI/spec/issue exploration, coverage judgment, review quality, and backlog hydration rather than direct product delivery.
+
 ## Why run it in parallel
 
 Running exploratory review in parallel helps teams:
@@ -99,9 +101,13 @@ Use it when the goal is:
 - discovery,
 - audit,
 - backlog hydration,
-- end-user validation.
+- end-user validation,
+- UI/spec/issue exploration,
+- exploratory judgment of coverage or report completeness.
 
 Do **not** treat exploration as Development by default.
+
+Planner/evaluator roles may live inside Exploration when they support non-delivery discovery.
 
 Move to build/fix mode only when explicitly requested or when your workflow has formally switched into Development.
 
@@ -129,6 +135,7 @@ Over time, this mode helps teams:
 
 ## Next reads
 
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
 - [Execution Modes](/docs/execution-modes)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Blocker Escalation](/docs/blocker-escalation)

--- a/docs/mode-selection-and-evidence-closing.md
+++ b/docs/mode-selection-and-evidence-closing.md
@@ -26,7 +26,22 @@ Fast rule:
 - **Evaluation** judges a bounded unit.
 - **Release verification** closes a Development-ready candidate.
 
-## 2. Do not let evidence shapes drift
+## 2. Work shape is not the same thing as loop placement
+
+A lot of confusion disappears once these are kept separate.
+
+- **mode / work shape** answers: what kind of work is this, and what evidence closes it?
+- **loop placement** answers: where does this work sit in the wider operating system?
+
+Typical mapping:
+- **Build Loop** mostly contains **Development** work
+- **Exploratory Loop** mostly contains **Exploration** work
+- **Human Feedback Loop** injects judgment, approval, correction, and reprioritisation into either one
+- **Evaluation** may be used inside any of those when a bounded verdict is needed
+
+So if you are unsure, choose the **mode** first, then describe the surrounding **loop** second.
+
+## 3. Do not let evidence shapes drift
 
 | If you are doing this... | You need this evidence shape |
 | --- | --- |
@@ -40,7 +55,7 @@ Anti-rule:
 - development diff/test proof does **not** replace release-readiness evidence
 - a blocker claim without a blocker artifact is not closure
 
-## 3. Minimum evidence by work shape
+## 4. Minimum evidence by work shape
 
 ### Exploration
 Use when the goal is discovery.
@@ -89,7 +104,7 @@ Minimum closure:
 - blocker artifact
 - redirected next work or recovery condition
 
-## 4. Which checkpoint/report shape should I use?
+## 5. Which checkpoint/report shape should I use?
 
 | Situation | Report shape |
 | --- | --- |
@@ -101,7 +116,7 @@ Minimum closure:
 Fast rule:
 - choose the checkpoint shape that matches the work, not the one that sounds most impressive.
 
-## 5. Where evaluation fits
+## 6. Where evaluation fits
 
 Evaluation is useful when the work needs a skeptical or criteria-based judgment.
 
@@ -115,7 +130,7 @@ What evaluation is **not**:
 - not a substitute for Development proof when behavior changed
 - not a free-floating third operating mode
 
-## 6. Common mode-mixing failures
+## 7. Common mode-mixing failures
 
 Avoid these:
 - exploratory findings presented as if they prove a fix shipped
@@ -125,7 +140,7 @@ Avoid these:
 - evaluation language used to hide missing scope or missing evidence
 - a vague "done" that collapses implemented, verified, reviewed, and released into one word
 
-## 7. The 20-second selection rule
+## 8. The 20-second selection rule
 
 Before starting or reporting, ask:
 
@@ -140,9 +155,11 @@ If the answers are blurry, the mode is probably blurry too.
 
 - [Quick Decisions](/docs/quick-decisions)
 - [Execution Modes](/docs/execution-modes)
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
 - [Evaluation Pattern](/docs/evaluation-pattern)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
+- [Reference Reading](/docs/reference-reading)
 - [The VibeGov SDLC](/docs/vibegov-sdlc)
 - [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
 - [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)

--- a/docs/mode-selection-and-evidence-closing.md
+++ b/docs/mode-selection-and-evidence-closing.md
@@ -76,6 +76,9 @@ Minimum closure:
 - blockers/risks recorded explicitly
 - go / no-go / conditional decision
 
+Version-label guidance:
+- when naming the reviewed candidate, prefer the canonical format `yyyy.m.d-<shortsha>` by default so the artifact is both human-readable and commit-traceable.
+
 ### Blocker checkpoint
 Use when work cannot meaningfully advance.
 

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -123,7 +123,7 @@ This section governs work structure, not implementation details. It does not pre
 
 > Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
 
-## Execution Modes
+## Execution Modes and Parallel Loops
 
 All meaningful work must declare an active execution mode. Silent mode mixing produces weak evidence and false completion claims.
 
@@ -133,16 +133,29 @@ VibeGov uses two operating modes:
 
 Release verification is not a third peer mode. It is part of Development's delivery path and release-readiness checks.
 
-> Commentary: Defines the allowed delivery postures so evidence and completion standards match the work being performed.
+These modes often run inside a broader parallel loop model:
+- a **Build Loop** that consumes governed scoped work from the repo/backlog and writes clear delivery outputs back,
+- an **Exploratory Loop** that inspects UI/spec/issue reality and feeds governed backlog/spec work into delivery,
+- and a **Human Feedback Loop** that injects approval, correction, judgment, taste, and reprioritisation.
+
+The Build Loop must not recursively self-source its own next work from its own outputs. It should consume governed input and produce governed output.
+
+Exploratory work is the non-delivery discovery/analysis lane. It may include planner-style scoping and evaluator-style judgment when those roles are being used to explore, review, classify, and hydrate backlog work rather than deliver the product change itself.
+
+Human feedback should be first-class, but not automatically global. When human input is needed, the system should prefer scoped blocking over stop-the-world blocking whenever unrelated ready work can continue.
+
+> Commentary: Defines the allowed delivery postures so evidence and completion standards match the work being performed, while clarifying how build, exploratory, and human-feedback loops coexist.
 
 ### Exploration mode
 
-Use when the objective is discovery, validation, or backlog hydration rather than immediate product change.
+Use when the objective is discovery, validation, review, judgment, or backlog hydration rather than immediate product change.
 
 Allowed work:
 - inspect live behavior from an end-user or operator perspective
 - compare observed behavior with specs, traceability, and existing test intent
 - create or refine backlog items, spec gaps, and planned verification follow-up
+- perform planner-style scoping of a review surface, route set, issue set, or analysis slice
+- perform evaluator-style judgment of exploratory artifacts, coverage, or review completeness
 
 Required evidence:
 - reviewed scope and scenarios exercised
@@ -150,8 +163,9 @@ Required evidence:
 - per-scenario classification: `Validated`, `Invalidated`, `Blocked`, or `Uncovered-spec-gap`
 - tracked follow-up artifacts for every invalidated, blocked, or uncovered item
 - next recommended backlog action
+- coverage or confidence limits when relevant
 
-> Commentary: Captures a specific delivery control so contributors and agents apply this rule consistently.
+> Commentary: Clarifies that exploratory work can contain planner/evaluator behavior when the goal is non-delivery discovery rather than implementation.
 
 ### Development mode
 
@@ -211,7 +225,7 @@ Backlog hydration is part of the core workflow, not a side activity.
 
 > Commentary: Treats discovery as a required planning input instead of informal side notes.
 
-## Blocker Escalation and Move-On Behavior
+## Scoped Blocking, Blocker Escalation, and Move-On Behavior
 
 Autonomy is expected, not unrestricted.
 
@@ -230,7 +244,13 @@ When blocked:
 
 A blocker pauses the current item. It does not pause delivery unless it removes all viable next work or requires a human decision.
 
-> Commentary: Keeps delivery moving by turning blockers into tracked decisions instead of stalled work.
+Prefer scoped blocking over global blocking:
+- only the lane that truly requires the missing approval, decision, or dependency should pause,
+- unrelated build work may continue,
+- unrelated exploratory work may continue,
+- and the blocked boundary should be made explicit in checkpoints or handoffs.
+
+> Commentary: Keeps delivery moving by turning blockers into tracked decisions instead of stalled work, and prevents one unanswered question from freezing all other loops.
 
 ## Scope Discipline
 

--- a/docs/published/gov-10-agent-state-closure-git-hygiene.md
+++ b/docs/published/gov-10-agent-state-closure-git-hygiene.md
@@ -19,62 +19,94 @@ Governed repositories should treat repository state as a control surface for age
 
 ## Core Principle
 
-- `GOV-10-GIT-001` Every substantive work unit must end with full working-tree accounting.
-- `GOV-10-GIT-002` Agents must not carry ambiguous repository state into the next work unit.
+- `GOV-10-GIT-001` Every substantive turn or work unit must end with full working-tree accounting.
+- `GOV-10-GIT-002` Agents must not carry ambiguous repository state into the next substantive turn or work unit.
 - `GOV-10-GIT-003` Repository cleanliness is not cosmetic. It is part of execution correctness.
+- `GOV-10-GIT-004` Git hygiene is mandatory, not optional polish.
+- `GOV-10-GIT-005` New governed work must not begin unless the local repo is on `develop`, except for an explicitly documented recovery or escalation exception.
 
-> Commentary: Defines the baseline expectation that repo state must be intentional before work can honestly move on.
+> Commentary: Defines repo-state closure as a hard requirement and makes `develop` the mandatory starting base for normal governed work.
+
+## What Counts as a Substantive Turn
+
+- `GOV-10-GIT-006` A substantive turn is any execution turn that leaves durable repo or issue state behind, changes the governed state of a ticket, or would create carry-over risk if left unresolved.
+- `GOV-10-GIT-007` This includes changing code, docs, specs, tests, config, workflows, issue metadata, branch state, or validation state in a way that affects execution, review, or closure.
+- `GOV-10-GIT-008` This also includes decisions or checks that materially change ticket status, for example moving work into blocked, validated, follow-up-required, or merge-ready state.
+- `GOV-10-GIT-009` Pure discussion, reading, or ephemeral probing with no kept repo or ticket state is not a substantive turn.
+- `GOV-10-GIT-010` If a turn produced kept changes, changed ticket state, or would be risky to leave dirty, treat it as substantive.
+
+> Commentary: Gives a practical test for when closure rules must fire, instead of leaving "substantive" vague.
+
+## Start-of-Work Preconditions
+
+- `GOV-10-GIT-011` Before starting a new governed slice, the agent must verify the local repo is on `develop`.
+- `GOV-10-GIT-012` If the repo is not on `develop`, the agent must not begin new work until the state is normalized or an explicit recovery/escalation note justifies the exception.
+- `GOV-10-GIT-013` Starting new governed work from an issue branch, archived branch, detached state, or another non-`develop` branch without explicit justification is non-compliant.
+- `GOV-10-GIT-014` This precondition exists to stop branch drift, hidden carry-over, and accidental continuation from the wrong base state.
+- `GOV-10-GIT-014A` Start-of-work hygiene must include an explicit assessment of the inherited repo state before new governed work begins.
+- `GOV-10-GIT-014B` The agent must classify inherited state, including branch position, modified files, untracked files, partial slices, and unmerged work, and decide what should be landed, deferred, archived, followed up, or escalated.
+- `GOV-10-GIT-014C` If the inherited state is mixed, unclear, or not safely attributable, the agent must not begin a new governed slice until treatment is chosen and recorded.
+
+> Commentary: This turns branch position into a start gate, and it also requires a deliberate inherited-state assessment before any new slice begins.
 
 ## Working-Tree Accounting
 
-- `GOV-10-GIT-004` Before a work unit is considered complete, blocked, deferred, or handed off, every modified, deleted, and untracked file in scope must be classified.
-- `GOV-10-GIT-005` Allowed classifications are:
+- `GOV-10-GIT-015` Before a substantive turn or work unit is considered complete, blocked, deferred, or handed off, every modified, deleted, and untracked file in scope must be classified.
+- `GOV-10-GIT-016` Allowed classifications are:
   - committed as intended governed change,
   - reverted because it is junk, noise, or failed experimentation,
   - ignored through an explicit ignore rule when the file is generated or intentionally untracked,
-  - intentionally deferred with an explicit note that names the file, reason, and next follow-up path.
-- `GOV-10-GIT-006` "I think this file is probably from earlier work" is not sufficient accounting.
-- `GOV-10-GIT-007` If a file cannot be explained, the work unit is not yet closed.
+  - intentionally deferred only when an explicit follow-up ticket or bounded follow-up path is recorded.
+- `GOV-10-GIT-017` Intentional deferral notes must name the file or branch, the reason it remains open, and the exact follow-up issue or path that will close it.
+- `GOV-10-GIT-018` "I think this file is probably from earlier work" is not sufficient accounting.
+- `GOV-10-GIT-019` If a file cannot be explained, the substantive turn or work unit is not yet closed.
 
 > Commentary: Forces explicit file-by-file accounting so previous-turn residue cannot silently contaminate later work.
 
 ## Dirty-Tree Discipline
 
-- `GOV-10-GIT-008` Agents must treat unresolved dirty state as actionable repository state, not passive background context.
-- `GOV-10-GIT-009` In single-actor repos or isolated worktrees, unresolved dirty state should be presumed agent-caused until proven otherwise.
-- `GOV-10-GIT-010` Reporting "tree is dirty" without classification, resolution intent, or follow-up path is non-compliant.
-- `GOV-10-GIT-011` If prior residue is discovered while starting new work, the agent should either resolve it first or explicitly escalate why safe resolution cannot happen yet.
+- `GOV-10-GIT-020` Agents must treat unresolved dirty state as actionable repository state, not passive background context.
+- `GOV-10-GIT-021` In single-actor repos or isolated worktrees, unresolved dirty state should be presumed agent-caused until proven otherwise.
+- `GOV-10-GIT-022` Reporting "tree is dirty" without classification, resolution intent, or follow-up path is non-compliant.
+- `GOV-10-GIT-023` If prior residue is discovered while starting new work, the agent should either resolve it first or explicitly escalate why safe resolution cannot happen yet.
 
 > Commentary: Prevents the common failure mode where agents report dirty state but leave the human to reason about it.
 
 ## Commit and Ignore Hygiene
 
-- `GOV-10-GIT-012` Durable kept changes should normally be committed before the work unit ends so the intended state has a real tracking boundary.
-- `GOV-10-GIT-013` Commits should be cohesive, reviewable, and limited to the intended governed change.
-- `GOV-10-GIT-014` Generated or environment-specific noise that should persist locally but not be tracked must be handled through explicit ignore rules rather than repeated manual omission.
-- `GOV-10-GIT-015` Ignore rules should be as narrow as practical so legitimate changes are not accidentally hidden.
+- `GOV-10-GIT-024` Durable kept changes must be committed by the end of each substantive turn so the intended state has a real tracking boundary.
+- `GOV-10-GIT-025` Commits should be cohesive, reviewable, and limited to the intended governed change.
+- `GOV-10-GIT-026` Generated or environment-specific noise that should persist locally but not be tracked must be handled through explicit ignore rules rather than repeated manual omission.
+- `GOV-10-GIT-027` Ignore rules should be as narrow as practical so legitimate changes are not accidentally hidden.
 
-> Commentary: Keeps git history meaningful while preventing recurring local noise from leaking across work units.
+> Commentary: Keeps git history meaningful while making turn-end commitment mandatory for kept state.
 
 ## Preserve Before Destructive Change
 
-- `GOV-10-GIT-016` Meaningful state includes kept code, docs, specs, notes, captured investigation output, and generated artifacts that are intentionally being preserved as evidence or deliverable state.
-- `GOV-10-GIT-017` Disposable cache, build output, or other reproducible noise is not meaningful state unless the current work unit explicitly depends on it as evidence or deliverable content.
-- `GOV-10-GIT-018` Before deleting, overwriting, archiving, or otherwise destructively changing meaningful state, the agent should preserve that state in a traceable form when safe to do so, normally through a commit or another durable governed artifact.
-- `GOV-10-GIT-019` If material is secret, unsafe, or otherwise inappropriate to preserve in normal history, the agent should use a separate safe-handling path and record the exception explicitly instead of silently discarding context.
-- `GOV-10-GIT-020` Cleanup, rollback, and archival actions must not silently erase why a change existed, what was learned, or what state is being retired.
-- `GOV-10-GIT-021` If old behavior or prior content needs to return, it should come back through a new traceable change rather than hidden history surgery or convenience-driven destructive rollback.
-- `GOV-10-GIT-022` This preservation rule does not require noisy micro-commits for trivial or disposable edits, but it does require a deliberate preservation boundary before meaningful destructive change.
+- `GOV-10-GIT-028` Meaningful state includes kept code, docs, specs, notes, captured investigation output, and generated artifacts that are intentionally being preserved as evidence or deliverable state.
+- `GOV-10-GIT-029` Disposable cache, build output, or other reproducible noise is not meaningful state unless the current work unit explicitly depends on it as evidence or deliverable content.
+- `GOV-10-GIT-030` Before deleting, overwriting, archiving, or otherwise destructively changing meaningful state, the agent must preserve that state in a traceable form when safe to do so, normally through a commit or another durable governed artifact.
+- `GOV-10-GIT-031` If material is secret, unsafe, or otherwise inappropriate to preserve in normal history, the agent should use a separate safe-handling path and record the exception explicitly instead of silently discarding context.
+- `GOV-10-GIT-031A` Resetting, hard cleanup, deletion, or destructive overwrite of inherited state is a last resort, not a default cleanup move.
+- `GOV-10-GIT-031B` When the state may be meaningful, destructive normalization should happen only after discussion or explicit approval, unless the material is already classified as disposable generated noise.
+- `GOV-10-GIT-031C` Default preference is to assess, classify, preserve, land, archive, defer with follow-up, or escalate before considering destructive cleanup.
+- `GOV-10-GIT-032` Cleanup, rollback, and archival actions must not silently erase why a change existed, what was learned, or what state is being retired.
+- `GOV-10-GIT-033` If old behavior or prior content needs to return, it should come back through a new traceable change rather than hidden history surgery or convenience-driven destructive rollback.
+- `GOV-10-GIT-034` This preservation rule does not require noisy micro-commits for trivial or disposable edits, but it does require a deliberate preservation boundary before meaningful destructive change.
 
-> Commentary: Makes destructive actions reviewable and recoverable by requiring preservation before erasure, while keeping safe exceptions and disposable noise separate.
+> Commentary: Makes destructive actions reviewable and recoverable by requiring preservation before erasure, and it explicitly rejects reset/delete as the default answer to inherited mixed state.
 
 ## Completion and Handoff Rules
 
-- `GOV-10-GIT-023` Completion claims are invalid if the repository state that remains is unexplained.
-- `GOV-10-GIT-024` A blocked or deferred work unit must still leave the repository in a classified state, even when implementation is incomplete.
-- `GOV-10-GIT-025` Handoff artifacts should state any intentionally deferred files or branches explicitly rather than relying on a future reader to infer them from git status.
+- `GOV-10-GIT-035` Completion claims are invalid if the repository state that remains is unexplained.
+- `GOV-10-GIT-036` A blocked or deferred substantive turn or work unit must still leave the repository in a classified state, even when implementation is incomplete.
+- `GOV-10-GIT-037` If the intended work is not actually complete by turn end, a focused follow-up ticket must be created rather than carrying unresolved branch or dirty-state ambiguity forward.
+- `GOV-10-GIT-038` A slice is not closed until the original ticket is merged into `develop`.
+- `GOV-10-GIT-039` After closure, the branch where the work was done must be archived under an `archive/`-prefixed branch name.
+- `GOV-10-GIT-040` After merge and archival, the local working repo should be returned to `develop`.
+- `GOV-10-GIT-041` Handoff artifacts should state any intentionally deferred files, branches, or follow-up tickets explicitly rather than relying on a future reader to infer them from git status.
 
-> Commentary: Extends state-closure discipline beyond successful completion into blockers, deferrals, and handoffs.
+> Commentary: Turns closure into a concrete end-state: committed, merged into `develop`, archived, and back on `develop`, with follow-up tickets when needed.
 
 ## Anti-Patterns
 
@@ -83,8 +115,14 @@ Avoid these failure modes:
 - deleting or overwriting meaningful state before it has a traceable preservation boundary
 - treating untracked temp files as harmless background clutter
 - leaving generated noise unignored across repeated runs
-- carrying mixed unrelated diffs across work units
+- carrying mixed unrelated diffs across substantive turns or work units
+- starting new governed work from a non-`develop` branch without explicit exception handling
+- skipping inherited-state assessment and just pushing ahead on top of mixed residue
+- auto-resetting, deleting, or force-cleaning inherited state to feel clean without first classifying it
 - using dirty state as a substitute for real tracking
+- marking a slice done before the original ticket is merged into `develop`
+- archiving a work branch without first closing the governed landing path
+- failing to create a follow-up ticket when the current turn cannot honestly close the slice
 - using cleanup, archival, or rollback to erase rationale instead of preserving it
 
 > Commentary: Names the residue patterns this rule is designed to eliminate.

--- a/docs/quick-decisions.md
+++ b/docs/quick-decisions.md
@@ -203,8 +203,10 @@ Fast rule:
 
 - [Execution Modes](/docs/execution-modes)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
 - [Evaluation Pattern](/docs/evaluation-pattern)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
+- [Reference Reading](/docs/reference-reading)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Blocker Escalation](/docs/blocker-escalation)
 - [Workflow Quality Rubric](/docs/workflow-quality-rubric)

--- a/docs/quick-decisions.md
+++ b/docs/quick-decisions.md
@@ -105,7 +105,67 @@ Fast rule:
 - cleanup should not erase rationale
 - archive after safe landing, not instead of it
 
-## 9. Should this become a rule, or just a note?
+## 9. What exactly makes a turn substantive?
+
+| If the turn... | Treat it as... |
+| --- | --- |
+| leaves kept repo or issue state behind | **substantive** |
+| changes code, docs, specs, tests, config, workflows, or issue metadata | **substantive** |
+| changes ticket status, closure state, validation state, or branch state | **substantive** |
+| would be risky to leave dirty for the next turn | **substantive** |
+| is only discussion, reading, or ephemeral probing with no kept state | **not substantive** |
+
+Fast rule:
+- if it changed durable state or ticket state, it was substantive
+- if it would be dangerous to leave dirty, it was substantive
+- substantive turns require git closure, not just a chat checkpoint
+
+## 10. What closes git hygiene for a substantive turn?
+
+| Required end-state | Why it matters |
+| --- | --- |
+| kept work committed | creates a real tracking boundary |
+| unresolved junk reverted or ignored explicitly | prevents residue from leaking forward |
+| if not finished, a focused follow-up ticket exists | prevents ambiguous carry-over |
+| original ticket merged into `develop` | closes the governed landing path |
+| working branch archived as `archive/<branch>` | preserves branch history cleanly |
+| local repo returned to `develop` | resets the next execution starting point |
+
+Fast rule:
+- git hygiene is mandatory
+- done means committed, merged to `develop`, archived, and back on `develop`
+- not done means follow-up ticket, not ambiguity
+
+## 11. What must be true before new governed work starts?
+
+| Start condition | Default rule |
+| --- | --- |
+| local repo is on `develop` | **start is allowed** |
+| local repo is on an issue branch, archive branch, or detached state | **do not start new work** |
+| repo is off `develop` because of recovery/debug/escalation work | **only proceed with explicit exception note** |
+| branch state is unclear | **stop and normalize first** |
+
+Fast rule:
+- normal governed work starts from `develop`
+- if you are not on `develop`, you are not ready to start
+- exceptions must be explicit, not implied
+
+## 12. What if I inherit repo state when I start?
+
+| Situation | Default choice |
+| --- | --- |
+| there are modified/untracked files or branch residue | **assess and classify it before new work** |
+| the inherited state is clear and attributable | **decide whether to land, defer, archive, or follow up** |
+| the inherited state is mixed or unclear | **stop and escalate before starting a new slice** |
+| you are tempted to reset/delete just to get clean | **do not do that by default** |
+| the material is clearly disposable generated noise | **clean it up directly if that classification is explicit** |
+
+Fast rule:
+- inherited state must be assessed, not ignored
+- preserve, land, archive, defer, or escalate before destructive cleanup
+- reset/delete is last resort after discussion unless it is obvious generated noise
+
+## 13. Should this become a rule, or just a note?
 
 | If the learning is... | Put it in... |
 | --- | --- |
@@ -117,7 +177,7 @@ Fast rule:
 - not every lesson deserves a rule
 - repeated durable failures usually do
 
-## 10. What are the most common failure modes?
+## 14. What are the most common failure modes?
 
 - exploratory findings with no artifacts
 - development claims with no direct proof
@@ -127,6 +187,8 @@ Fast rule:
 - treating chat memory as durable state
 - deleting meaningful state before preserving it
 - archiving a branch as a substitute for landing traceable work
+- skipping inherited-state assessment and starting anyway
+- force-cleaning or deleting inherited state before deciding what it is
 - promoting every tiny preference into bloated governance
 
 ## Start here if you are unsure

--- a/docs/reference-reading.md
+++ b/docs/reference-reading.md
@@ -1,0 +1,320 @@
+---
+sidebar_position: 1
+---
+
+# Reference Reading
+
+This page collects external reading that materially shaped or sharpened VibeGov thinking.
+
+These are **references, not canonical rules**.
+The VibeGov canon remains the governance docs and published GOV pages in this repo.
+
+Use this page for three things:
+- track important outside ideas worth revisiting,
+- record what is genuinely useful,
+- make clear what VibeGov should borrow, adapt, or reject.
+
+## Current reading set
+
+| Source | Main contribution | Best VibeGov use |
+| --- | --- | --- |
+| [Geoffrey Huntley, *Ralph*](https://ghuntley.com/ralph/) | memorable articulation of looped agentic execution and the surrounding discussion that pushed these patterns into wider view | origin point and comparison baseline for loop-centered agent operating models |
+| [Mitchell Hashimoto, *My AI Adoption Journey*](https://mitchellh.com/writing/my-ai-adoption-journey#step-6-always-have-an-agent-running) | practical adoption path from chatbot use to harnessed background agents | useful operator framing for continuous delegated work |
+| [OpenAI, *Harness engineering: leveraging Codex in an agent-first world*](https://openai.com/index/harness-engineering/) | repo-first, harness-first delivery system for agent software work | strong evidence for in-repo truth, custom tooling, drift control, and agent legibility |
+| [Anthropic, *Effective harnesses for long-running agents*](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) | initializer/coding-agent pattern for multi-context-window progress | useful baseline pattern for long-running bounded progress |
+| [Anthropic, *Harness design for long-running application development*](https://www.anthropic.com/engineering/harness-design-long-running-apps) | planner/generator/evaluator harness with explicit grading and sprint contracts | strongest external articulation of separate generation and skeptical evaluation |
+
+## Reading notes
+
+## 1) Geoffrey Huntley, *Ralph*
+
+Source:
+- <https://ghuntley.com/ralph/>
+
+### Why it should sit at the top
+
+This is the right origin point for the current reading stack.
+It is the piece that most directly crystallized the modern loop-heavy framing around long-running coding agents and made it a thing other people started reacting to, adopting, refining, or arguing against.
+
+### What it contributes
+
+- a strong, memorable articulation of continuous agent loops,
+- a sharper public reference point for "let the agent keep going",
+- a useful forcing function for thinking about autonomy, orchestration, and review pressure,
+- and a useful contrast case for what VibeGov wants to keep, tighten, or reject.
+
+### Why it matters to VibeGov
+
+VibeGov should treat *Ralph* as an important catalyst, but not as the finished governance model.
+
+What it gets right:
+- looped execution can create real leverage,
+- waiting for one-shot perfection is the wrong mental model,
+- iteration pressure and repeated review matter,
+- long-running work changes the operating model.
+
+What VibeGov should sharpen:
+- loops need bounded work units,
+- loop outputs need governed sinks,
+- skeptical evaluation should be structurally explicit,
+- human feedback should be a first-class loop rather than an occasional interruption,
+- and build should not recursively self-source new work from its own emissions.
+
+### Best VibeGov use
+
+Use *Ralph* as the origin reference for loop-based agent work, then read the later pieces as increasingly specific attempts to stabilize, instrument, evaluate, and govern that instinct.
+
+## 2) Mitchell Hashimoto, *My AI Adoption Journey*
+
+Source:
+- <https://mitchellh.com/writing/my-ai-adoption-journey#step-6-always-have-an-agent-running>
+
+### What it argues
+
+Hashimoto describes a staged shift from weak chatbot usage toward stronger agent usage:
+- stop expecting chat UIs to do serious engineering work well,
+- use real agents with tools,
+- learn by making agents reproduce real work,
+- let agents run in background/end-of-day windows,
+- invest in harness improvements when they fail,
+- aim to keep an agent usefully running as often as possible.
+
+### Strongest ideas
+
+- **Adoption is a journey, not a switch.** The article is good at describing how competence forms through repeated real use rather than hype-driven instant transformation.
+- **Reproduce your own work first.** This is a practical way to calibrate where agents are genuinely useful versus merely impressive.
+- **Harness engineering emerges from pain.** Bad recurring behaviors should turn into better instructions, better scripts, or better checks.
+- **Background work matters.** The "end-of-day agents" pattern is a realistic bridge between occasional prompting and real delegated work.
+- **Continuous delegation depends on work quality, not just model quality.** "Always have an agent running" only works if there is a steady stream of bounded tasks worth delegating.
+
+### What VibeGov should borrow
+
+- the practical progression from ad hoc use to governed delegation,
+- the idea that repeated agent failure should become harness improvement,
+- the emphasis on bounded, verifiable background tasks,
+- the insight that human attention is the scarce resource.
+
+### What VibeGov should sharpen or reject
+
+- **"Always have an agent running" is directionally useful, but incomplete.** VibeGov should not treat constant activity as a virtue by itself.
+- The article is operator-strong but governance-light. It focuses on usefulness more than on canonical sources, backlog discipline, traceability, or completion semantics.
+- VibeGov should sharpen the model into explicit loops:
+  - **build loop** consumes repo/issues and writes clear outputs back,
+  - **exploratory loop** discovers new governed work,
+  - **human feedback loop** injects review, correction, and reprioritisation.
+- VibeGov should explicitly separate **work sourcing** from **work execution**. A build loop should not recursively self-expand from its own outputs.
+
+### Best VibeGov takeaway
+
+This article is a strong practical argument for why there should often be delegated work in motion, but VibeGov should govern that with source boundaries, evidence requirements, and loop separation.
+
+## 3) OpenAI, *Harness engineering: leveraging Codex in an agent-first world*
+
+Source:
+- <https://openai.com/index/harness-engineering/>
+
+### What it argues
+
+OpenAI describes building a real internal product with humans steering and Codex doing the writing. The central thesis is that once agents become primary executors, engineering effort shifts toward:
+- repository structure,
+- agent legibility,
+- internal tools,
+- custom lints and quality gates,
+- environment design,
+- and continuous cleanup/drift control.
+
+### Strongest ideas
+
+- **Humans steer, agents execute.** This is a strong abstraction shift.
+- **The repo becomes the operating environment.** If the agent cannot discover it in-repo, it effectively does not exist.
+- **AGENTS.md should be a map, not an encyclopedia.** This aligns strongly with progressive disclosure and discoverable truth.
+- **Mechanical enforcement beats advisory preference.** Custom linters, structural checks, and tool-visible boundaries multiply reliability.
+- **Agent-first architecture changes what "good engineering" looks like.** Rigid layering and explicit dependency rules become leverage, not bureaucracy.
+- **Drift control should be continuous.** Their recurring cleanup/refactoring loop is essentially a form of garbage collection.
+
+### Where it most strongly aligns with VibeGov
+
+This piece strongly reinforces existing VibeGov directions around:
+- **in-repo truth**,
+- **agent legibility**,
+- **drift control and garbage collection**,
+- **feedback loops as engineering work**,
+- **structured workflow and bounded execution**.
+
+This is probably the clearest external support for GOV-10, GOV-11, GOV-12, and GOV-13 style controls.
+
+### What VibeGov should borrow
+
+- shorter map-style top-level agent instructions with deeper linked sources,
+- stronger repo-local knowledge architecture,
+- recurring doc-gardening and cleanup loops,
+- mechanical boundary enforcement over loose conventions,
+- quality/error messages designed to be legible to agents,
+- treating observability and UI inspection as first-class agent inputs.
+
+### What VibeGov should challenge
+
+- The article leans very far toward **agent-to-agent review and minimal merge gating**. That can work in a high-investment internal environment, but VibeGov should be careful not to generalize that as universally safe.
+- It is very strong on execution scaffolding, but weaker than VibeGov should be on **portable governance**, **human-visible accountability**, and **comparable completion semantics across teams**.
+- "Humans steer" is good, but VibeGov should make the **human feedback loop** more explicit rather than leaving it implicit in steering behavior.
+
+### Best VibeGov takeaway
+
+The biggest win here is confirmation that harness engineering is not just prompts. It is repo design, knowledge architecture, boundary enforcement, observability access, and recurring cleanup encoded into the system.
+
+## 4) Anthropic, *Effective harnesses for long-running agents*
+
+Source:
+- <https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents>
+
+### What it argues
+
+Anthropic presents a baseline long-running harness pattern for agents that must work across many context windows. The key move is a two-part structure:
+- an **initializer agent** that sets up the environment and durable artifacts,
+- a **coding agent** that makes bounded incremental progress and leaves clean handoff state.
+
+Key supporting artifacts include:
+- a feature list,
+- progress notes,
+- git commits,
+- an init script,
+- and explicit instructions to work one feature at a time.
+
+### Strongest ideas
+
+- **Long-running work needs durable session handoff artifacts.** This is the core contribution.
+- **Incremental progress beats one-shot ambition.** Asking the agent to do one feature at a time is a direct answer to common failure modes.
+- **Clean-state endings matter.** A session should end in a state a new session can resume from without archaeology.
+- **Feature status should be structured.** The JSON feature-list idea is a practical anti-drift move.
+- **Start each session by regaining bearings and testing the current state.** This is simple, but important.
+
+### Where it aligns with VibeGov
+
+This article aligns with VibeGov on:
+- durable state,
+- bounded work units,
+- handoff artifacts,
+- explicit recovery from context loss,
+- progress continuity as a design concern, not an afterthought.
+
+### What VibeGov should borrow
+
+- clearer handoff artifacts for long-running work,
+- explicit start-of-session reorientation steps,
+- stronger clean-state requirements at session boundaries,
+- structured feature/backlog state where freeform notes are too lossy,
+- the idea that context resets can be a feature, not only a failure.
+
+### What VibeGov should sharpen or reject
+
+- This pattern is excellent for **multi-window continuity**, but it is still mostly a **single production lane** pattern.
+- VibeGov should add stronger distinction between:
+  - **build execution**,
+  - **exploratory backlog hydration**,
+  - **human feedback / approval / reprioritisation**.
+- The article is lighter on issue visibility, traceability discipline, and broader governance semantics than VibeGov should be.
+
+### Best VibeGov takeaway
+
+This is a strong foundational reference for continuity and incrementalism. VibeGov should treat it as a baseline harness pattern, then add stricter governance and multi-loop separation on top.
+
+## 5) Anthropic, *Harness design for long-running application development*
+
+Source:
+- <https://www.anthropic.com/engineering/harness-design-long-running-apps>
+
+### What it argues
+
+This article extends Anthropic's earlier long-running harness into a richer multi-agent system. The main additions are:
+- explicit concern about **self-evaluation failure**,
+- a **planner / generator / evaluator** structure,
+- graded evaluation criteria,
+- evaluator skepticism as a tuned role,
+- sprint contracts negotiated before implementation,
+- and iterative quality improvement over long runs.
+
+The frontend-design section is especially important because it shows how subjective quality can be made more gradable by converting taste into criteria.
+
+### Strongest ideas
+
+- **Separate generation from skeptical evaluation.** This is the single strongest idea in the piece.
+- **Self-evaluation is weak by default.** Agents praise their own work too easily, especially on subjective tasks.
+- **Criteria make subjective judgment more usable.** Not perfectly objective, but much more gradable.
+- **Sprint contracts are a useful bridge between high-level product intent and concrete verification.**
+- **Context resets versus compaction is a real design choice.** The article usefully distinguishes fresh-slate resets from summarized continuity.
+
+### Where it aligns with VibeGov
+
+This article strongly supports VibeGov positions on:
+- evaluation as a bounded control pattern,
+- skeptical review as structurally separate from generation,
+- explicit contract-before-build behavior,
+- quality criteria as reusable governance artifacts,
+- long-running work as orchestrated, not just prompted.
+
+It is probably the clearest external support for VibeGov's distinction between **evaluation** and **exploration**.
+
+### What VibeGov should borrow
+
+- clearer evaluator-role guidance,
+- explicit anti-self-grading rules,
+- more contract-shaped handoff artifacts between planning, implementation, and review,
+- criteria libraries for subjective but important dimensions like product quality, communication quality, and design quality,
+- clearer separation between generator output and evaluator verdict.
+
+### What VibeGov should sharpen or reject
+
+- The planner/generator/evaluator pattern is powerful, but VibeGov should not let it collapse all work into one internal harness worldview.
+- Exploration should remain broader than bounded evaluator judgment. Exploration discovers across a surface; evaluation judges a bounded unit.
+- Human feedback should remain first-class. Even with strong evaluator loops, human taste, approval, and reprioritisation still matter.
+- VibeGov should also keep repo/issues as the build-loop source of truth, so internal harness chatter does not become the primary backlog system.
+
+### Best VibeGov takeaway
+
+This article gives the strongest external argument for treating **evaluation as a distinct control pattern** and for separating skeptical review from generation pressure.
+
+## Cross-reading synthesis
+
+Taken together, these five pieces suggest a clearer operating model:
+
+- **Geoffrey Huntley** strengthens the case for loop-based agent execution as a real operating model rather than a one-shot prompting pattern.
+- **Mitchell Hashimoto** strengthens the case for continuous useful delegated work.
+- **OpenAI** strengthens the case for harness engineering as repo design, tooling, boundaries, and cleanup, not just prompting.
+- **Anthropic (effective harnesses)** strengthens the case for durable handoffs, initializer/setup logic, and bounded incremental progress.
+- **Anthropic (harness design)** strengthens the case for separate evaluator roles, contract-based sprints, and graded skepticism.
+
+## What VibeGov should do with this reading set
+
+These references support a stronger VibeGov framing built around:
+
+1. **Build loop**
+   - source: repo + repo issues/backlog
+   - job: consume bounded scoped work and write clear outputs back
+   - should not recursively self-expand from its own outputs
+
+2. **Exploratory loop**
+   - source: real product/repo behavior under review
+   - job: discover gaps, drift, uncovered contracts, and hydrate backlog/spec work
+
+3. **Human feedback loop**
+   - source: user, reviewer, stakeholder, operator judgment
+   - job: inject approval, correction, taste, reprioritisation, and new scope
+   - should be asynchronous and scoped, not a global stop-the-world gate
+
+4. **Evaluation pattern inside loops**
+   - bounded skeptical judgment against explicit criteria
+   - useful inside build, exploration, or release verification
+   - not the same thing as broad exploratory review
+
+## Related VibeGov pages
+
+- [Harness Engineering and What VibeGov Does With It](/blog/harness-engineering-what-we-do-with-it)
+- [Governance from Harness Engineering and Beyond](/blog/governance-from-harness-engineering-and-beyond)
+- [Exploratory Review Mode](/docs/exploratory-review-mode)
+- [Evaluation Pattern](/docs/evaluation-pattern)
+- [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
+- [Published GOV 08 Exploratory Review](/docs/published/gov-08-exploratory-review)
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 12 Drift Control and Garbage Collection](/docs/published/gov-12-drift-control-garbage-collection)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)

--- a/docs/reference-reading.md
+++ b/docs/reference-reading.md
@@ -14,6 +14,27 @@ Use this page for three things:
 - record what is genuinely useful,
 - make clear what VibeGov should borrow, adapt, or reject.
 
+## How to use this page
+
+Do not treat this page as a second canon.
+Use it as a translation layer between influential outside writing and the actual VibeGov rules/docs.
+
+A practical reading order is:
+1. read the external source,
+2. note the useful idea,
+3. map that idea into the VibeGov docs where it actually landed,
+4. prefer the VibeGov rule/doc when making decisions.
+
+## Where these ideas landed in VibeGov
+
+| External pressure | Where it shows up in VibeGov |
+| --- | --- |
+| loop-based operating model | [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops), [Published GOV 02 Workflow](/docs/published/gov-02-workflow) |
+| exploration vs evaluation separation | [Execution Modes](/docs/execution-modes), [Evaluation Pattern](/docs/evaluation-pattern), [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing) |
+| in-repo truth, harness engineering, drift control | [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene), [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth), [Published GOV 12 Drift Control and Garbage Collection](/docs/published/gov-12-drift-control-garbage-collection) |
+| human feedback as a first-class loop | [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern), [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops) |
+| bounded skeptical judgment | [Evaluation Pattern](/docs/evaluation-pattern), [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline) |
+
 ## Current reading set
 
 | Source | Main contribution | Best VibeGov use |
@@ -308,6 +329,9 @@ These references support a stronger VibeGov framing built around:
 
 ## Related VibeGov pages
 
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
+- [Execution Modes](/docs/execution-modes)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Harness Engineering and What VibeGov Does With It](/blog/harness-engineering-what-we-do-with-it)
 - [Governance from Harness Engineering and Beyond](/blog/governance-from-harness-engineering-and-beyond)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)

--- a/docs/release-artifact-and-test-prep.md
+++ b/docs/release-artifact-and-test-prep.md
@@ -32,6 +32,16 @@ Example:
 2026.4.19-55b47ec
 ```
 
+Why this format:
+- keeps the label human-readable by date,
+- keeps it traceable to an exact commit,
+- avoids ambiguous split schemes by default,
+- and gives one canonical build/release label shape unless a project explicitly chooses otherwise.
+
+Default rule:
+- do **not** invent separate date-only "stable" labels and date+SHA prerelease labels unless the project has explicitly chosen that distinction.
+- use the same canonical format for build/release labels by default.
+
 ### What the release package contains
 
 The package is intentionally narrow.

--- a/sidebars.js
+++ b/sidebars.js
@@ -39,6 +39,7 @@ const sidebars = {
       label: 'Operational Guides',
       items: [
         'execution-modes',
+        'build-exploratory-human-feedback-loops',
         'quick-decisions',
         'mode-selection-and-evidence-closing',
         'simplicity-first',
@@ -52,6 +53,13 @@ const sidebars = {
         'blocker-escalation',
         'workflow-quality-rubric',
         'release-artifact-and-test-prep',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Reference Reading',
+      items: [
+        'reference-reading',
       ],
     },
     {


### PR DESCRIPTION
## Summary\n- promote the recovered and normalized develop state to main\n- includes the 17 recovered doc/governance commits plus the follow-up coherence tightening commit\n- closes the current branch-state mismatch where develop is ahead of main\n\n## Validation\n- npm run build\n\n## Notes\n- this is a promotion PR from develop state after recovery/normalization\n- local execution flow will be returned to develop after merge