### PR TITLE
#107 improve bootstrap support doc discoverability

### DIFF
--- a/.governance/specs/bootstrap-support-doc-discoverability.md
+++ b/.governance/specs/bootstrap-support-doc-discoverability.md
@@ -1,0 +1,42 @@
+# Bootstrap Support Document Discoverability
+
+## Intent
+Make the bootstrap support documents easy to find from the main bootstrap reader path. This matters because the canonical bootstrap contract now relies on support concepts such as GitHub board preflight/normalization and `INIT-TODO.md`, but readers entering through Bootstrap or Quick Start can miss the deeper support guidance entirely.
+
+## Scope
+In scope:
+- improve discoverability of `docs/github-project-bootstrap.md` and `docs/init-todo.md`
+- strengthen the main bootstrap path with explicit links from Bootstrap, Quick Start, Bootstrap Update, and Bootstrap Review where support concepts first appear
+- expose bootstrap support docs clearly in the docs sidebar/navigation
+- ensure support docs link back into the main bootstrap path
+
+Out of scope:
+- changing the canonical bootstrap contract itself
+- rewriting the substantive GitHub bootstrap or INIT-TODO guidance
+- broad Quick Start contract repair beyond discoverability/routing
+
+## Acceptance Criteria
+- `BOOT-DISC-001` Readers entering through `docs/bootstrap.md` can clearly discover `docs/github-project-bootstrap.md` and `docs/init-todo.md` when those concepts are first mentioned.
+- `BOOT-DISC-002` `docs/quickstart.md`, `docs/bootstrap-update.md`, and `docs/bootstrap-review.md` provide discoverable paths into the relevant support docs.
+- `BOOT-DISC-003` The sidebar exposes bootstrap support docs as part of the bootstrap path instead of leaving them effectively orphaned.
+- `BOOT-DISC-004` `docs/github-project-bootstrap.md` and `docs/init-todo.md` link back to the main bootstrap flow.
+- `BOOT-DISC-005` `npm run build` succeeds after the navigation/doc updates.
+
+## Tests and Evidence
+- inspect `docs/bootstrap.md`
+- inspect `docs/quickstart.md`
+- inspect `docs/bootstrap-update.md`
+- inspect `docs/bootstrap-review.md`
+- inspect `docs/github-project-bootstrap.md`
+- inspect `docs/init-todo.md`
+- inspect `sidebars.js`
+- run `npm run build`
+
+## Documentation Impact
+- update `docs/bootstrap.md`
+- update `docs/quickstart.md`
+- update `docs/bootstrap-update.md`
+- update `docs/bootstrap-review.md`
+- update `docs/github-project-bootstrap.md`
+- update `docs/init-todo.md`
+- update `sidebars.js`

--- a/docs/bootstrap-review.md
+++ b/docs/bootstrap-review.md
@@ -9,6 +9,10 @@ Use this when a repo already has some bootstrap state and you want to **audit it
 This is **not** a separate bootstrap contract.
 It is the same contract from [Bootstrap](/docs/bootstrap), run in **`review` mode**.
 
+When review work touches GitHub bootstrap behavior or durable prerequisite capture, use these support docs directly:
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)
+- [INIT-TODO.md](/docs/init-todo)
+
 ## Mode behavior
 
 - `init` — create missing bootstrap state
@@ -46,3 +50,11 @@ Review mode should use the same reporting structure as init/update:
 ## Rule
 
 If a repo fails bootstrap review, the next remediation pass should use **bootstrap update** against the same canonical contract.
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Update](/docs/bootstrap-update)
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)
+- [INIT-TODO.md](/docs/init-todo)
+- [Quick Start](/docs/quickstart)

--- a/docs/bootstrap-update.md
+++ b/docs/bootstrap-update.md
@@ -12,6 +12,10 @@ Shorthand ref:
 It does **not** use a weaker or different contract.
 Use the canonical bootstrap contract at [Bootstrap](/docs/bootstrap).
 
+When update work hits GitHub preflight/board questions or missing prerequisite capture, use these support docs directly:
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)
+- [INIT-TODO.md](/docs/init-todo)
+
 ## Update behavior
 
 - preserve valid existing artifacts
@@ -57,3 +61,11 @@ Preferred shape:
 - `.governance/project/bootstrap/history/<timestamp>/` = the historical run bundle for this pass
 
 When migrating a repo that still uses the older flat bootstrap layout, BU should normalize reporting into the structured layout instead of extending the old pattern.
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Review](/docs/bootstrap-review)
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)
+- [INIT-TODO.md](/docs/init-todo)
+- [Quick Start](/docs/quickstart)

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -21,6 +21,14 @@ Mode differences are behavioral only:
 - `update` repairs/normalizes existing bootstrap state
 - `review` audits against the same contract without claiming missing work was completed
 
+## Bootstrap support docs
+
+Use the canonical contract here, then branch into the support docs when those topics first matter:
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap) for GitHub preflight, canonical board selection, repo linkage, and final GitHub-state reconciliation
+- [INIT-TODO.md](/docs/init-todo) for durable prerequisite/remediation capture during bootstrap and adoption/update work
+- [Bootstrap Update](/docs/bootstrap-update) for repair/normalization runs against an already bootstrapped repo
+- [Bootstrap Review](/docs/bootstrap-review) for audit-only runs against the same contract
+
 ## Canonical bootstrap prompt
 
 ```text
@@ -98,6 +106,12 @@ Before writing any product code (or before claiming bootstrap review is complete
 17. Distinguish final current state from historical evidence gathered earlier in the run.
 18. If migrating a repo from the older flat layout (`BOOTSTRAP_*.md` and `bootstrap-runs/<timestamp>-*.md`), normalize it into the current-surface plus historical-run-bundle structure instead of extending the legacy shape.
 
+Support docs for this contract:
+- use [GitHub Project Bootstrap](/docs/github-project-bootstrap) when the repo is GitHub-hosted and board/project setup is in scope
+- use [INIT-TODO.md](/docs/init-todo) when prerequisites, blockers, or exact remediation steps need durable capture
+- use [Bootstrap Update](/docs/bootstrap-update) for remediation/normalization runs
+- use [Bootstrap Review](/docs/bootstrap-review) for audit-only runs against the same contract
+
 Mode-specific behavior:
 - `init`: create the missing bootstrap state required by the contract
 - `update`: preserve valid existing artifacts and repair stale/missing/contradictory ones, including missing operational bootstrap artifacts, until the same contract is satisfied; if that cannot be done, leave explicit status/blocker artifacts plus a settled end-state classification (`committed/pushed`, `pending-review`, or `blocked`)
@@ -174,3 +188,14 @@ normalize it toward:
 - `.governance/project/bootstrap/history/<timestamp>/...`
 
 During transition, older flat artifacts may remain as legacy history, but new bootstrap work should use the structured reporting layout.
+
+## Related docs
+
+- [Quick Start](/docs/quickstart)
+- [Bootstrap Update](/docs/bootstrap-update)
+- [Bootstrap Review](/docs/bootstrap-review)
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)
+- [INIT-TODO.md](/docs/init-todo)
+- [Bootstrap Feedback Prompt](/docs/bootstrap-feedback-prompt)
+- [FAQ: When do I use Bootstrap Init?](/docs/faq/when-do-i-use-bootstrap-init)
+- [FAQ: When do I use Bootstrap Update?](/docs/faq/when-do-i-use-bootstrap-update)

--- a/docs/github-project-bootstrap.md
+++ b/docs/github-project-bootstrap.md
@@ -6,6 +6,9 @@ sidebar_position: 9
 
 Use this when adopting VibeGov in a GitHub-hosted repository.
 
+This is a bootstrap support page, not a separate contract.
+Start with [Bootstrap](/docs/bootstrap) or [Quick Start](/docs/quickstart), then use this page when GitHub preflight, board normalization, repo linkage, or final GitHub-state reconciliation becomes relevant.
+
 ## Mandatory preflight before any board mutation
 
 Check and classify each dependency as one of:
@@ -88,3 +91,11 @@ For GitHub-hosted bootstrap, report:
 - any degraded-verification warnings caused by hosted-feature limits, with exact evidence and next action
 - `develop` branch local/remote/protection status
 - final live-state reconciliation result
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Update](/docs/bootstrap-update)
+- [Bootstrap Review](/docs/bootstrap-review)
+- [Quick Start](/docs/quickstart)
+- [INIT-TODO.md](/docs/init-todo)

--- a/docs/init-todo.md
+++ b/docs/init-todo.md
@@ -6,6 +6,9 @@ sidebar_position: 12
 
 Use `INIT-TODO.md` as the durable setup/remediation scratchpad during bootstrap and major adoption/update work.
 
+This is a bootstrap support page, not a separate contract.
+Start with [Bootstrap](/docs/bootstrap) or [Quick Start](/docs/quickstart), then use this page when prerequisites, blockers, or exact remediation steps need durable capture.
+
 It is for things the agent discovered during setup that must be reported or resolved before bootstrap can be considered complete.
 
 ## Record here
@@ -37,3 +40,11 @@ It is for things the agent discovered during setup that must be reported or reso
 ## Rule
 
 If bootstrap depends on a missing prerequisite, record it in `INIT-TODO.md` with the exact remediation step instead of leaving the gap only in chat.
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Update](/docs/bootstrap-update)
+- [Bootstrap Review](/docs/bootstrap-review)
+- [Quick Start](/docs/quickstart)
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,6 +15,15 @@ Bootstrap now uses one canonical contract with explicit modes:
 
 Use [Bootstrap](/docs/bootstrap) as the canonical contract surface.
 
+## If you need the support docs
+
+Quick Start is the short path, not the whole support surface.
+When those topics come up, jump directly to:
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap) for GitHub preflight, board setup, repo linkage, and GitHub-state reconciliation
+- [INIT-TODO.md](/docs/init-todo) for durable prerequisite/remediation capture
+- [Bootstrap Update](/docs/bootstrap-update) if the repo already has bootstrap state and needs normalization
+- [Bootstrap Review](/docs/bootstrap-review) if you need an audit against the same contract without claiming missing work was completed
+
 ## Copy-paste bootstrap prompt
 
 ```text
@@ -65,3 +74,13 @@ Then stop before product-code implementation.
 - Scaffold-only output is incomplete for GitHub-hosted repos unless missing operational pieces are explicitly blocked and reported.
 - If product intent is unclear, do not invent domain direction from repo name.
 - Prefer bootstrap/update remediation that preserves valid artifacts and only repairs weak/missing/contradictory state.
+- If you hit GitHub board/preflight questions, jump to [GitHub Project Bootstrap](/docs/github-project-bootstrap).
+- If you need durable prerequisite or remediation capture, jump to [INIT-TODO](/docs/init-todo).
+
+## Related docs
+
+- [Bootstrap](/docs/bootstrap)
+- [Bootstrap Update](/docs/bootstrap-update)
+- [Bootstrap Review](/docs/bootstrap-review)
+- [GitHub Project Bootstrap](/docs/github-project-bootstrap)
+- [INIT-TODO](/docs/init-todo)

--- a/sidebars.js
+++ b/sidebars.js
@@ -18,8 +18,18 @@ const sidebars = {
     'start-here',
     'bootstrap',
     'bootstrap-update',
+    'bootstrap-review',
     'quickstart',
     'bootstrap-feedback-prompt',
+    {
+      type: 'category',
+      label: 'Bootstrap Support',
+      items: [
+        'github-project-bootstrap',
+        'init-todo',
+        'agents-template',
+      ],
+    },
     {
       type: 'category',
       label: 'FAQ',


### PR DESCRIPTION
## Summary\n- add a focused spec for bootstrap support-doc discoverability\n- expose bootstrap support docs in the sidebar\n- add explicit support-doc routing from Bootstrap, Quick Start, Bootstrap Update, and Bootstrap Review\n- add return-path related links on GitHub Project Bootstrap and INIT-TODO\n\n## Validation\n- npm run build\n\nCloses #107