### PR TITLE
issue-124: sharpen Codex prompting governance profile

### DIFF
--- a/.governance/rules/gov-11-agent-legibility-in-repo-truth.mdc
+++ b/.governance/rules/gov-11-agent-legibility-in-repo-truth.mdc
@@ -39,6 +39,14 @@ Governed systems should optimize for agent legibility by making intent, constrai
 - `GOV-11-LEG-015` When a repeated rule or invariant is mechanically enforceable, governed systems should prefer enforcing it through code, tests, or linting over relying only on prose reminders.
 - `GOV-11-LEG-016` Human review should be treated as a source of new invariants to encode, not only as a one-time correction channel.
 
+## Legible Execution and Bounded Autonomy
+
+- `GOV-11-LEG-017` High-agency execution profiles should optimize for interrupt-efficient legibility: enough visible state for an operator to understand progress, risk, and decision boundaries without forcing the agent into constant narration.
+- `GOV-11-LEG-018` Meaningful execution checkpoints should surface start or resume, major plan change, blocker or risk state, validation outcome, and closure outcome when those states occur.
+- `GOV-11-LEG-019` Agents should act autonomously on clear, reversible internal work, but decision boundaries must remain visible for destructive, external, privacy-sensitive, irreversible, or judgment-dependent actions.
+- `GOV-11-LEG-020` Silence is not inherently better than chatter. The governed target is concise, high-signal visibility rather than either status spam or opaque black-box execution.
+- `GOV-11-LEG-021` Throughput-oriented prompting or harness design must not suppress the visibility needed for accountability, recoverability, or safe interruption.
+
 ## Anti-Patterns
 
 Avoid these failure modes:
@@ -47,3 +55,6 @@ Avoid these failure modes:
 - expecting future agents to infer unwritten norms from scattered examples
 - storing critical intent in one giant unstructured instruction file
 - keeping durable rules in people’s heads instead of repo artifacts
+- treating silence as superior to operator-legible checkpoints
+- optimizing throughput by hiding meaningful risk, validation, or decision-boundary state
+- applying high autonomy to destructive or externally consequential actions without making the decision boundary visible

--- a/.governance/specs/codex-prompting-vibegov-profile.md
+++ b/.governance/specs/codex-prompting-vibegov-profile.md
@@ -1,0 +1,48 @@
+# Codex Prompting Through a VibeGov Lens
+
+## Intent
+Capture the useful parts of Codex-oriented prompting and harness style without importing Codex performance heuristics wholesale into VibeGov.
+
+## Scope
+In scope:
+- define what VibeGov should borrow from Codex prompting
+- define what VibeGov should reject or constrain
+- add a formal public doc page that explains the resulting governed stance
+- add a focused GOV rule addition for bounded autonomy and operator-legible execution
+- update the Codex harness profile so it reflects the governed profile concretely
+
+Out of scope:
+- making Codex the mandatory runtime for VibeGov
+- replacing existing core GOV rules with Codex-specific wording
+- prescribing one exact CLI prompt or one local machine setup
+- importing benchmark-oriented heuristics when they weaken legibility, closure, or safety
+
+## Acceptance Criteria
+- `.governance/specs/codex-prompting-vibegov-profile.md` exists with bounded intent/scope.
+- `docs/codex-prompting-through-vibegov.md` exists and is linked in `sidebars.js`.
+- One GOV rule is extended to capture the durable lesson around bounded autonomy and interrupt-efficient legibility.
+- `docs/harness-profile-codex.md` is updated to show a stronger governed Codex profile, not only a minor wording pass.
+- Supporting published GOV page stays aligned with the canonical rule.
+- `npm run build` passes.
+
+## Tests and Evidence
+- inspect `.governance/specs/codex-prompting-vibegov-profile.md`
+- inspect `docs/codex-prompting-through-vibegov.md`
+- inspect `.governance/rules/gov-11-agent-legibility-in-repo-truth.mdc`
+- inspect `docs/published/gov-11-agent-legibility-in-repo-truth.md`
+- inspect `docs/harness-profile-codex.md`
+- inspect `sidebars.js`
+- run `npm run build`
+
+## Documentation Impact
+- add `docs/codex-prompting-through-vibegov.md`
+- update `docs/harness-profile-codex.md`
+- update `docs/published/gov-11-agent-legibility-in-repo-truth.md`
+- update `sidebars.js`
+
+## Verification
+Verification is docs/build driven. Success requires a coherent public explanation, a concrete harness-profile update, an aligned canonical/published GOV rule update, discoverable navigation, and a passing site build.
+
+## Change Notes
+- This slice should sharpen VibeGov’s Codex adapter stance without weakening tool-agnostic governance.
+- The resulting profile should preserve Codex’s execution energy while keeping VibeGov’s stronger closure, oversight, and traceability model.

--- a/docs/codex-prompting-through-vibegov.md
+++ b/docs/codex-prompting-through-vibegov.md
@@ -1,0 +1,159 @@
+---
+sidebar_position: 14
+---
+
+# Codex Prompting Through a VibeGov Lens
+
+OpenAI's Codex prompting guidance is useful.
+
+It is also incomplete as governance.
+
+VibeGov should borrow the parts that sharpen execution quality, reject the parts that weaken operator legibility or state closure, and wrap the remainder in governed controls.
+
+## What VibeGov should borrow
+
+### Tool-first execution
+
+Borrow the bias toward dedicated tools, fast discovery, and precise edits.
+
+Use structured tools over raw shell when possible. Prefer fast repo search, targeted reads, and coherent edits over terminal thrash.
+
+### Bias toward completion
+
+Borrow the expectation that a clear task should usually move through context gathering, implementation, verification, and closure in one coherent loop.
+
+The useful lesson is not "never ask questions." The useful lesson is "do not substitute plans and preambles for progress."
+
+### Read enough before changing
+
+Borrow the discipline of understanding local patterns, reuse opportunities, and surrounding behavior before editing.
+
+This reduces diff thrash and lowers the risk of narrow fixes that break neighboring surfaces.
+
+### Truthful verification
+
+Borrow the insistence that changes should be verified before being claimed complete.
+
+VibeGov agrees with the core idea: passing evidence matters more than confident narration.
+
+### Low-noise communication
+
+Borrow the instinct to reduce empty status chatter.
+
+Agent updates should carry information, not ceremony.
+
+## What VibeGov should reject or constrain
+
+### Do not absolutize parallelism
+
+Codex-style guidance is directionally right when it says to batch known reads and parallelize obvious independent work.
+
+But real debugging is often sequential and hypothesis-driven. "Always maximize parallelism" is a useful optimization heuristic, not a governance rule.
+
+### Do not optimize away operator legibility
+
+Benchmark-style prompting often pushes hard against preambles, plans, and progress updates.
+
+VibeGov should reject the extreme version of that rule. Operators need meaningful checkpoints for start/resume, blocker state, validation results, and closure.
+
+The target is interrupt-efficient legibility, not silence.
+
+### Do not treat dirty-state handling as simplistic stop/go logic
+
+"Unexpected changes appeared, stop immediately" is too crude for governed work.
+
+VibeGov wants inherited-state assessment, explicit classification, and a visible treatment decision. Mixed repo state is a governance problem to classify, not just a trigger to freeze.
+
+### Constrain autonomy by risk class
+
+Codex prompting is strongest on reversible repository work.
+
+VibeGov should constrain the same autonomy when work becomes destructive, privacy-sensitive, public-facing, irreversible, production-affecting, or dependent on human judgment that has not yet been made visible.
+
+### Reject throughput as the top-level objective
+
+Codex prompting often optimizes for coding throughput and rollout momentum.
+
+VibeGov should optimize first for legibility, recoverability, accountability, and state closure. Throughput matters, but under those controls.
+
+## The governed synthesis
+
+The right synthesis is:
+
+- keep Codex's execution energy
+- keep VibeGov's closure and evidence model
+- keep human interruption points visible when they matter
+- keep repo state and governed artifacts honest at every boundary
+
+This produces a stronger operating profile than either one alone.
+
+Codex contributes a sharp implementation stance.
+
+VibeGov contributes bounded autonomy, durable state, explicit evidence, and repeatable closure semantics.
+
+## Proposed Codex-style VibeGov profile
+
+A Codex-style VibeGov profile should behave like this:
+
+### Act like a strong implementation agent
+
+- prefer action over ceremonial planning
+- implement the scoped change
+- verify before claiming progress
+- keep the loop coherent and bounded
+
+### Stay tool-first, not terminal-first
+
+- use dedicated tools where available
+- prefer fast search and targeted edits
+- parallelize when targets are already known
+- do not force batching that makes investigation worse
+
+### Stay truthful about reality
+
+- do not fake support for contracts that the system does not actually implement
+- do not let UI claims outrun backend truth
+- do not present exploratory findings as shipped fixes
+
+### Keep the operator informed at the right moments
+
+The profile should surface:
+- start or resume of the active slice
+- meaningful plan change
+- blocker or decision boundary
+- validation result
+- closure outcome
+
+It should not narrate every trivial step.
+
+### Treat closure as part of the work
+
+The slice is not complete at "files edited."
+
+The governed close should include the expected issue, spec, evidence, git-state, merge, archive, and return-to-base behavior for the repo.
+
+### Bound autonomy by consequence
+
+Act freely on clear, reversible internal work.
+
+Pause when the work becomes destructive, external, privacy-sensitive, non-recoverable, or dependent on unresolved human intent.
+
+## Why this matters
+
+Without the Codex influence, a governed agent can become overly ceremonial and slow.
+
+Without the VibeGov layer, a high-performance coding agent can become hard to audit, hard to interrupt, and too willing to optimize speed over closure.
+
+The goal is not to choose between them.
+
+The goal is to combine execution sharpness with governed operability.
+
+## Recommended reading path
+
+- [Harness Profile: Codex](/docs/harness-profile-codex)
+- [Harness Profile: Minimal Claude Harness](/docs/harness-profile-minimal-claude)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)

--- a/docs/harness-profile-codex.md
+++ b/docs/harness-profile-codex.md
@@ -4,7 +4,7 @@ sidebar_position: 13
 
 # Harness Profile: Codex
 
-This profile shows how to apply VibeGov harness controls in Codex-oriented delivery loops.
+This profile shows how to run a Codex-centered delivery loop inside VibeGov without letting Codex's speed-oriented prompting become the whole governance model.
 
 It is a profile, not a core-governance replacement.
 
@@ -12,9 +12,20 @@ It is a profile, not a core-governance replacement.
 
 Use this when your team runs implementation loops primarily through Codex sessions and wants explicit control over:
 - scoped work-unit execution,
-- verifier and evaluator gates,
-- durable session-to-session state,
-- bounded retries and escalation.
+- operator-legible progress and decision boundaries,
+- truthful verifier and evaluator gates,
+- durable state artifacts,
+- bounded retries and escalation,
+- closure that reaches governed repo state instead of stopping at edited files.
+
+## Profile stance
+
+This profile intentionally combines two different strengths:
+
+- **Codex contribution:** tool-first execution, strong implementation momentum, low tolerance for empty planning chatter, and a bias toward verification.
+- **VibeGov contribution:** bounded autonomy, governed artifacts, operator-legible checkpoints, state closure, and accountability at work-unit boundaries.
+
+Do not adopt Codex prompting wholesale. Adopt the useful execution posture and keep the stronger governance layer around it.
 
 ## Profile contract
 
@@ -25,28 +36,58 @@ A Codex harness loop should explicitly provide:
 
 2. **Verifier contract**
    - explicit command(s) that define baseline and post-change verification.
+   - verifier results should be reported truthfully, not inferred from confidence or partial inspection.
 
 3. **Evaluator contract**
-   - separate skeptical evaluation path with explicit pass/fail output.
+   - separate skeptical evaluation path with explicit pass/fail or scored output.
    - treat that evaluator path as a bounded control inside the active Development or Exploration flow, not as a third top-level mode.
 
 4. **State artifacts**
-   - durable plan/progress/evidence artifacts in repo.
+   - durable plan, progress, evidence, and follow-up artifacts in repo.
 
-5. **Closure semantics**
-   - completion only when verification/evaluation/traceability/git-state closure conditions are met.
+5. **Legibility contract**
+   - concise checkpoints for start or resume, plan change, blocker or risk, validation outcome, and closure outcome.
+   - avoid both status spam and opaque black-box silence.
 
-6. **Escalation semantics**
-   - bounded retry loops and explicit blocked outcomes when confidence cannot be raised.
+6. **Closure semantics**
+   - completion only when verification, evaluation, traceability, and git-state closure conditions are met.
+
+7. **Escalation semantics**
+   - bounded retry loops and explicit blocked outcomes when confidence cannot be raised honestly.
+
+8. **Autonomy boundary**
+   - clear, reversible internal work may proceed without waiting.
+   - destructive, external, privacy-sensitive, irreversible, or judgment-dependent actions should surface a visible decision boundary.
+
+## What to borrow from Codex prompting
+
+Borrow these parts aggressively:
+- tool-first work over raw terminal drift
+- completion bias instead of plan theater
+- reading enough context before editing
+- repo-convention reuse before invention
+- verification before completion claims
+- concise communication instead of ceremonial narration
+
+## What to reject or constrain
+
+Do not import these as hard rules:
+- maximize parallelism at all times
+- suppress progress updates just because silence benchmarks well
+- treat dirty or inherited repo state as a simplistic stop signal instead of a classification problem
+- optimize rollout speed above closure, accountability, or recoverability
+- treat edited files as an adequate completion boundary
 
 ## Mapping to VibeGov controls
 
 | Codex harness concern | VibeGov control |
 | --- | --- |
 | One scoped task loop | GOV-07 tasks + GOV-02 workflow |
+| Tool-first execution inside a bounded work unit | GOV-02 workflow + GOV-11 legibility |
 | Baseline and post-change verification | GOV-05 testing + GOV-04 quality gate |
 | Separate evaluator judgment | GOV-13 review loops + GOV-04 anti-fake-completion |
 | Durable plan/progress artifacts | GOV-11 in-repo truth + GOV-09 continuity |
+| Operator-legible checkpoints | GOV-11 legible execution and bounded autonomy |
 | Git state closure before move-on | GOV-10 state closure and git hygiene |
 | Recurring cleanup and anti-slop | GOV-12 drift control |
 | Blocked/retry/stop behavior | GOV-02 escalation and move-on behavior |
@@ -55,25 +96,38 @@ A Codex harness loop should explicitly provide:
 
 For each work unit:
 
-1. orient on issue/spec + current repo state
-2. run baseline verifier
-3. implement the scoped change only
-4. run post-change verifier
-5. run skeptical evaluator pass
-6. apply fixes if needed (bounded retries)
-7. close state (commit/revert/ignore/defer explicit accounting)
-8. record evidence + follow-up artifacts
+1. orient on issue, spec, and inherited repo state
+2. classify any residue before starting fresh work
+3. run baseline verifier
+4. implement the scoped change only
+5. run post-change verifier
+6. run skeptical evaluator pass when the slice warrants it
+7. loop on fixes only while the loop is producing real progress
+8. close state through commit, merge-path, archive-path, or explicit follow-up handling
+9. record evidence and any residual risks truthfully
 
-## Profile adoption checklist
+## Adoption checklist
 
 When adopting this profile in a repo:
 
 - define canonical verifier command(s)
 - define evaluator output schema and fail conditions
-- define plan/progress artifact locations and update rules
+- define plan, progress, evidence, and follow-up artifact locations
+- define the checkpoint/report moments operators should expect
 - define retry cap and blocked/escalation handoff path
 - enforce git-state closure at work-unit boundaries
-- require evidence links in issue/PR checkpoints
+- require evidence links in issue and PR checkpoints
+- decide which actions require visible human decision boundaries
+
+## Minimum quality bar for this profile
+
+A Codex-centered run should not be considered complete unless:
+- acceptance criteria are traceable,
+- verification evidence is captured,
+- evaluator outcome is explicit when used,
+- repo state is fully accounted for,
+- residual risks and follow-ups are tracked,
+- the governed landing path is clear.
 
 ## Common failure modes
 
@@ -83,21 +137,29 @@ Avoid these:
 - marking done on passing build alone
 - carrying dirty-tree residue to the next work unit
 - running unbounded retries without escalation
+- hiding meaningful risk or uncertainty to preserve rollout momentum
+- treating low narration as permission for low legibility
+
+## Recommended rollout strategy
+
+- start with a small governed pilot in one repo
+- keep the loop simple until the real failure modes are known
+- tighten verifier, evaluator, and closure controls before adding orchestration layers
+- reassess prompt/harness complexity whenever model capability improves
+- remove stale scaffolding when simpler governed paths become good enough
 
 ## Core vs adapter reminder
 
 VibeGov core remains tool-agnostic.
 
-This Codex profile is an adapter layer that helps teams implement the same governance controls in Codex-centered workflows.
+This Codex profile is an adapter layer that helps teams apply the same governance controls in Codex-centered workflows.
 
 ## Related docs
 
-- [Execution Modes](/docs/execution-modes)
-- [Evaluation Pattern](/docs/evaluation-pattern)
+- [Codex Prompting Through a VibeGov Lens](/docs/codex-prompting-through-vibegov)
+- [Harness Profile: Minimal Claude Harness](/docs/harness-profile-minimal-claude)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
-- [Published GOV 02 Workflow](/docs/published/gov-02-workflow)
-- [Published GOV 05 Testing](/docs/published/gov-05-testing)
-- [Published GOV 09 Agent Continuity Bootstrap](/docs/published/gov-09-agent-continuity-bootstrap)
 - [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
 - [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
 - [Published GOV 12 Drift Control and Garbage Collection](/docs/published/gov-12-drift-control-garbage-collection)

--- a/docs/published/gov-11-agent-legibility-in-repo-truth.md
+++ b/docs/published/gov-11-agent-legibility-in-repo-truth.md
@@ -58,6 +58,16 @@ Governed systems should optimize for agent legibility by making intent, constrai
 
 > Commentary: Pushes repeatable human taste from comments into enforceable controls.
 
+## Legible Execution and Bounded Autonomy
+
+- `GOV-11-LEG-017` High-agency execution profiles should optimize for interrupt-efficient legibility: enough visible state for an operator to understand progress, risk, and decision boundaries without forcing the agent into constant narration.
+- `GOV-11-LEG-018` Meaningful execution checkpoints should surface start or resume, major plan change, blocker or risk state, validation outcome, and closure outcome when those states occur.
+- `GOV-11-LEG-019` Agents should act autonomously on clear, reversible internal work, but decision boundaries must remain visible for destructive, external, privacy-sensitive, irreversible, or judgment-dependent actions.
+- `GOV-11-LEG-020` Silence is not inherently better than chatter. The governed target is concise, high-signal visibility rather than either status spam or opaque black-box execution.
+- `GOV-11-LEG-021` Throughput-oriented prompting or harness design must not suppress the visibility needed for accountability, recoverability, or safe interruption.
+
+> Commentary: Converts "talk less" into a governed rule about showing the right state at the right time instead of choosing between noise and opacity.
+
 ## Anti-Patterns
 
 Avoid these failure modes:
@@ -66,5 +76,8 @@ Avoid these failure modes:
 - expecting future agents to infer unwritten norms from scattered examples
 - storing critical intent in one giant unstructured instruction file
 - keeping durable rules in people’s heads instead of repo artifacts
+- treating silence as superior to operator-legible checkpoints
+- optimizing throughput by hiding meaningful risk, validation, or decision-boundary state
+- applying high autonomy to destructive or externally consequential actions without making the decision boundary visible
 
-> Commentary: Calls out the exact hidden-knowledge patterns that break agent reliability.
+> Commentary: Calls out the exact hidden-knowledge and hidden-state patterns that break agent reliability.

--- a/sidebars.js
+++ b/sidebars.js
@@ -58,6 +58,7 @@ const sidebars = {
         'evaluation-pattern',
         'harness-profile-minimal-claude',
         'harness-profile-codex',
+        'codex-prompting-through-vibegov',
         'exploratory-review-mode',
         'checkpoint-reporting',
         'blocker-escalation',


### PR DESCRIPTION
## Summary
- add a formal VibeGov doc page on Codex prompting through a governance lens
- extend GOV-11 with bounded autonomy + interrupt-efficient legibility guidance
- strengthen the Codex harness profile and link it into the docs nav

## Validation
- npm run build

Closes #124
