### PR TITLE
issue-126: translate execution patterns into VibeGov

### DIFF
--- a/.governance/specs/codex-prompting-vibegov-profile.md
+++ b/.governance/specs/codex-prompting-vibegov-profile.md
@@ -1,13 +1,14 @@
 # Codex Prompting Through a VibeGov Lens
 
 ## Intent
-Capture the useful parts of Codex-oriented prompting and harness style without importing Codex performance heuristics wholesale into VibeGov.
+Translate strong execution patterns from Codex-oriented prompting and harness style into native VibeGov artifacts without keeping the outcome trapped in comparative meta-language.
 
 ## Scope
 In scope:
-- define what VibeGov should borrow from Codex prompting
-- define what VibeGov should reject or constrain
-- add a formal public doc page that explains the resulting governed stance
+- translate the strongest execution patterns into native VibeGov guidance
+- tighten the public doc page so it reads as direct VibeGov guidance rather than comparison commentary
+- add a companion public article version
+- add a minimal practical snippet for harness use
 - add a focused GOV rule addition for bounded autonomy and operator-legible execution
 - update the Codex harness profile so it reflects the governed profile concretely
 
@@ -35,7 +36,9 @@ Out of scope:
 - run `npm run build`
 
 ## Documentation Impact
-- add `docs/codex-prompting-through-vibegov.md`
+- update `docs/codex-prompting-through-vibegov.md`
+- add `docs/minimal-vibegov-execution-profile-snippet.md`
+- add `blog/2026-04-24-execution-sharpness-and-governed-closure.md`
 - update `docs/harness-profile-codex.md`
 - update `docs/published/gov-11-agent-legibility-in-repo-truth.md`
 - update `sidebars.js`
@@ -44,5 +47,5 @@ Out of scope:
 Verification is docs/build driven. Success requires a coherent public explanation, a concrete harness-profile update, an aligned canonical/published GOV rule update, discoverable navigation, and a passing site build.
 
 ## Change Notes
-- This slice should sharpen VibeGov’s Codex adapter stance without weakening tool-agnostic governance.
-- The resulting profile should preserve Codex’s execution energy while keeping VibeGov’s stronger closure, oversight, and traceability model.
+- This slice should sharpen VibeGov’s execution guidance without weakening tool-agnostic governance.
+- The resulting profile should preserve execution energy while keeping VibeGov’s stronger closure, oversight, and traceability model.

--- a/blog/2026-04-24-execution-sharpness-and-governed-closure.md
+++ b/blog/2026-04-24-execution-sharpness-and-governed-closure.md
@@ -1,0 +1,123 @@
+---
+slug: execution-sharpness-and-governed-closure
+title: "Execution Sharpness and Governed Closure"
+authors: [VibeGov_team]
+tags: [agents, execution, governance, harness, delivery]
+---
+
+A lot of agent systems now know how to move fast.
+
+That part is getting easier.
+
+The harder problem is keeping fast execution legible, governable, and closable.
+
+## The real upgrade teams need
+
+The next upgrade is not more agent theater.
+It is not longer plans.
+It is not status spam.
+
+It is a tighter operating shape:
+- direct execution on bounded work,
+- verification before completion claims,
+- concise checkpoints at meaningful state changes,
+- explicit handling of inherited state,
+- and closure that reaches the governed landing path.
+
+That is what dependable execution looks like.
+
+## What strong execution should feel like
+
+A healthy implementation loop should feel crisp.
+
+When the task is clear, the agent should:
+- gather the needed context,
+- make the change,
+- run the right proof,
+- close the state honestly,
+- and stop pretending that "edited files" means finished work.
+
+That is the productive part of high-agency execution.
+
+## What goes wrong when speed loses governance
+
+Fast execution becomes dangerous when teams let it collapse into black-box momentum.
+
+Common failure modes look like this:
+- inherited repo mess ignored in the name of progress,
+- silence mistaken for professionalism,
+- passing build output treated as completion,
+- risky decisions taken without visible boundary,
+- and residue pushed into the next work unit.
+
+These are not small style issues.
+They are reliability problems.
+
+## The operating rule VibeGov should encode
+
+The useful rule is simple:
+
+**Keep execution sharp, but make closure and legibility non-negotiable.**
+
+That means:
+- tool-first execution,
+- bounded work units,
+- truthful verifier and evaluator gates,
+- concise operator-visible checkpoints,
+- explicit inherited-state assessment,
+- and governed git/repo closure.
+
+## Legibility is not the same as chatter
+
+Teams often get stuck between two bad options:
+- constant narration, or
+- total silence.
+
+The better target is interrupt-efficient legibility.
+
+Operators should be able to see:
+- when a slice started or resumed,
+- when the plan materially changed,
+- when a blocker or decision boundary appeared,
+- what validation actually passed or failed,
+- and how the slice closed.
+
+That is enough for oversight without drowning the channel.
+
+## Closure is part of the work
+
+A slice is not complete when the code exists.
+
+A slice is complete when the governed path is closed:
+- issue/spec state is updated where required,
+- evidence exists,
+- git state is accounted for,
+- the merge or follow-up path is explicit,
+- and the repo returns to its expected base state.
+
+If that part is missing, the execution loop is still open.
+
+## Practical takeaway
+
+The goal is not to make agents slower.
+
+The goal is to make fast execution dependable.
+
+A strong system should feel like this:
+- less ceremony,
+- less ambiguity,
+- less hidden residue,
+- more direct proof,
+- more reliable closure.
+
+That is what VibeGov should normalize.
+
+## Related reading
+
+- [Execution Sharpness and Governed Closure](/docs/codex-prompting-through-vibegov)
+- [Harness Profile: Codex](/docs/harness-profile-codex)
+- [Minimal VibeGov Execution Profile Snippet](/docs/minimal-vibegov-execution-profile-snippet)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)

--- a/docs/codex-prompting-through-vibegov.md
+++ b/docs/codex-prompting-through-vibegov.md
@@ -2,155 +2,119 @@
 sidebar_position: 14
 ---
 
-# Codex Prompting Through a VibeGov Lens
+# Execution Sharpness and Governed Closure
 
-OpenAI's Codex prompting guidance is useful.
+VibeGov should encode strong execution behavior directly into its own rules, docs, and harness profiles.
 
-It is also incomplete as governance.
+That means keeping the useful execution patterns that help agents move cleanly from intent to verified result while expressing them in native VibeGov language.
 
-VibeGov should borrow the parts that sharpen execution quality, reject the parts that weaken operator legibility or state closure, and wrap the remainder in governed controls.
+## The execution stance
 
-## What VibeGov should borrow
+A strong VibeGov execution profile should behave like this:
 
 ### Tool-first execution
 
-Borrow the bias toward dedicated tools, fast discovery, and precise edits.
+Use dedicated tools, fast discovery, and precise edits where possible.
 
-Use structured tools over raw shell when possible. Prefer fast repo search, targeted reads, and coherent edits over terminal thrash.
+Prefer structured tool use over raw terminal drift. Prefer targeted reads and coherent edits over scattered thrash.
 
-### Bias toward completion
+### Completion bias
 
-Borrow the expectation that a clear task should usually move through context gathering, implementation, verification, and closure in one coherent loop.
+When a task is clear, move through context gathering, implementation, verification, and closure in one bounded loop.
 
-The useful lesson is not "never ask questions." The useful lesson is "do not substitute plans and preambles for progress."
+The point is not "never ask questions." The point is "do not substitute planning ceremony for progress."
 
 ### Read enough before changing
 
-Borrow the discipline of understanding local patterns, reuse opportunities, and surrounding behavior before editing.
+Understand local patterns, reuse opportunities, and surrounding behavior before editing.
 
-This reduces diff thrash and lowers the risk of narrow fixes that break neighboring surfaces.
+This reduces narrow fixes, diff churn, and accidental inconsistency across neighboring surfaces.
 
 ### Truthful verification
 
-Borrow the insistence that changes should be verified before being claimed complete.
+Do not treat confidence as proof.
 
-VibeGov agrees with the core idea: passing evidence matters more than confident narration.
+If behavior changed, the closing state should include direct evidence: checks, tests, inspection, screenshots, release verification, or another honest gate that matches the work.
 
 ### Low-noise communication
 
-Borrow the instinct to reduce empty status chatter.
+Keep updates concise and high-signal.
 
-Agent updates should carry information, not ceremony.
+Silence is not the goal. Constant narration is not the goal either. The goal is legible execution with minimal wasted interruption.
 
-## What VibeGov should reject or constrain
+## The guardrails
 
-### Do not absolutize parallelism
+Execution sharpness becomes dangerous when it loses closure or hides decision boundaries.
 
-Codex-style guidance is directionally right when it says to batch known reads and parallelize obvious independent work.
+A governed profile must keep these guardrails in place.
 
-But real debugging is often sequential and hypothesis-driven. "Always maximize parallelism" is a useful optimization heuristic, not a governance rule.
+### Legibility over black-box speed
 
-### Do not optimize away operator legibility
-
-Benchmark-style prompting often pushes hard against preambles, plans, and progress updates.
-
-VibeGov should reject the extreme version of that rule. Operators need meaningful checkpoints for start/resume, blocker state, validation results, and closure.
-
-The target is interrupt-efficient legibility, not silence.
-
-### Do not treat dirty-state handling as simplistic stop/go logic
-
-"Unexpected changes appeared, stop immediately" is too crude for governed work.
-
-VibeGov wants inherited-state assessment, explicit classification, and a visible treatment decision. Mixed repo state is a governance problem to classify, not just a trigger to freeze.
-
-### Constrain autonomy by risk class
-
-Codex prompting is strongest on reversible repository work.
-
-VibeGov should constrain the same autonomy when work becomes destructive, privacy-sensitive, public-facing, irreversible, production-affecting, or dependent on human judgment that has not yet been made visible.
-
-### Reject throughput as the top-level objective
-
-Codex prompting often optimizes for coding throughput and rollout momentum.
-
-VibeGov should optimize first for legibility, recoverability, accountability, and state closure. Throughput matters, but under those controls.
-
-## The governed synthesis
-
-The right synthesis is:
-
-- keep Codex's execution energy
-- keep VibeGov's closure and evidence model
-- keep human interruption points visible when they matter
-- keep repo state and governed artifacts honest at every boundary
-
-This produces a stronger operating profile than either one alone.
-
-Codex contributes a sharp implementation stance.
-
-VibeGov contributes bounded autonomy, durable state, explicit evidence, and repeatable closure semantics.
-
-## Proposed Codex-style VibeGov profile
-
-A Codex-style VibeGov profile should behave like this:
-
-### Act like a strong implementation agent
-
-- prefer action over ceremonial planning
-- implement the scoped change
-- verify before claiming progress
-- keep the loop coherent and bounded
-
-### Stay tool-first, not terminal-first
-
-- use dedicated tools where available
-- prefer fast search and targeted edits
-- parallelize when targets are already known
-- do not force batching that makes investigation worse
-
-### Stay truthful about reality
-
-- do not fake support for contracts that the system does not actually implement
-- do not let UI claims outrun backend truth
-- do not present exploratory findings as shipped fixes
-
-### Keep the operator informed at the right moments
-
-The profile should surface:
-- start or resume of the active slice
-- meaningful plan change
+Operators need to see meaningful state transitions:
+- start or resume
+- major plan change
 - blocker or decision boundary
-- validation result
+- validation outcome
 - closure outcome
 
-It should not narrate every trivial step.
+That is enough visibility for safe interruption and review without forcing noisy status spam.
 
-### Treat closure as part of the work
+### Inherited-state assessment before new work
+
+Messy repo state is not just an inconvenience.
+
+It must be assessed, classified, and treated explicitly before a new governed slice starts. Hidden residue should not be allowed to ride forward just because the agent wants momentum.
+
+### Autonomy bounded by consequence
+
+High agency is appropriate for clear, reversible internal work.
+
+The decision boundary must stay visible when the work becomes destructive, external, privacy-sensitive, public-facing, irreversible, or dependent on unresolved human judgment.
+
+### Closure as part of execution
 
 The slice is not complete at "files edited."
 
-The governed close should include the expected issue, spec, evidence, git-state, merge, archive, and return-to-base behavior for the repo.
+The close should include the expected issue, spec, evidence, git-state, merge-path, archive-path, and return-to-base behavior required by the repo.
 
-### Bound autonomy by consequence
+## Practical profile shape
 
-Act freely on clear, reversible internal work.
+A strong implementation profile inside VibeGov should:
+- act directly on clear bounded work
+- prefer tool-first execution
+- reuse repo patterns before inventing new ones
+- verify before claiming success
+- keep checkpoints concise but visible
+- classify inherited state before continuing
+- stop hiding uncertainty behind momentum
+- close the governed landing path fully
 
-Pause when the work becomes destructive, external, privacy-sensitive, non-recoverable, or dependent on unresolved human intent.
+## Common failure modes
+
+Avoid these patterns:
+- treating maximal parallelism as a rule instead of a heuristic
+- suppressing all progress updates in the name of efficiency
+- treating dirty or inherited repo state as background noise
+- optimizing rollout speed above accountability or recoverability
+- using passing build output as a substitute for true closure
+- claiming low narration while actually running as an opaque black box
 
 ## Why this matters
 
-Without the Codex influence, a governed agent can become overly ceremonial and slow.
+Without execution sharpness, a governed system becomes ceremonial and slow.
 
-Without the VibeGov layer, a high-performance coding agent can become hard to audit, hard to interrupt, and too willing to optimize speed over closure.
+Without governed closure, a fast implementation system becomes hard to audit, hard to interrupt, and too willing to trade reliability for momentum.
 
-The goal is not to choose between them.
+VibeGov should encode both:
+- strong execution posture
+- strong closure and legibility controls
 
-The goal is to combine execution sharpness with governed operability.
+That combination is the point.
 
 ## Recommended reading path
 
 - [Harness Profile: Codex](/docs/harness-profile-codex)
+- [Minimal VibeGov Execution Profile Snippet](/docs/minimal-vibegov-execution-profile-snippet)
 - [Harness Profile: Minimal Claude Harness](/docs/harness-profile-minimal-claude)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)

--- a/docs/harness-profile-codex.md
+++ b/docs/harness-profile-codex.md
@@ -4,7 +4,7 @@ sidebar_position: 13
 
 # Harness Profile: Codex
 
-This profile shows how to run a Codex-centered delivery loop inside VibeGov without letting Codex's speed-oriented prompting become the whole governance model.
+This profile shows how to run a Codex-centered delivery loop inside VibeGov without letting runtime speed become the whole governance model.
 
 It is a profile, not a core-governance replacement.
 
@@ -20,12 +20,14 @@ Use this when your team runs implementation loops primarily through Codex sessio
 
 ## Profile stance
 
-This profile intentionally combines two different strengths:
+This profile keeps a strong implementation posture inside firm governance boundaries.
 
-- **Codex contribution:** tool-first execution, strong implementation momentum, low tolerance for empty planning chatter, and a bias toward verification.
-- **VibeGov contribution:** bounded autonomy, governed artifacts, operator-legible checkpoints, state closure, and accountability at work-unit boundaries.
-
-Do not adopt Codex prompting wholesale. Adopt the useful execution posture and keep the stronger governance layer around it.
+The intended operating shape is:
+- move directly on clear bounded work
+- stay tool-first instead of terminal-first
+- keep progress visible at meaningful checkpoints
+- verify before claiming completion
+- close the governed landing path fully
 
 ## Profile contract
 
@@ -59,24 +61,27 @@ A Codex harness loop should explicitly provide:
    - clear, reversible internal work may proceed without waiting.
    - destructive, external, privacy-sensitive, irreversible, or judgment-dependent actions should surface a visible decision boundary.
 
-## What to borrow from Codex prompting
+## Execution pattern
 
-Borrow these parts aggressively:
-- tool-first work over raw terminal drift
-- completion bias instead of plan theater
-- reading enough context before editing
-- repo-convention reuse before invention
-- verification before completion claims
-- concise communication instead of ceremonial narration
+A healthy run should look like this:
+- orient on issue, spec, and inherited repo state
+- classify residue before starting fresh work
+- run baseline verifier
+- implement the scoped change only
+- run post-change verifier
+- run skeptical evaluator pass when the slice warrants it
+- loop on fixes only while the loop is producing real progress
+- close state through commit, merge-path, archive-path, or explicit follow-up handling
+- record evidence and residual risk truthfully
 
-## What to reject or constrain
+## Non-negotiable guardrails
 
-Do not import these as hard rules:
-- maximize parallelism at all times
-- suppress progress updates just because silence benchmarks well
-- treat dirty or inherited repo state as a simplistic stop signal instead of a classification problem
-- optimize rollout speed above closure, accountability, or recoverability
-- treat edited files as an adequate completion boundary
+Do not treat these as optional:
+- inherited repo state must be classified before new governed work starts
+- meaningful risk and uncertainty must stay visible
+- low narration does not justify low legibility
+- passing build output alone does not close a slice
+- rollout momentum does not outrank closure, accountability, or recoverability
 
 ## Mapping to VibeGov controls
 
@@ -92,20 +97,6 @@ Do not import these as hard rules:
 | Recurring cleanup and anti-slop | GOV-12 drift control |
 | Blocked/retry/stop behavior | GOV-02 escalation and move-on behavior |
 
-## Recommended Codex session pattern
-
-For each work unit:
-
-1. orient on issue, spec, and inherited repo state
-2. classify any residue before starting fresh work
-3. run baseline verifier
-4. implement the scoped change only
-5. run post-change verifier
-6. run skeptical evaluator pass when the slice warrants it
-7. loop on fixes only while the loop is producing real progress
-8. close state through commit, merge-path, archive-path, or explicit follow-up handling
-9. record evidence and any residual risks truthfully
-
 ## Adoption checklist
 
 When adopting this profile in a repo:
@@ -118,6 +109,14 @@ When adopting this profile in a repo:
 - enforce git-state closure at work-unit boundaries
 - require evidence links in issue and PR checkpoints
 - decide which actions require visible human decision boundaries
+- keep the prompt/profile small enough that operators can actually inspect it
+
+## Minimal prompt/profile snippet
+
+For a compact starting point, see:
+- [Minimal VibeGov Execution Profile Snippet](/docs/minimal-vibegov-execution-profile-snippet)
+
+Use it as a small harness seed, then add repo-specific verifier/evaluator/artifact details around it.
 
 ## Minimum quality bar for this profile
 
@@ -156,7 +155,8 @@ This Codex profile is an adapter layer that helps teams apply the same governanc
 
 ## Related docs
 
-- [Codex Prompting Through a VibeGov Lens](/docs/codex-prompting-through-vibegov)
+- [Execution Sharpness and Governed Closure](/docs/codex-prompting-through-vibegov)
+- [Minimal VibeGov Execution Profile Snippet](/docs/minimal-vibegov-execution-profile-snippet)
 - [Harness Profile: Minimal Claude Harness](/docs/harness-profile-minimal-claude)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)

--- a/docs/minimal-vibegov-execution-profile-snippet.md
+++ b/docs/minimal-vibegov-execution-profile-snippet.md
@@ -1,0 +1,89 @@
+---
+sidebar_position: 15
+---
+
+# Minimal VibeGov Execution Profile Snippet
+
+Use this when you want a compact execution-profile seed for a harness, session bootstrap, or repo-local agent prompt.
+
+It is intentionally small.
+
+Add repo-specific verifier commands, evaluator contracts, issue/spec paths, and deployment/release rules around it.
+
+## Minimal snippet
+
+```text
+You are operating inside a governed VibeGov delivery loop.
+
+Work as a strong implementation agent on clear, bounded tasks.
+Use the best available tools rather than drifting into raw terminal work.
+Read enough context before editing.
+Reuse existing repo patterns before inventing new ones.
+
+Do not substitute planning chatter for progress.
+When the task is clear, move through context, implementation, verification, and closure in one coherent loop.
+
+Keep execution legible.
+Surface meaningful checkpoints when they occur:
+- start or resume
+- major plan change
+- blocker or decision boundary
+- validation outcome
+- closure outcome
+Do not narrate every trivial step.
+
+Treat inherited repo state as real state.
+Before starting new governed work, assess and classify residue, mixed diffs, branch state, and untracked files.
+Do not carry unexplained state into the next slice.
+
+Verification is required before completion claims.
+Use the smallest honest gate that matches the work: test, build, typecheck, lint, focused inspection, screenshot, or release check.
+Confidence is not evidence.
+
+Closure is part of the work.
+A slice is not complete at edited files.
+Close through the repo's governed path: issue/spec updates where required, evidence captured, git-state accounted for, merge/follow-up path explicit, and repo returned to the expected base state.
+
+Act autonomously on clear, reversible internal work.
+Make decision boundaries visible for destructive, external, privacy-sensitive, irreversible, or unresolved-judgment actions.
+
+If retries stop producing real progress, stop churning, surface the blocker, and escalate or redirect honestly.
+```
+
+## How to use it
+
+Use this snippet as the compact execution layer.
+
+Then wrap it with repo-specific details such as:
+- canonical verifier commands
+- evaluator expectations
+- issue/spec/traceability locations
+- merge and branch-closure rules
+- release verification steps
+- environment- or project-specific safety boundaries
+
+## What this snippet is trying to preserve
+
+This snippet is meant to preserve a specific operating shape:
+- direct execution instead of ceremony
+- verification instead of confidence theater
+- concise legibility instead of status spam
+- closure instead of residue
+- autonomy with visible boundaries instead of black-box momentum
+
+## When not to use only this snippet
+
+Do not treat this as a full governance system.
+
+It is only a compact execution seed.
+If the repo has meaningful delivery machinery, release rules, review gates, or issue/spec requirements, those must still be defined elsewhere in governed artifacts.
+
+## Related docs
+
+- [Execution Sharpness and Governed Closure](/docs/codex-prompting-through-vibegov)
+- [Harness Profile: Codex](/docs/harness-profile-codex)
+- [Checkpoint Reporting](/docs/checkpoint-reporting)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)

--- a/sidebars.js
+++ b/sidebars.js
@@ -59,6 +59,7 @@ const sidebars = {
         'harness-profile-minimal-claude',
         'harness-profile-codex',
         'codex-prompting-through-vibegov',
+        'minimal-vibegov-execution-profile-snippet',
         'exploratory-review-mode',
         'checkpoint-reporting',
         'blocker-escalation',


### PR DESCRIPTION
## Summary
- tighten the recent execution docs so they read as direct VibeGov guidance instead of meta comparison
- add a companion article version
- add a minimal practical execution-profile snippet for harness use

## Validation
- npm run build

Closes #126
