### PR TITLE
issue-128: refine codex harness guidance

### DIFF
--- a/.governance/specs/codex-harness-second-pass-refinements.md
+++ b/.governance/specs/codex-harness-second-pass-refinements.md
@@ -1,0 +1,48 @@
+# Codex Harness Second-Pass Refinements
+
+## Intent
+Capture the worthwhile second-pass follow-through from a full review of OpenAI's Codex Prompting Guide without turning VibeGov into a Codex-specific or benchmark-shaped governance system.
+
+## Scope
+In scope:
+- tighten the Codex harness profile around tool-surface design, tool-response shaping, commentary/final-answer separation, `AGENTS.md` layering, and governed metaprompting
+- clarify in the execution-sharpness doc that these concerns belong primarily to the execution/harness layer rather than the canonical bootstrap contract
+- add one small practical public checklist doc for harness builders
+- keep runtime-specific guidance runtime-specific while preserving tool-agnostic governance at the core
+
+Out of scope:
+- making Codex mandatory for VibeGov
+- importing rigid "maximize parallelism" or benchmark-first heuristics as governance rules
+- bloating the minimal execution snippet into a full harness manual
+- replacing GOV rules with provider-specific prompt cargo cults
+
+## Acceptance Criteria
+- `.governance/specs/codex-harness-second-pass-refinements.md` exists with bounded intent and scope.
+- `docs/harness-profile-codex.md` explicitly covers tool-surface design, tool-response shaping, commentary/final-answer separation, `AGENTS.md` layering, and governed metaprompting.
+- `docs/codex-prompting-through-vibegov.md` explicitly distinguishes bootstrap contract concerns from execution/harness concerns and names the second-pass additions.
+- A new small public checklist doc exists for harness builders and is linked in `sidebars.js`.
+- `docs/minimal-vibegov-execution-profile-snippet.md` remains aligned with the refined profile framing.
+- `npm run build` passes.
+
+## Tests and Evidence
+- inspect `.governance/specs/codex-harness-second-pass-refinements.md`
+- inspect `docs/harness-profile-codex.md`
+- inspect `docs/codex-prompting-through-vibegov.md`
+- inspect `docs/harness-builder-checklist.md`
+- inspect `docs/minimal-vibegov-execution-profile-snippet.md`
+- inspect `sidebars.js`
+- run `npm run build`
+
+## Documentation Impact
+- update `docs/harness-profile-codex.md`
+- update `docs/codex-prompting-through-vibegov.md`
+- add `docs/harness-builder-checklist.md`
+- update `docs/minimal-vibegov-execution-profile-snippet.md`
+- update `sidebars.js`
+
+## Verification
+Verification is documentation/build driven. Success requires that the new additions read as concrete harness-design guidance, stay consistent with VibeGov's stronger closure/continuity model, remain discoverable in docs navigation, and build cleanly.
+
+## Change Notes
+- This slice should preserve the earlier native-VibeGov translation while adding the harness-level details that were still missing after the first pass.
+- The result should make it easier for teams to build good coding-agent harnesses without mistaking runtime-specific mechanics for core governance law.

--- a/docs/codex-prompting-through-vibegov.md
+++ b/docs/codex-prompting-through-vibegov.md
@@ -8,6 +8,12 @@ VibeGov should encode strong execution behavior directly into its own rules, doc
 
 That means keeping the useful execution patterns that help agents move cleanly from intent to verified result while expressing them in native VibeGov language.
 
+It also means being explicit about scope.
+
+The canonical bootstrap contract is still about installing governed repo structure, continuity, issue/spec discipline, and reporting surfaces.
+
+The second-pass Codex lessons mostly improve the execution and harness layer around that contract: tool surface design, output shaping, commentary mechanics, instruction layering, and governed self-improvement.
+
 ## The execution stance
 
 A strong VibeGov execution profile should behave like this:
@@ -41,6 +47,24 @@ If behavior changed, the closing state should include direct evidence: checks, t
 Keep updates concise and high-signal.
 
 Silence is not the goal. Constant narration is not the goal either. The goal is legible execution with minimal wasted interruption.
+
+### Tool surface and output shaping
+
+Prompt quality is only part of the harness.
+
+The tool surface itself matters. A strong coding-agent harness should expose purpose-fit tools with obvious semantics, stable argument shapes, and readable result formats. Large tool outputs should be intentionally shaped or truncated so they preserve decision-useful signal instead of drowning the transcript in noise.
+
+### Instruction layering
+
+Top-level agent instruction files should behave like maps.
+
+A short `AGENTS.md` that points clearly to deeper canonical sources is usually better than a giant top-level encyclopedia. Progressive disclosure improves both discoverability and compliance.
+
+### Governed self-improvement
+
+Metaprompting can be useful.
+
+But if a harness or prompt lesson proves durable, it should be promoted into a governed artifact rather than left as one clever conversation or hidden operator habit.
 
 ## The guardrails
 
@@ -82,10 +106,12 @@ The close should include the expected issue, spec, evidence, git-state, merge-pa
 A strong implementation profile inside VibeGov should:
 - act directly on clear bounded work
 - prefer tool-first execution
+- shape tools and outputs so the model can work legibly
 - reuse repo patterns before inventing new ones
 - verify before claiming success
 - keep checkpoints concise but visible
 - classify inherited state before continuing
+- keep top-level instruction layers short and discoverable
 - stop hiding uncertainty behind momentum
 - close the governed landing path fully
 
@@ -95,6 +121,8 @@ Avoid these patterns:
 - treating maximal parallelism as a rule instead of a heuristic
 - suppressing all progress updates in the name of efficiency
 - treating dirty or inherited repo state as background noise
+- treating tool design as an implementation detail instead of a primary harness lever
+- dumping huge raw outputs into the transcript without shaping
 - optimizing rollout speed above accountability or recoverability
 - using passing build output as a substitute for true closure
 - claiming low narration while actually running as an opaque black box

--- a/docs/harness-builder-checklist.md
+++ b/docs/harness-builder-checklist.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 16
+---
+
+# Harness Builder Checklist
+
+Use this when you are building or refining a coding-agent harness and want a compact checklist that sits between high-level governance and low-level prompt tinkering.
+
+This is not a full governance system.
+
+It is a practical checklist for the harness layer.
+
+## What this checklist is for
+
+A good coding-agent harness is not only a prompt.
+
+It is also:
+- instruction layering,
+- tool surface design,
+- output shaping,
+- progress-message behavior,
+- verification gates,
+- and improvement paths.
+
+## Checklist
+
+### 1. Separate bootstrap from execution
+
+Be clear about what belongs to the canonical bootstrap contract versus the active execution harness.
+
+Bootstrap should install governed structure, continuity, issue/spec discipline, and reporting surfaces.
+
+The execution harness should shape how the model works inside that governed environment.
+
+### 2. Keep top-level instructions map-like
+
+Use `AGENTS.md` or the equivalent top-level instruction file as a short entrypoint.
+
+It should point clearly to deeper canonical sources instead of trying to contain every rule in one giant file.
+
+### 3. Expose purpose-fit tools
+
+Prefer tools whose names and arguments make the intended action obvious.
+
+If the model always has to reconstruct intent through raw shell usage, the harness is making the work harder than it needs to be.
+
+### 4. Shape large outputs deliberately
+
+Do not let logs, diffs, or search results flood the transcript by default.
+
+Define how large outputs are truncated, summarized, or split while preserving the signal needed for the next decision.
+
+### 5. Preserve commentary vs closeout semantics
+
+If the runtime supports progress/commentary messages separately from final answers, use that distinction intentionally.
+
+Progress updates should orient the operator without turning into a synthetic activity log.
+
+### 6. Keep verification explicit
+
+Define the smallest honest gate that matches the work.
+
+Do not let confidence, narration quality, or a passing build alone stand in for verification.
+
+### 7. Make inherited state visible
+
+Classify dirty tree state, mixed diffs, branch state, untracked files, and missing prerequisites before new governed work begins.
+
+Do not let hidden residue ride forward.
+
+### 8. Bound retries and escalation
+
+Define when the model should keep going, when it should retry once, and when it should stop and surface a blocker.
+
+Unbounded churn is not autonomy.
+
+### 9. Capture durable improvements durably
+
+If a prompt or harness adjustment proves genuinely useful, promote it into a governed artifact.
+
+Do not leave important lessons trapped in chat transcripts, operator memory, or one-off local tweaks.
+
+## What this checklist protects against
+
+It helps reduce:
+- prompt cargo culting,
+- shell-first drift,
+- transcript flooding,
+- black-box execution,
+- closure theater,
+- and hidden harness folklore.
+
+## Related docs
+
+- [Harness Profile: Codex](/docs/harness-profile-codex)
+- [Execution Sharpness and Governed Closure](/docs/codex-prompting-through-vibegov)
+- [Minimal VibeGov Execution Profile Snippet](/docs/minimal-vibegov-execution-profile-snippet)
+- [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
+- [Published GOV 11 Agent Legibility and In-Repo Truth](/docs/published/gov-11-agent-legibility-in-repo-truth)
+- [Published GOV 13 Review Loops and Completion Discipline](/docs/published/gov-13-review-loops-completion-discipline)

--- a/docs/harness-profile-codex.md
+++ b/docs/harness-profile-codex.md
@@ -44,32 +44,53 @@ A Codex harness loop should explicitly provide:
    - separate skeptical evaluation path with explicit pass/fail or scored output.
    - treat that evaluator path as a bounded control inside the active Development or Exploration flow, not as a third top-level mode.
 
-4. **State artifacts**
+4. **Tool-surface contract**
+   - expose solver-shaped tools that make the intended action obvious.
+   - prefer stable tool names, structured arguments, and purpose-fit wrappers over forcing the model to reconstruct everything through raw shell use.
+
+5. **Output-shaping contract**
+   - tool responses should preserve the signal needed for the next step rather than dumping uncontrolled bulk.
+   - large outputs should be intentionally shaped or truncated with explicit loss markers so the transcript stays useful.
+
+6. **State artifacts**
    - durable plan, progress, evidence, and follow-up artifacts in repo.
 
-5. **Legibility contract**
+7. **Legibility contract**
    - concise checkpoints for start or resume, plan change, blocker or risk, validation outcome, and closure outcome.
    - avoid both status spam and opaque black-box silence.
 
-6. **Closure semantics**
+8. **Commentary contract**
+   - if the runtime distinguishes commentary from final closeout, preserve that distinction cleanly.
+   - progress updates should orient the operator without turning into a synthetic tool-call log.
+
+9. **Instruction-layering contract**
+   - treat `AGENTS.md` and related instruction files as a progressive-disclosure map, not a dumping ground.
+   - keep the top-level entrypoint short, discoverable, and explicitly linked to deeper canonical sources.
+
+10. **Closure semantics**
    - completion only when verification, evaluation, traceability, and git-state closure conditions are met.
 
-7. **Escalation semantics**
+11. **Escalation semantics**
    - bounded retry loops and explicit blocked outcomes when confidence cannot be raised honestly.
 
-8. **Autonomy boundary**
+12. **Autonomy boundary**
    - clear, reversible internal work may proceed without waiting.
    - destructive, external, privacy-sensitive, irreversible, or judgment-dependent actions should surface a visible decision boundary.
+
+13. **Improvement-loop contract**
+   - metaprompting and self-improvement are allowed, but the learned change should be persisted into governed artifacts rather than left as chat-only folklore.
 
 ## Execution pattern
 
 A healthy run should look like this:
-- orient on issue, spec, and inherited repo state
+- orient on issue, spec, inherited repo state, and active instruction layers
 - classify residue before starting fresh work
+- confirm the solver/tool surface fits the intended work
 - run baseline verifier
 - implement the scoped change only
 - run post-change verifier
 - run skeptical evaluator pass when the slice warrants it
+- shape large outputs so they remain readable and decision-useful
 - loop on fixes only while the loop is producing real progress
 - close state through commit, merge-path, archive-path, or explicit follow-up handling
 - record evidence and residual risk truthfully
@@ -80,6 +101,8 @@ Do not treat these as optional:
 - inherited repo state must be classified before new governed work starts
 - meaningful risk and uncertainty must stay visible
 - low narration does not justify low legibility
+- top-level instruction files should stay map-like and discoverable
+- large tool output should be shaped intentionally instead of flooding the transcript
 - passing build output alone does not close a slice
 - rollout momentum does not outrank closure, accountability, or recoverability
 
@@ -89,12 +112,16 @@ Do not treat these as optional:
 | --- | --- |
 | One scoped task loop | GOV-07 tasks + GOV-02 workflow |
 | Tool-first execution inside a bounded work unit | GOV-02 workflow + GOV-11 legibility |
+| Purpose-fit tool surface and wrappers | GOV-02 workflow + GOV-11 in-repo truth |
+| Output shaping and truncation discipline | GOV-11 legibility + GOV-04 quality |
 | Baseline and post-change verification | GOV-05 testing + GOV-04 quality gate |
 | Separate evaluator judgment | GOV-13 review loops + GOV-04 anti-fake-completion |
 | Durable plan/progress artifacts | GOV-11 in-repo truth + GOV-09 continuity |
 | Operator-legible checkpoints | GOV-11 legible execution and bounded autonomy |
+| `AGENTS.md` as progressive-disclosure map | GOV-11 in-repo truth + GOV-01 instructions |
 | Git state closure before move-on | GOV-10 state closure and git hygiene |
 | Recurring cleanup and anti-slop | GOV-12 drift control |
+| Metaprompting captured as durable learning | GOV-13 review loops + feedback assimilation pattern |
 | Blocked/retry/stop behavior | GOV-02 escalation and move-on behavior |
 
 ## Adoption checklist
@@ -103,12 +130,16 @@ When adopting this profile in a repo:
 
 - define canonical verifier command(s)
 - define evaluator output schema and fail conditions
+- define the tool surface the model should prefer for common actions
 - define plan, progress, evidence, and follow-up artifact locations
+- define how large tool outputs are truncated or summarized without hiding important evidence
 - define the checkpoint/report moments operators should expect
 - define retry cap and blocked/escalation handoff path
 - enforce git-state closure at work-unit boundaries
 - require evidence links in issue and PR checkpoints
 - decide which actions require visible human decision boundaries
+- keep top-level instruction files short and map-like
+- define how harness/prompt improvements get promoted into governed artifacts
 - keep the prompt/profile small enough that operators can actually inspect it
 
 ## Minimal prompt/profile snippet
@@ -133,8 +164,11 @@ A Codex-centered run should not be considered complete unless:
 Avoid these:
 - letting Codex self-grade as the only quality gate
 - using chat memory as durable state instead of repo artifacts
+- making the shell the default interface when purpose-fit tools exist
+- flooding the transcript with raw bulk output instead of shaping it
 - marking done on passing build alone
 - carrying dirty-tree residue to the next work unit
+- turning `AGENTS.md` into an encyclopedia instead of a map
 - running unbounded retries without escalation
 - hiding meaningful risk or uncertainty to preserve rollout momentum
 - treating low narration as permission for low legibility

--- a/docs/minimal-vibegov-execution-profile-snippet.md
+++ b/docs/minimal-vibegov-execution-profile-snippet.md
@@ -58,6 +58,7 @@ Then wrap it with repo-specific details such as:
 - canonical verifier commands
 - evaluator expectations
 - issue/spec/traceability locations
+- tool-surface and output-shaping expectations
 - merge and branch-closure rules
 - release verification steps
 - environment- or project-specific safety boundaries
@@ -82,6 +83,7 @@ If the repo has meaningful delivery machinery, release rules, review gates, or i
 
 - [Execution Sharpness and Governed Closure](/docs/codex-prompting-through-vibegov)
 - [Harness Profile: Codex](/docs/harness-profile-codex)
+- [Harness Builder Checklist](/docs/harness-builder-checklist)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Published GOV 10 Agent State Closure and Git Hygiene](/docs/published/gov-10-agent-state-closure-git-hygiene)

--- a/sidebars.js
+++ b/sidebars.js
@@ -59,6 +59,7 @@ const sidebars = {
         'harness-profile-minimal-claude',
         'harness-profile-codex',
         'codex-prompting-through-vibegov',
+        'harness-builder-checklist',
         'minimal-vibegov-execution-profile-snippet',
         'exploratory-review-mode',
         'checkpoint-reporting',


### PR DESCRIPTION
## Summary
- add a second-pass spec for worthwhile Codex harness follow-through
- expand the Codex harness profile with tool-surface design, output shaping, commentary/final-answer handling, instruction layering, and governed metaprompting
- add a small public Harness Builder Checklist and keep the execution snippet/nav aligned

## Testing
- npm run build

## Notes
- This keeps the new guidance at the harness/execution layer rather than turning runtime-specific mechanics into core VibeGov law.
