### PR TITLE
issue-130: add feedback intake work shape

### DIFF
--- a/.governance/specs/feedback-intake-mode.md
+++ b/.governance/specs/feedback-intake-mode.md
@@ -1,0 +1,50 @@
+# Feedback Intake Mode
+
+## Intent
+Define **Feedback Intake** as the named VibeGov work shape for converting human feedback into governed ready work without collapsing immediately into implementation.
+
+## Scope
+In scope:
+- define Feedback Intake as the work shape used when a human gives feature/product/process feedback and the agent should capture, split, deduplicate, bind, and stop before implementation
+- explain how Feedback Intake relates to the Human Feedback Loop
+- distinguish it from Development, Exploration, Evaluation, and generic planning
+- define expected outputs and minimum closure evidence
+- update the relevant public docs and navigation
+
+Out of scope:
+- forcing Feedback Intake to replace existing Exploration or Development semantics
+- adding provider-specific Codex/VS Code prompt recipes in this slice
+- turning Feedback Intake into a bloated umbrella for every non-implementation task
+- changing core GOV rules unless a clear gap appears
+
+## Acceptance Criteria
+- `.governance/specs/feedback-intake-mode.md` exists with bounded intent and scope.
+- `docs/feedback-intake.md` exists and clearly defines the work shape.
+- `docs/execution-modes.md` explains where Feedback Intake sits relative to the two primary modes.
+- `docs/build-exploratory-human-feedback-loops.md` explicitly names Feedback Intake inside the Human Feedback Loop.
+- `docs/mode-selection-and-evidence-closing.md` includes Feedback Intake in the work-shape/evidence guidance.
+- `sidebars.js` links the new public doc.
+- `npm run build` passes.
+
+## Tests and Evidence
+- inspect `.governance/specs/feedback-intake-mode.md`
+- inspect `docs/feedback-intake.md`
+- inspect `docs/execution-modes.md`
+- inspect `docs/build-exploratory-human-feedback-loops.md`
+- inspect `docs/mode-selection-and-evidence-closing.md`
+- inspect `sidebars.js`
+- run `npm run build`
+
+## Documentation Impact
+- add `docs/feedback-intake.md`
+- update `docs/execution-modes.md`
+- update `docs/build-exploratory-human-feedback-loops.md`
+- update `docs/mode-selection-and-evidence-closing.md`
+- update `sidebars.js`
+
+## Verification
+Verification is documentation/build driven. Success requires the term to be crisply defined, differentiated from nearby concepts, discoverable in docs, and validated by a passing build.
+
+## Change Notes
+- Feedback Intake should preserve the clarity of the current loop/mode model rather than muddy it.
+- The goal is to name a real recurring work shape, not to invent ceremony.

--- a/docs/build-exploratory-human-feedback-loops.md
+++ b/docs/build-exploratory-human-feedback-loops.md
@@ -26,7 +26,7 @@ That distinction matters.
 In practice:
 - the **Build Loop** usually runs **Development** work,
 - the **Exploratory Loop** usually runs **Exploration** work,
-- the **Human Feedback Loop** can reshape either one,
+- the **Human Feedback Loop** often uses **Feedback Intake** to reshape either one,
 - and the **Evaluation pattern** may appear inside either mode when bounded judgment is needed.
 
 That is why loops and modes should support each other, not compete with each other.
@@ -134,6 +134,20 @@ The Human Feedback Loop should feed back into the system by:
 - creating or reshaping governed work,
 - changing acceptance criteria,
 - or explicitly blocking/unblocking a specific path.
+
+### Feedback Intake inside the Human Feedback Loop
+
+The most common governed work shape inside this loop is **Feedback Intake**.
+
+That means the agent should often:
+- capture the feedback cleanly,
+- check for existing related issues/specs,
+- split broad feedback into the right work units,
+- bind or create the right issue/spec artifacts,
+- classify readiness/dependencies,
+- and stop before implementation unless the human explicitly switches modes.
+
+This is how human feedback becomes governed backlog/spec state instead of evaporating into chat or immediately collapsing into ad hoc implementation.
 
 ## 4) Scoped Blocking
 
@@ -278,11 +292,13 @@ Ask four questions:
 1. Am I consuming governed work and changing reality? → **Build Loop**
 2. Am I reviewing reality and feeding new governed work? → **Exploratory Loop**
 3. Am I injecting human judgment, approval, or reprioritisation? → **Human Feedback Loop**
-4. Does this input block everything, or only one specific lane? → apply **Scoped Blocking**
+4. Am I capturing that input into governed ready work without implementing yet? → **Feedback Intake**
+5. Does this input block everything, or only one specific lane? → apply **Scoped Blocking**
 
 ## Related docs
 
 - [Execution Modes](/docs/execution-modes)
+- [Feedback Intake](/docs/feedback-intake)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Exploratory Review Mode](/docs/exploratory-review-mode)
 - [Evaluation Pattern](/docs/evaluation-pattern)

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -10,6 +10,12 @@ A review pass and a delivery pass are not interchangeable. They need different o
 
 ## The two operating modes
 
+VibeGov still keeps two primary operating modes: **Exploration** and **Development**.
+
+But there are also named work shapes that sit around or inside those modes.
+
+One of the most important is **Feedback Intake**: the governed work shape used inside the Human Feedback Loop when the goal is to convert human feedback into ready backlog/spec work without implementing immediately.
+
 ### 1) Exploration mode
 Use Exploration mode when the goal is discovery, review, judgment, or backlog hydration on non-delivery surfaces.
 
@@ -61,6 +67,29 @@ What not to do:
 - collapse multiple unrelated findings into one vague change
 - claim done without proof
 
+## Feedback Intake sits beside the primary modes
+
+Feedback Intake is not just vague planning and not a full delivery mode.
+
+It is the work shape for:
+- capturing human feedback on work that already exists
+- checking for existing related issues/specs
+- splitting broad feedback into the right governed work units
+- tightening acceptance criteria or priority/dependency notes
+- stopping before implementation unless the human explicitly switches to Development
+
+Expected outputs:
+- issue creation or updates
+- spec links or `SPEC_GAP`
+- split/scoped follow-up work units
+- readiness, blocker, and dependency notes
+- recommended execution order
+
+What not to do:
+- claim the product change was delivered
+- hide the work as a chat-only plan
+- blur feedback capture into implementation by default
+
 ## Evaluation lives inside a mode
 
 Evaluation is not a third peer mode. It is a bounded judgment pattern used inside Exploration or Development when explicit criteria-based review is needed.
@@ -84,6 +113,7 @@ Release verification is not a third peer mode. It is part of Development's deliv
 This is also where loops and modes meet cleanly:
 - release verification usually sits inside the **Build Loop**,
 - exploratory review usually sits inside the **Exploratory Loop**,
+- feedback intake usually sits inside the **Human Feedback Loop**,
 - and human feedback can reshape either one without becoming a separate execution mode.
 
 Typical release-verification work includes:
@@ -114,6 +144,14 @@ Mode selection keeps the workflow honest.
 - expected vs actual notes
 - artifact links created
 
+### Feedback Intake evidence
+- feedback source or reviewed target identified
+- issue IDs created or updated
+- spec binding or `SPEC_GAP`
+- split/dedupe decisions made visible
+- readiness, blocker, or dependency notes captured
+- no false implication that implementation already happened
+
 ### Development evidence
 - requirement IDs
 - commands/checks/tests run
@@ -126,13 +164,14 @@ Mode selection keeps the workflow honest.
 
 Ask one question before you start:
 
-> Am I trying to discover reality, or change reality and ship it safely?
+> Am I trying to discover reality, turn human feedback into ready work, or change reality and ship it safely?
 
-That answer should determine the mode.
+That answer should determine the work shape.
 
 ## Related docs
 
 - [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
+- [Feedback Intake](/docs/feedback-intake)
 - [Quick Decisions](/docs/quick-decisions)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Evaluation Pattern](/docs/evaluation-pattern)

--- a/docs/feedback-intake.md
+++ b/docs/feedback-intake.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 8
+---
+
+# Feedback Intake
+
+Feedback Intake is the VibeGov work shape for turning human feedback into governed ready work without implementing immediately.
+
+It is the named intake behavior inside the **Human Feedback Loop**.
+
+## What Feedback Intake is for
+
+Use Feedback Intake when a human is reacting to work that already exists and the immediate goal is to capture, reshape, and route that feedback correctly before delivery starts.
+
+Typical inputs:
+- feature feedback
+- flow/UX reactions
+- reprioritisation notes
+- scope corrections
+- quality/taste direction
+- partial "this is close but not right" guidance
+- a burst of ideas that should become proper issues rather than immediate edits
+
+## What Feedback Intake does
+
+A good Feedback Intake pass should:
+- understand the feedback in context
+- check for existing related issues/specs so work is not duplicated
+- split broad feedback into the smallest correct governed work units
+- bind the feedback to the right issue, spec, or `SPEC_GAP`
+- classify dependencies, blockers, and readiness
+- recommend next execution order
+- stop before implementation unless the human explicitly switches modes
+
+## What Feedback Intake is not
+
+Feedback Intake is **not**:
+- vague planning with no artifacts
+- direct implementation
+- exploratory discovery of unknown reality
+- release verification
+- a substitute for explicit Development evidence
+
+It may involve planning, but its output is governed backlog/spec state rather than a chat-only plan.
+
+## Expected outputs
+
+Typical Feedback Intake outputs include:
+- new or updated GitHub issues
+- spec links or `SPEC_GAP` markers
+- split child issues when a feedback bundle is too broad
+- acceptance-criteria tightening
+- priority/dependency notes
+- a recommended next-ready execution order
+
+## Minimum closure evidence
+
+Feedback Intake is honestly complete when it leaves:
+- the feedback source or reviewed target clearly identified
+- the created or updated issue IDs
+- spec binding or `SPEC_GAP`
+- dedupe/splitting decisions made visible
+- readiness/blocker/dependency notes captured
+- no false implication that the product change itself was delivered
+
+## Relationship to other work shapes
+
+### Feedback Intake vs Development
+
+- **Feedback Intake** converts feedback into governed ready work.
+- **Development** changes the product and proves the change.
+
+### Feedback Intake vs Exploration
+
+- **Feedback Intake** starts from human judgment/correction.
+- **Exploration** starts from review/discovery of reality and feeds new governed work back from that discovery.
+
+### Feedback Intake vs Evaluation
+
+- **Feedback Intake** routes and structures work.
+- **Evaluation** gives a bounded criteria-based verdict inside another work shape.
+
+### Feedback Intake vs planning
+
+- **Planning** may happen inside many work shapes.
+- **Feedback Intake** is a concrete governed output shape with issue/spec artifacts.
+
+## Fast rule
+
+Use Feedback Intake when the real question is:
+
+> "How do I turn this human feedback into the right governed work without implementing yet?"
+
+## Related docs
+
+- [Execution Modes](/docs/execution-modes)
+- [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
+- [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
+- [Feedback Assimilation Pattern](/docs/feedback-assimilation-pattern)
+- [Quick Decisions](/docs/quick-decisions)

--- a/docs/mode-selection-and-evidence-closing.md
+++ b/docs/mode-selection-and-evidence-closing.md
@@ -16,12 +16,14 @@ This is the compact operator guide for choosing the right VibeGov work shape wit
 | If the real goal is... | Work shape | What closes it |
 | --- | --- | --- |
 | inspect behavior, discover gaps, understand reality, hydrate backlog | **Exploration** | reviewed scope, scenario classifications, expected vs actual notes, linked issues/spec gaps |
+| turn human feedback into governed ready work without implementing yet | **Feedback Intake** | issue/spec updates, split/dedupe decisions, readiness/dependency notes, recommended next order |
 | change behavior and carry the change toward safe delivery | **Development** | issue/spec binding, changed artifacts, validation evidence, traceability/docs updates |
 | judge a bounded unit against explicit criteria | **Evaluation pattern** inside the current mode | explicit criteria, bounded judgment, pass/fail or scored result |
 | decide whether a built candidate is safe to promote or ship | **Release verification** inside Development | build/version reviewed, integrated checks, go/no-go decision, blockers/risks made visible |
 
 Fast rule:
 - **Exploration** discovers.
+- **Feedback Intake** captures and shapes human feedback into ready work.
 - **Development** changes.
 - **Evaluation** judges a bounded unit.
 - **Release verification** closes a Development-ready candidate.
@@ -36,7 +38,7 @@ A lot of confusion disappears once these are kept separate.
 Typical mapping:
 - **Build Loop** mostly contains **Development** work
 - **Exploratory Loop** mostly contains **Exploration** work
-- **Human Feedback Loop** injects judgment, approval, correction, and reprioritisation into either one
+- **Human Feedback Loop** often uses **Feedback Intake** to inject judgment, approval, correction, and reprioritisation into either one
 - **Evaluation** may be used inside any of those when a bounded verdict is needed
 
 So if you are unsure, choose the **mode** first, then describe the surrounding **loop** second.
@@ -67,6 +69,17 @@ Minimum closure:
 - expected vs actual notes for failures or interesting findings
 - linked issue/spec/traceability artifacts for each real finding
 - residual scope noted honestly
+
+### Feedback Intake
+Use when the goal is to capture human feedback as governed ready work.
+
+Minimum closure:
+- feedback source or reviewed target identified
+- created or updated issue IDs
+- spec binding or `SPEC_GAP`
+- split/dedupe decisions made visible
+- readiness/blocker/dependency notes captured
+- no false implication that implementation already happened
 
 ### Development
 Use when behavior changed.
@@ -155,6 +168,7 @@ If the answers are blurry, the mode is probably blurry too.
 
 - [Quick Decisions](/docs/quick-decisions)
 - [Execution Modes](/docs/execution-modes)
+- [Feedback Intake](/docs/feedback-intake)
 - [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
 - [Evaluation Pattern](/docs/evaluation-pattern)
 - [Checkpoint Reporting](/docs/checkpoint-reporting)

--- a/docs/quick-decisions.md
+++ b/docs/quick-decisions.md
@@ -13,10 +13,12 @@ Use it when you need a practical answer quickly, then follow the linked deeper d
 | If the goal is... | Use this | What closes it |
 | --- | --- | --- |
 | discover reality, inspect behavior, find gaps, hydrate backlog | **Exploration** | reviewed scope, scenario classifications, artifact links for every real finding |
+| turn human feedback into governed ready work without implementing yet | **Feedback Intake** | issue/spec updates, split/dedupe decisions, readiness/dependency notes |
 | change behavior and carry the change toward release safely | **Development** | issue/spec binding, changed artifacts, validation evidence, traceability updates |
 
 Fast rule:
 - **Exploration** discovers.
+- **Feedback Intake** captures and shapes human feedback into ready work.
 - **Development** changes.
 
 ## 2. Am I exploring or just avoiding proof?
@@ -24,6 +26,7 @@ Fast rule:
 | Signal | Likely answer |
 | --- | --- |
 | you are reviewing routes, flows, UX, gaps, or product reality | **Exploration** |
+| you are reacting to existing work and want proper issues/spec updates before coding | **Feedback Intake** |
 | you changed code, docs, config, content, or delivery machinery | **Development** |
 | you are claiming something works now | **Development evidence required** |
 
@@ -193,8 +196,8 @@ Fast rule:
 
 ## Start here if you are unsure
 
-1. Ask: **Am I discovering, or changing?**
-2. Choose **Exploration** or **Development**.
+1. Ask: **Am I discovering, capturing human feedback into ready work, or changing?**
+2. Choose **Exploration**, **Feedback Intake**, or **Development**.
 3. If you need a bounded judgment, apply the **evaluation pattern** inside that mode.
 4. Keep the execution shape as simple as possible.
 5. Do not claim done until the evidence matches the work shape.
@@ -202,6 +205,7 @@ Fast rule:
 ## Related docs
 
 - [Execution Modes](/docs/execution-modes)
+- [Feedback Intake](/docs/feedback-intake)
 - [Mode Selection and Evidence Closing](/docs/mode-selection-and-evidence-closing)
 - [Build Loop, Exploratory Loop, Human Feedback Loop, and Scoped Blocking](/docs/build-exploratory-human-feedback-loops)
 - [Evaluation Pattern](/docs/evaluation-pattern)

--- a/sidebars.js
+++ b/sidebars.js
@@ -50,6 +50,7 @@ const sidebars = {
       items: [
         'execution-modes',
         'build-exploratory-human-feedback-loops',
+        'feedback-intake',
         'quick-decisions',
         'mode-selection-and-evidence-closing',
         'simplicity-first',


### PR DESCRIPTION
## Summary
- define Feedback Intake as the named VibeGov work shape for turning human feedback into governed ready work without immediate implementation
- add a dedicated public doc and wire it into the loop/mode/quick-decision guidance
- keep the two-primary-mode model intact while naming the feedback-capture behavior explicitly

## Testing
- npm run build
