### PR TITLE
issue-134: add structured data and tighten entry-page metadata

### DIFF
--- a/.governance/specs/site-structured-data-and-seo-tightening.md
+++ b/.governance/specs/site-structured-data-and-seo-tightening.md
@@ -1,0 +1,41 @@
+# Site Structured Data and SEO Tightening
+
+## Intent
+Improve VibeGov’s public machine-readable identity and page-level search metadata so major entry pages are more descriptive and the site exposes accurate minimal structured data.
+
+## Scope
+In scope:
+- add minimal accurate schema.org / JSON-LD for the public site
+- start with Organization and WebSite structured data only
+- tighten metadata on the main public entry docs that still rely on weak/default descriptions
+- validate generated HTML and JSON-LD in the built output
+
+Out of scope:
+- broad page-by-page copy rewrites across the whole docs tree
+- speculative schema spam or unjustified page-specific schema types
+- search-engine ranking claims beyond metadata quality improvements
+
+## Acceptance Criteria
+- `SEO2-001` The public site emits accurate Organization structured data for VibeGov.
+- `SEO2-002` The public site emits accurate WebSite structured data for vibegov.io.
+- `SEO2-003` Key public entry docs pages use explicit page-specific metadata instead of generic/default descriptions where that materially improves clarity.
+- `SEO2-004` `npm run build` succeeds after the changes.
+- `SEO2-005` Generated HTML inspection confirms the expected JSON-LD and updated title/description metadata.
+
+## Tests and Evidence
+- `npm run build`
+- inspect built HTML for homepage and selected docs entry pages
+- confirm JSON-LD script output in generated HTML matches the intended site identity
+
+## Documentation Impact
+- update the affected public docs pages with explicit frontmatter metadata
+- add structured data emission in the theme layer
+
+## Verification
+- build locally
+- inspect generated homepage/docs HTML for title, description, and JSON-LD output
+- confirm no unrelated docs pages were changed just for metadata churn
+
+## Change Notes
+- Prefer a small truthful schema footprint over expansive schema markup.
+- Tighten the highest-value entry pages first rather than mechanically adding metadata to every docs page.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: Bootstrap
+description: Use the canonical VibeGov bootstrap contract to install or normalize governance, specs, workflow rules, and reporting before product-code implementation.
 ---
 
 # Bootstrap

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 6
+title: Execution Modes
+description: Learn when to use Development, Exploration, Feedback Intake, and evaluation patterns so AI-assisted delivery stays mode-correct and evidence-honest.
 ---
 
 # Execution Modes

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 3
+title: Quick Start
+description: Install VibeGov quickly with the hardened bootstrap contract and the shortest practical path into governed AI-assisted delivery.
 ---
 
 # Quick Start

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 2
+title: Start Here
+description: Get oriented in VibeGov quickly and choose the right next doc for bootstrap, execution modes, operator guidance, or the broader SDLC model.
 ---
 
 # Start Here

--- a/docs/vibegov-sdlc.md
+++ b/docs/vibegov-sdlc.md
@@ -1,5 +1,7 @@
 ---
 sidebar_position: 4
+title: The VibeGov SDLC
+description: See the governed VibeGov SDLC from bootstrap through issue/spec binding, execution mode selection, validation, reporting, and backlog feedback loops.
 ---
 
 # The VibeGov SDLC

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,31 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
+const structuredData = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': 'https://vibegov.io/#organization',
+    name: 'VibeGov',
+    url: 'https://vibegov.io/',
+    logo: 'https://vibegov.io/img/vibegov-icon.svg',
+    description: 'Governance for AI-assisted software delivery.',
+    sameAs: ['https://github.com/governance-foundation/vibegov.io'],
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    '@id': 'https://vibegov.io/#website',
+    url: 'https://vibegov.io/',
+    name: 'VibeGov',
+    description: 'Governance for AI-assisted software delivery.',
+    inLanguage: 'en',
+    publisher: {
+      '@id': 'https://vibegov.io/#organization',
+    },
+  },
+];
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'VibeGov',
@@ -58,6 +83,14 @@ const config = {
       }),
     ],
   ],
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {type: 'application/ld+json'},
+      innerHTML: JSON.stringify(structuredData),
+    },
+  ],
+
   plugins: [
     [
       require.resolve('@easyops-cn/docusaurus-search-local'),


### PR DESCRIPTION
## Summary
- add minimal Organization and WebSite JSON-LD for vibegov.io via Docusaurus headTags
- tighten explicit metadata on the main public docs entry pages that were still relying on weaker defaults
- add a focused spec for the structured-data and SEO tightening slice

## Validation
- npm run build
- inspected generated HTML for homepage plus key docs entry pages
- confirmed emitted application/ld+json and updated title/description metadata

Fixes #134