### PR TITLE
#140 #141 tighten branch closure and merged PR cleanup

### DIFF
--- a/.governance/rules/gov-02-workflow.mdc
+++ b/.governance/rules/gov-02-workflow.mdc
@@ -51,6 +51,8 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-004B` A non-`main` / non-`develop` branch is a governed work unit, not a reusable parent branch.
 - `GOV-02-GIT-004C` Hotfix branches must be created from `main` only.
 - `GOV-02-GIT-004D` Any stacked-branch exception requires explicit human approval, a bounded reason, and an explicit reconciliation plan.
+- `GOV-02-GIT-004E` A governed work turn is not complete while the local repo remains parked on a non-`main` / non-`develop` branch after the bounded slice is finished. The work must be reconciled through the governed landing path and the repo returned to its canonical resting branch: `develop` for normal work, `main` for `main`-sourced hotfix or release work.
+- `GOV-02-GIT-004F` Leaving the repo stranded on a stray issue/work branch at turn end without explicit justification and handoff state is a failed work turn, because it blocks or contaminates the next governed work unit.
 - `GOV-02-GIT-005` Every agent-authored non-hotfix change must use a pull request into `develop` that links the governing issue/spec and records verification evidence.
 - `GOV-02-GIT-005A` Branch cleanup, retirement, deletion, or archival must not substitute for landing the intended result. A governed work branch should only be retired once the desired preserved outcome is safely landed through the repository's governed flow, or the retained state has been deliberately preserved elsewhere with an explicit follow-up path.
 - `GOV-02-GIT-006` Promotion from `develop` to `main` must be explicit and reviewable. Release or promotion pull requests should state what is being promoted and what release-readiness evidence supports the move.

--- a/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
+++ b/.governance/rules/gov-10-agent-state-closure-git-hygiene.mdc
@@ -79,8 +79,10 @@ Governed repositories should treat repository state as a control surface for age
 - `GOV-10-GIT-036` A blocked or deferred substantive turn or work unit must still leave the repository in a classified state, even when implementation is incomplete.
 - `GOV-10-GIT-037` If the intended work is not actually complete by turn end, a focused follow-up ticket must be created rather than carrying unresolved branch or dirty-state ambiguity forward.
 - `GOV-10-GIT-038` A slice is not closed until the original ticket is merged into `develop`.
-- `GOV-10-GIT-039` After closure, the branch where the work was done must be archived under an `archive/`-prefixed branch name.
-- `GOV-10-GIT-040` After merge and archival, the local working repo should be returned to `develop`.
+- `GOV-10-GIT-039` After a PR is merged, the merged work branch should normally be deleted locally and remotely as part of the same closure routine.
+- `GOV-10-GIT-039A` `archive/` branches are for stale, unmerged, or intentionally preserved branches that still need history retention. Do not archive a branch by default when its PR is already merged and the landed history is preserved in the target branch.
+- `GOV-10-GIT-040` After merge and branch cleanup, the local working repo must be returned to the lane's canonical resting branch: `develop` for normal work, `main` for `main`-sourced hotfix or release work.
+- `GOV-10-GIT-040A` If a bounded work turn finishes but the repo is still left on a stray issue/work branch, the turn is not merely untidy; it is failed closure because it blocks or contaminates the next work unit.
 - `GOV-10-GIT-041` Handoff artifacts should state any intentionally deferred files, branches, or follow-up tickets explicitly rather than relying on a future reader to infer them from git status.
 
 ## Anti-Patterns
@@ -96,6 +98,7 @@ Avoid these failure modes:
 - auto-resetting, deleting, or force-cleaning inherited state to feel clean without first classifying it
 - using dirty state as a substitute for real tracking
 - marking a slice done before the original ticket is merged into `develop`
+- archiving a merged work branch by default when simple branch deletion was the correct closure path
 - archiving a work branch without first closing the governed landing path
 - failing to create a follow-up ticket when the current turn cannot honestly close the slice
 - using cleanup, archival, or rollback to erase rationale instead of preserving it

--- a/.governance/specs/merged-pr-branch-cleanup-and-resting-branch-closure.md
+++ b/.governance/specs/merged-pr-branch-cleanup-and-resting-branch-closure.md
@@ -1,0 +1,41 @@
+# Spec: Merged PR Branch Cleanup and Resting-Branch Closure
+
+## Intent
+
+Tighten VibeGov git-closure guidance so agents do not leave repos stranded on work branches and do not archive merged PR branches by default.
+
+## Problem
+
+Two costly hygiene failures need to be prevented:
+
+1. agents treating a repo left on a work branch after a bounded slice as "basically done"
+2. agents preserving merged PR branches by default, which creates branch clutter and expensive downstream cleanup debt even though the landed history already exists in the target branch
+
+## Requirements
+
+- `MPRC-001` A governed work turn is not complete while the local repo remains parked on a non-`main` / non-`develop` work branch after the bounded slice is finished.
+- `MPRC-002` Closure must return the local repo to its canonical resting branch: `develop` for normal work, `main` for `main`-sourced hotfix or release work.
+- `MPRC-003` Leaving the repo stranded on a stray work branch at turn end without explicit handoff state is failed closure, not cosmetic untidiness.
+- `MPRC-004` After a PR is merged, the merged work branch should normally be deleted locally and remotely as part of the same closure routine.
+- `MPRC-005` `archive/` branches are reserved for stale, unmerged, or intentionally preserved branches that still need history retention.
+- `MPRC-006` Governance quick-reference and operator-facing docs must stop teaching archive-after-merge as the default closure path.
+
+## Acceptance Criteria
+
+- AC-001: `GOV-02` explicitly requires return to the correct resting branch after bounded work closure.
+- AC-002: `GOV-10` explicitly treats stranded work branches as failed closure.
+- AC-003: `GOV-10` explicitly states merged PR branches are normally deleted locally and remotely.
+- AC-004: `GOV-10` explicitly reserves `archive/` for stale, unmerged, or intentionally preserved branches.
+- AC-005: `AGENTS.md` mirrors the resting-branch closure rule in plain language.
+- AC-006: Published/operator docs align with the delete-merged-branch default.
+- AC-007: Site build passes after the documentation updates.
+
+## Evidence
+
+- Rule/doc diff inspection
+- `npm run build`
+
+## Related Issues
+
+- #140 Governed work turns should fail closure when repos are left stranded on work branches
+- #141 Merged PR branches should be deleted by default, not archived

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,4 +39,6 @@ Observe -> Plan -> Implement -> Verify -> Document
 
 Keep spec/intent as source of truth and keep issue/task/release artifacts traceable to that intent.
 
+A governed work turn is not successfully closed if the repo is left parked on a stray issue/work branch after the bounded slice is finished. Return the local repo to `develop` for normal work, or to `main` for `main`-sourced hotfix/release work; otherwise treat the turn as failed closure, not minor untidiness.
+
 

--- a/docs/codex-prompting-through-vibegov.md
+++ b/docs/codex-prompting-through-vibegov.md
@@ -99,7 +99,7 @@ The decision boundary must stay visible when the work becomes destructive, exter
 
 The slice is not complete at "files edited."
 
-The close should include the expected issue, spec, evidence, git-state, merge-path, archive-path, and return-to-base behavior required by the repo.
+The close should include the expected issue, spec, evidence, git-state, merge-path, merged-branch cleanup behavior, any exceptional archive-path if truly needed, and return-to-base behavior required by the repo.
 
 ## Practical profile shape
 

--- a/docs/harness-profile-codex.md
+++ b/docs/harness-profile-codex.md
@@ -92,7 +92,7 @@ A healthy run should look like this:
 - run skeptical evaluator pass when the slice warrants it
 - shape large outputs so they remain readable and decision-useful
 - loop on fixes only while the loop is producing real progress
-- close state through commit, merge-path, archive-path, or explicit follow-up handling
+- close state through commit, merge-path, merged-branch deletion by default, exceptional archive-path only when preservation is needed, or explicit follow-up handling
 - record evidence and residual risk truthfully
 
 ## Non-negotiable guardrails

--- a/docs/published/gov-02-workflow.md
+++ b/docs/published/gov-02-workflow.md
@@ -76,6 +76,8 @@ Governed repositories should install a strict Git workflow during bootstrap so p
 - `GOV-02-GIT-004B` A non-`main` / non-`develop` branch is a governed work unit, not a reusable parent branch.
 - `GOV-02-GIT-004C` Hotfix branches must be created from `main` only.
 - `GOV-02-GIT-004D` Any stacked-branch exception requires explicit human approval, a bounded reason, and an explicit reconciliation plan.
+- `GOV-02-GIT-004E` A governed work turn is not complete while the local repo remains parked on a non-`main` / non-`develop` branch after the bounded slice is finished. The work must be reconciled through the governed landing path and the repo returned to its canonical resting branch: `develop` for normal work, `main` for `main`-sourced hotfix or release work.
+- `GOV-02-GIT-004F` Leaving the repo stranded on a stray issue/work branch at turn end without explicit justification and handoff state is a failed work turn, because it blocks or contaminates the next governed work unit.
 - `GOV-02-GIT-005` Every agent-authored non-hotfix change must use a pull request into `develop` that links the governing issue/spec and records verification evidence.
 - `GOV-02-GIT-005A` Branch cleanup, retirement, deletion, or archival must not substitute for landing the intended result. A governed work branch should only be retired once the desired preserved outcome is safely landed through the repository's governed flow, or the retained state has been deliberately preserved elsewhere with an explicit follow-up path.
 - `GOV-02-GIT-006` Promotion from `develop` to `main` must be explicit and reviewable. Release or promotion pull requests should state what is being promoted and what release-readiness evidence supports the move.

--- a/docs/published/gov-10-agent-state-closure-git-hygiene.md
+++ b/docs/published/gov-10-agent-state-closure-git-hygiene.md
@@ -102,11 +102,13 @@ Governed repositories should treat repository state as a control surface for age
 - `GOV-10-GIT-036` A blocked or deferred substantive turn or work unit must still leave the repository in a classified state, even when implementation is incomplete.
 - `GOV-10-GIT-037` If the intended work is not actually complete by turn end, a focused follow-up ticket must be created rather than carrying unresolved branch or dirty-state ambiguity forward.
 - `GOV-10-GIT-038` A slice is not closed until the original ticket is merged into `develop`.
-- `GOV-10-GIT-039` After closure, the branch where the work was done must be archived under an `archive/`-prefixed branch name.
-- `GOV-10-GIT-040` After merge and archival, the local working repo should be returned to `develop`.
+- `GOV-10-GIT-039` After a PR is merged, the merged work branch should normally be deleted locally and remotely as part of the same closure routine.
+- `GOV-10-GIT-039A` `archive/` branches are for stale, unmerged, or intentionally preserved branches that still need history retention. Do not archive a branch by default when its PR is already merged and the landed history is preserved in the target branch.
+- `GOV-10-GIT-040` After merge and branch cleanup, the local working repo must be returned to the lane's canonical resting branch: `develop` for normal work, `main` for `main`-sourced hotfix or release work.
+- `GOV-10-GIT-040A` If a bounded work turn finishes but the repo is still left on a stray issue/work branch, the turn is not merely untidy; it is failed closure because it blocks or contaminates the next work unit.
 - `GOV-10-GIT-041` Handoff artifacts should state any intentionally deferred files, branches, or follow-up tickets explicitly rather than relying on a future reader to infer them from git status.
 
-> Commentary: Turns closure into a concrete end-state: committed, merged into `develop`, archived, and back on `develop`, with follow-up tickets when needed.
+> Commentary: Turns closure into a concrete end-state: committed, merged through the governed flow, merged branches deleted by default, archive reserved for exceptional preservation cases, and the repo returned to the correct resting branch rather than stranded on a work branch.
 
 ## Anti-Patterns
 
@@ -121,6 +123,7 @@ Avoid these failure modes:
 - auto-resetting, deleting, or force-cleaning inherited state to feel clean without first classifying it
 - using dirty state as a substitute for real tracking
 - marking a slice done before the original ticket is merged into `develop`
+- archiving a merged work branch by default when simple branch deletion was the correct closure path
 - archiving a work branch without first closing the governed landing path
 - failing to create a follow-up ticket when the current turn cannot honestly close the slice
 - using cleanup, archival, or rollback to erase rationale instead of preserving it

--- a/docs/quick-decisions.md
+++ b/docs/quick-decisions.md
@@ -131,12 +131,13 @@ Fast rule:
 | unresolved junk reverted or ignored explicitly | prevents residue from leaking forward |
 | if not finished, a focused follow-up ticket exists | prevents ambiguous carry-over |
 | original ticket merged into `develop` | closes the governed landing path |
-| working branch archived as `archive/<branch>` | preserves branch history cleanly |
+| merged work branch deleted locally and remotely | removes stale branch carry-over after landing |
 | local repo returned to `develop` | resets the next execution starting point |
 
 Fast rule:
 - git hygiene is mandatory
-- done means committed, merged to `develop`, archived, and back on `develop`
+- done means committed, merged to `develop`, merged branch deleted, and back on `develop`
+- archive only stale/unmerged or intentionally preserved branches
 - not done means follow-up ticket, not ambiguity
 
 ## 11. What must be true before new governed work starts?


### PR DESCRIPTION
## Summary\n- make stranded work branches explicit failed closure in GOV-02/GOV-10/AGENTS guidance\n- switch merged-PR cleanup guidance from archive-by-default to delete-by-default\n- add a supporting spec and align the quick-reference/operator docs\n\n## Verification\n- 
pm run build\n\nCloses #140\nCloses #141